### PR TITLE
Add support for list of resources as a type

### DIFF
--- a/src/test/java/eu/ratkay/operation/598f82/631067-bundle-approved.json
+++ b/src/test/java/eu/ratkay/operation/598f82/631067-bundle-approved.json
@@ -1,0 +1,16 @@
+/*eu.ratkay.operation.ResultTest.operateList when initial resource is OperationOutcome but INFORMATION*/
+{
+  "entry": [
+    {
+      "resource": {
+        "issue": [
+          {
+            "severity": "error"
+          }
+        ],
+        "resourceType": "OperationOutcome"
+      }
+    }
+  ],
+  "resourceType": "Bundle"
+}

--- a/src/test/java/eu/ratkay/operation/598f82/631067-parameter-approved.json
+++ b/src/test/java/eu/ratkay/operation/598f82/631067-parameter-approved.json
@@ -1,0 +1,17 @@
+/*eu.ratkay.operation.ResultTest.operateList when initial resource is OperationOutcome but INFORMATION*/
+{
+  "parameter": [
+    {
+      "name": "operationoutcome",
+      "resource": {
+        "issue": [
+          {
+            "severity": "error"
+          }
+        ],
+        "resourceType": "OperationOutcome"
+      }
+    }
+  ],
+  "resourceType": "Parameters"
+}

--- a/src/test/java/eu/ratkay/operation/598f82/b32c55-bundle-approved.json
+++ b/src/test/java/eu/ratkay/operation/598f82/b32c55-bundle-approved.json
@@ -1,0 +1,26 @@
+/*eu.ratkay.operation.ResultTest.operateResourceList when initial resource is OperationOutcome but INFORMATION*/
+{
+  "entry": [
+    {
+      "resource": {
+        "issue": [
+          {
+            "severity": "information"
+          }
+        ],
+        "resourceType": "OperationOutcome"
+      }
+    },
+    {
+      "resource": {
+        "issue": [
+          {
+            "severity": "error"
+          }
+        ],
+        "resourceType": "OperationOutcome"
+      }
+    }
+  ],
+  "resourceType": "Bundle"
+}

--- a/src/test/java/eu/ratkay/operation/598f82/b32c55-parameter-approved.json
+++ b/src/test/java/eu/ratkay/operation/598f82/b32c55-parameter-approved.json
@@ -1,0 +1,28 @@
+/*eu.ratkay.operation.ResultTest.operateResourceList when initial resource is OperationOutcome but INFORMATION*/
+{
+  "parameter": [
+    {
+      "name": "operationoutcome",
+      "resource": {
+        "issue": [
+          {
+            "severity": "information"
+          }
+        ],
+        "resourceType": "OperationOutcome"
+      }
+    },
+    {
+      "name": "operationoutcome",
+      "resource": {
+        "issue": [
+          {
+            "severity": "error"
+          }
+        ],
+        "resourceType": "OperationOutcome"
+      }
+    }
+  ],
+  "resourceType": "Parameters"
+}

--- a/src/test/java/eu/ratkay/operation/OperationResultTest.kt
+++ b/src/test/java/eu/ratkay/operation/OperationResultTest.kt
@@ -792,6 +792,50 @@ class OperationResultTest {
         assertThat(actualAsBundle, sameJsonAsApproved<String?>().withUniqueId("bundle"))
     }
 
+    /**
+     * Hash: b32c55
+     */
+    @Test
+    fun `operateResourceList when initial resource is OperationOutcome but INFORMATION`() {
+        // GIVEN
+        val operationOutcome = getOperationOutcome(IssueSeverity.INFORMATION)
+
+        // WHEN
+        val operationResult = OperationResult.of(operationOutcome)
+            .operateResourceList { resource ->
+                listOf(resource, getOperationOutcome(IssueSeverity.ERROR))
+            }
+
+        val actualAsParameters = jsonParser.encodeResourceToString(operationResult.asParameters())
+        val actualAsBundle = jsonParser.encodeResourceToString(operationResult.asBundle())
+
+        // THEN
+        assertThat(actualAsParameters, sameJsonAsApproved<String?>().withUniqueId("parameter"))
+        assertThat(actualAsBundle, sameJsonAsApproved<String?>().withUniqueId("bundle"))
+    }
+
+    /**
+     * Hash: 631067
+     */
+    @Test
+    fun `operateList when initial resource is OperationOutcome but INFORMATION`() {
+        // GIVEN
+        val operationOutcome = getOperationOutcome(IssueSeverity.INFORMATION)
+
+        // WHEN
+        val operationResult = OperationResult.of(operationOutcome)
+            .operateList {
+                listOf(getOperationOutcome(IssueSeverity.ERROR))
+            }
+
+        val actualAsParameters = jsonParser.encodeResourceToString(operationResult.asParameters())
+        val actualAsBundle = jsonParser.encodeResourceToString(operationResult.asBundle())
+
+        // THEN
+        assertThat(actualAsParameters, sameJsonAsApproved<String?>().withUniqueId("parameter"))
+        assertThat(actualAsBundle, sameJsonAsApproved<String?>().withUniqueId("bundle"))
+    }
+
     private fun getPatient(): Patient {
         return Patient().apply {
             name = listOf(HumanName().apply {


### PR DESCRIPTION
OperationResult can handle lists of resources as return types and can pass them trough the chain.