### PR TITLE
Expand functional transformation methods on OperationResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,13 +165,55 @@ result.isNotEmpty()
 
 These return a new `OperationResult` without modifying the original.
 
+#### Filtering
+
 ```kotlin
 // Reified overloads — no KClass argument needed
 result.filterByType<Patient>()         // keep only entries whose values are Patients
 result.filterByType(Patient::class)    // same, explicit form
 
 result.filterByName("patient")         // keep only the "patient" key
-result.mapValues { base -> transform(base) }
+```
+
+#### Mapping and chaining
+
+```kotlin
+// Type-safe map — transforms every value across all keys, changes pipeline head type
+val mapped: OperationResult<Appointment> = result.mapValues { base -> toAppointment(base) }
+
+// flatMap — chain an inner pipeline; all its parameter entries are merged into the outer map
+val combined: OperationResult<Coverage> = OperationResult.of(patient)
+    .flatMap { p ->
+        OperationResult.of(coverage(p), "coverage")
+            .add("encounter") { lookupEncounter(p) }
+    }
+// outer map now contains: patient, coverage, encounter
+
+// merge — combine two OperationResults; overlapping keys accumulate their values
+val merged = resultA.merge(resultB)   // OperationResult<T> — A's head type preserved
+```
+
+#### Structural edits
+
+```kotlin
+result.remove("coverage")             // new OperationResult without the "coverage" key (no-op if absent)
+result.rename("old", "new")           // move all values from "old" to "new"
+```
+
+#### Side effects (peek)
+
+```kotlin
+result.peek { map ->                  // inspect the map without modifying the pipeline
+    log.debug("keys: {}", map.keys)
+}
+```
+
+#### Convenience lookups
+
+```kotlin
+result.takeFirst("patient")                       // Base? — first value under "patient"
+result.takeFirstTyped("patient", Patient::class)  // Patient? — first Patient under "patient"
+result.takeFirstTyped<Patient>("patient")         // same, reified form
 ```
 
 ### Logging and Metrics
@@ -554,7 +596,31 @@ result.toTransactionBundle()
 val patientsOnly = result.filterByType<Patient>()
 val patientEntry = result.filterByName("patient")
 val allPatients  = result.getByType<Patient>()
-val mapped       = result.mapValues { base -> normalize(base) }
+
+// Type-safe map — changes pipeline head type to Appointment
+val mapped: OperationResult<Appointment> = result.mapValues { base -> normalize(base) }
+
+// Peek for side effects (debugging, logging) — returns the same instance unchanged
+val same = result.peek { map -> log.debug("state: {}", map.keys) }
+
+// Convenience first-value lookups
+val firstPatient: Patient? = result.takeFirstTyped<Patient>("patient")
+val first: Base?           = result.takeFirst("patient")
+
+// Remove a key (no-op if absent) or rename a key
+val trimmed  = result.remove("draft")
+val renamed  = result.rename("old", "new")
+
+// Merge two pipelines — overlapping keys accumulate
+val merged = resultA.merge(resultB)
+
+// flatMap — chain an inner pipeline and merge all of its entries into the outer map
+val result = OperationResult.of(patient)
+    .flatMap { p ->
+        OperationResult.of(encounter(p), "encounter")
+            .add("coverage") { fetchCoverage(p) }
+    }
+// map now contains: patient, encounter, coverage
 ```
 
 ### 11. Async DAG — parallel fetching with typed dependencies

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -375,12 +375,86 @@ class OperationResult<T> private constructor(
         return OperationResult(filtered, result, outcomes, errorStrategy, failedTasks, timingEnabled, metrics)
     }
 
-    fun mapValues(transform: (Base) -> Base): OperationResult<T> {
+    fun <R : Base> mapValues(transform: (Base) -> R): OperationResult<R> {
         val transformed = parameters.mapValues { (_, values) ->
-            values.map(transform).toMutableList()
+            val newList = mutableListOf<Base>()
+            values.forEach { newList.add(transform(it)) }
+            newList
         }.toMutableMap()
-        return OperationResult(transformed, result, outcomes, errorStrategy, failedTasks, timingEnabled, metrics)
+        return OperationResult(transformed, null, outcomes, errorStrategy, failedTasks, timingEnabled, metrics)
     }
+
+    /**
+     * Chains an inner pipeline on the current typed result [T], merges all of its parameter map
+     * entries into the outer map, and returns an [OperationResult] whose head type and current
+     * result come from the inner pipeline.
+     *
+     * On key collision with the outer map the values are accumulated under the same key.
+     */
+    fun <R : Base> flatMap(transform: (T) -> OperationResult<R>): OperationResult<R> {
+        if (shouldSkip()) return skippedResult()
+        val inner = transform(getResult())
+        val newParams = parameters.mapValues { (_, values) -> values.toMutableList() }.toMutableMap()
+        inner.parameters.forEach { (key, values) ->
+            newParams.getOrPut(key) { mutableListOf() }.addAll(values)
+        }
+        return OperationResult(newParams, inner.result, outcomes, errorStrategy, failedTasks, timingEnabled, metrics)
+    }
+
+    /**
+     * Combines the parameter maps of this result and [other]. On key collision the values from
+     * both results are accumulated under the same key. The current typed result [T] is preserved.
+     */
+    fun merge(other: OperationResult<*>): OperationResult<T> {
+        val newParams = parameters.mapValues { (_, values) -> values.toMutableList() }.toMutableMap()
+        other.parameters.forEach { (key, values) ->
+            newParams.getOrPut(key) { mutableListOf() }.addAll(values)
+        }
+        return OperationResult(newParams, result, outcomes, errorStrategy, failedTasks, timingEnabled, metrics)
+    }
+
+    /** Returns a new [OperationResult] without the entry for [name]. No-op if [name] is absent. */
+    fun remove(name: String): OperationResult<T> {
+        val newParams = parameters.mapValues { (_, values) -> values.toMutableList() }.toMutableMap()
+        newParams.remove(name)
+        return OperationResult(newParams, result, outcomes, errorStrategy, failedTasks, timingEnabled, metrics)
+    }
+
+    /**
+     * Returns a new [OperationResult] where all values stored under [oldName] are moved to
+     * [newName]. If [oldName] does not exist, the result is unchanged. If [newName] already
+     * exists, the moved values are accumulated alongside the existing ones.
+     */
+    fun rename(oldName: String, newName: String): OperationResult<T> {
+        val newParams = parameters.mapValues { (_, values) -> values.toMutableList() }.toMutableMap()
+        val values = newParams.remove(oldName)
+        if (values != null) {
+            newParams.getOrPut(newName) { mutableListOf() }.addAll(values)
+        }
+        return OperationResult(newParams, result, outcomes, errorStrategy, failedTasks, timingEnabled, metrics)
+    }
+
+    /**
+     * Invokes [block] with a snapshot of the current parameter map for side-effects (logging,
+     * debugging) and returns this [OperationResult] unchanged.
+     */
+    fun peek(block: (Map<String, List<Base>>) -> Unit): OperationResult<T> {
+        block(getAllParameters())
+        return this
+    }
+
+    /** Returns the first value stored under [name], or `null` if the key is absent or empty. */
+    fun takeFirst(name: String): Base? = parameters[name]?.firstOrNull()
+
+    /**
+     * Returns the first value stored under [name] that is an instance of [type], or `null`.
+     * Prefer the inline reified overload [takeFirstTyped] where the type can be inferred.
+     */
+    fun <R : Base> takeFirstTyped(name: String, type: KClass<R>): R? =
+        parameters[name]?.filterIsInstance(type.java)?.firstOrNull()
+
+    /** Reified overload — no [KClass] argument needed at call sites. */
+    inline fun <reified R : Base> takeFirstTyped(name: String): R? = takeFirstTyped(name, R::class)
 
     // Reference linking
 

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
@@ -723,6 +723,295 @@ class OperationResultTest {
         assertThat(result.getResult(), instanceOf(Patient::class.java))
     }
 
+    // ── mapValues (type-safe) ─────────────────────────────────────────────────
+
+    @Test
+    fun `mapValues type-safe transforms every value and changes pipeline type`() {
+        val result: OperationResult<Appointment> = OperationResult.of(patient(), "p")
+            .mapValues { _ -> appointment() }
+
+        assertThat(result.getByType<Appointment>(), hasSize(1))
+        assertThat(result.getByType<Patient>(), empty())
+    }
+
+    @Test
+    fun `mapValues transforms values across multiple keys`() {
+        val result = OperationResult.of(patient(), "patient")
+            .add("appt") { appointment() }
+            .mapValues { _ -> Patient() }
+
+        // Both entries should now be Patients
+        assertThat(result.getByType<Patient>(), hasSize(2))
+        assertThat(result.getByType<Appointment>(), empty())
+    }
+
+    // ── flatMap ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `flatMap merges inner pipeline parameter entries into outer map`() {
+        val inner = OperationResult.of(appointment(), "inner-appt")
+
+        val result = OperationResult.of(patient(), "outer-patient")
+            .flatMap { _ -> inner }
+
+        assertTrue(result.containsKey("outer-patient"))
+        assertTrue(result.containsKey("inner-appt"))
+    }
+
+    @Test
+    fun `flatMap result type and getResult reflect inner pipeline head`() {
+        val appt = appointment()
+        val result: OperationResult<Appointment> = OperationResult.of(patient())
+            .flatMap { _ -> OperationResult.of(appt, "appt") }
+
+        assertThat(result.getResult(), sameInstance(appt))
+    }
+
+    @Test
+    fun `flatMap on key collision accumulates values under same key`() {
+        val inner = OperationResult.of(patient(), "patient")
+
+        val result = OperationResult.of(patient(), "patient")
+            .flatMap { _ -> inner }
+
+        assertEquals(2, result.count("patient"))
+    }
+
+    @Test
+    fun `flatMap chains sequentially — all inner keys visible in each step`() {
+        val result = OperationResult.of(patient(), "patient")
+            .flatMap { _ ->
+                OperationResult.of(appointment(), "appt")
+                    .add("coverage") { Coverage() }
+            }
+
+        assertTrue(result.containsKey("patient"))
+        assertTrue(result.containsKey("appt"))
+        assertTrue(result.containsKey("coverage"))
+    }
+
+    @Test
+    fun `flatMap skips transform when pipeline has errors in FAIL_FAST`() {
+        val result = OperationResult.of(patient())
+            .add { error("boom") }
+            .flatMap { _ -> OperationResult.of(appointment(), "appt") }
+
+        assertFalse(result.containsKey("appt"))
+        assertTrue(result.hasErrors())
+    }
+
+    // ── merge ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `merge combines two non-overlapping parameter maps`() {
+        val a = OperationResult.of(patient(), "patient")
+        val b = OperationResult.of(appointment(), "appt")
+
+        val merged = a.merge(b)
+
+        assertTrue(merged.containsKey("patient"))
+        assertTrue(merged.containsKey("appt"))
+    }
+
+    @Test
+    fun `merge accumulates values under the same key on collision`() {
+        val a = OperationResult.of(patient(), "resource")
+        val b = OperationResult.of(appointment(), "resource")
+
+        val merged = a.merge(b)
+
+        assertEquals(2, merged.count("resource"))
+    }
+
+    @Test
+    fun `merge preserves outer result type and current result`() {
+        val patient = patient()
+        val a: OperationResult<Patient> = OperationResult.of(patient, "patient")
+        val b = OperationResult.of(appointment(), "appt")
+
+        val merged: OperationResult<Patient> = a.merge(b)
+
+        assertThat(merged.getResult(), sameInstance(patient))
+    }
+
+    @Test
+    fun `merge does not modify original OperationResult`() {
+        val a = OperationResult.of(patient(), "patient")
+        val b = OperationResult.of(appointment(), "appt")
+
+        a.merge(b)
+
+        assertFalse(a.containsKey("appt"))
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `remove eliminates the specified key`() {
+        val result = OperationResult.of(patient(), "patient")
+            .add("appt") { appointment() }
+            .remove("appt")
+
+        assertFalse(result.containsKey("appt"))
+        assertTrue(result.containsKey("patient"))
+    }
+
+    @Test
+    fun `remove nonexistent key is a no-op`() {
+        val result = OperationResult.of(patient(), "patient")
+            .remove("missing")
+
+        assertTrue(result.containsKey("patient"))
+        assertEquals(1, result.totalCount())
+    }
+
+    @Test
+    fun `remove preserves the current result`() {
+        val patient = patient()
+        val result: OperationResult<Patient> = OperationResult.of(patient, "patient")
+            .addOrSkip("appt") { appointment() }
+            .remove("appt")
+
+        assertThat(result.getResult(), sameInstance(patient))
+    }
+
+    // ── rename ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `rename moves values from old key to new key`() {
+        val patient = patient()
+        val result = OperationResult.of(patient, "old")
+            .rename("old", "new")
+
+        assertFalse(result.containsKey("old"))
+        assertTrue(result.containsKey("new"))
+        assertThat(result.getAll("new").first(), sameInstance(patient))
+    }
+
+    @Test
+    fun `rename on nonexistent key is a no-op`() {
+        val result = OperationResult.of(patient(), "patient")
+            .rename("missing", "other")
+
+        assertTrue(result.containsKey("patient"))
+        assertFalse(result.containsKey("other"))
+    }
+
+    @Test
+    fun `rename to an existing key accumulates values`() {
+        val p1 = patient()
+        val p2 = patient()
+        val result = OperationResult.of(p1, "source")
+            .add("target") { p2 }
+            .rename("source", "target")
+
+        assertFalse(result.containsKey("source"))
+        assertEquals(2, result.count("target"))
+    }
+
+    // ── peek ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `peek invokes block with current parameter snapshot`() {
+        var capturedKeys: Set<String>? = null
+        OperationResult.of(patient(), "patient")
+            .add("appt") { appointment() }
+            .peek { map -> capturedKeys = map.keys }
+
+        assertThat(capturedKeys, containsInAnyOrder("patient", "appt"))
+    }
+
+    @Test
+    fun `peek does not modify the parameter map`() {
+        val base = OperationResult.of(patient(), "patient")
+            .add("appt") { appointment() }
+
+        val after = base.peek { map ->
+            // Attempt to cast and mutate — this is a snapshot so it won't affect state,
+            // but even if it were mutable this peek returns the same instance
+            @Suppress("UNUSED_VARIABLE")
+            val ignored = map
+        }
+
+        assertEquals(base.getAllParameters(), after.getAllParameters())
+    }
+
+    @Test
+    fun `peek returns the same OperationResult instance`() {
+        val before = OperationResult.of(patient(), "patient")
+        val after = before.peek { }
+
+        assertThat(after, sameInstance(before))
+    }
+
+    @Test
+    fun `peek preserves result type and getResult`() {
+        val patient = patient()
+        val result: OperationResult<Patient> = OperationResult.of(patient, "patient")
+            .peek { }
+
+        assertThat(result.getResult(), sameInstance(patient))
+    }
+
+    // ── takeFirst / takeFirstTyped ────────────────────────────────────────────
+
+    @Test
+    fun `takeFirst returns first value for the given key`() {
+        val p = patient()
+        val result = OperationResult.of(p, "patient")
+
+        assertThat(result.takeFirst("patient"), sameInstance(p))
+    }
+
+    @Test
+    fun `takeFirst returns null for missing key`() {
+        val result = OperationResult.of(patient(), "patient")
+
+        assertEquals(null, result.takeFirst("missing"))
+    }
+
+    @Test
+    fun `takeFirst returns first among multiple values`() {
+        val first = patient()
+        val result = OperationResult.of(first, "patient")
+            .add("patient") { patient() }
+
+        assertThat(result.takeFirst("patient"), sameInstance(first))
+    }
+
+    @Test
+    fun `takeFirstTyped returns first value matching the given type`() {
+        val appt = appointment()
+        val result = OperationResult.of(patient(), "entry")
+            .add("entry") { appt }
+
+        val found: Appointment? = result.takeFirstTyped("entry", Appointment::class)
+        assertThat(found, sameInstance(appt))
+    }
+
+    @Test
+    fun `takeFirstTyped returns null when no value matches the given type`() {
+        val result = OperationResult.of(patient(), "patient")
+
+        assertEquals(null, result.takeFirstTyped("patient", Appointment::class))
+    }
+
+    @Test
+    fun `takeFirstTyped reified overload requires no KClass argument`() {
+        val p = patient()
+        val result = OperationResult.of(p, "patient")
+
+        val found: Patient? = result.takeFirstTyped<Patient>("patient")
+        assertThat(found, sameInstance(p))
+    }
+
+    @Test
+    fun `takeFirstTyped reified returns null for missing key`() {
+        val result = OperationResult.of(patient(), "patient")
+
+        assertEquals(null, result.takeFirstTyped<Appointment>("missing"))
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private fun patient() = Patient().apply {


### PR DESCRIPTION
- mapValues<R : Base> is now type-safe: returns OperationResult<R> instead of OperationResult<T>
- flatMap<R : Base>(T -> OperationResult<R>): chains an inner pipeline, merges all its parameter
  map entries into the outer map, and carries the inner result as the new typed head
- merge(other): combines two OperationResults' parameter maps; overlapping keys accumulate values
- remove(name): returns a new OperationResult without the specified key (no-op if absent)
- rename(oldName, newName): moves all values from one key to another
- peek(block): invokes a side-effect lambda with the current parameter snapshot and returns this
- takeFirst(name): returns Base? — first value under the given key
- takeFirstTyped(name, type) / takeFirstTyped<R>(name): returns R? — first typed match

Tests cover all new methods plus edge cases:
  merge with overlapping keys, remove nonexistent key, flatMap chaining with all inner keys
  visible in the outer map, peek does not modify state, takeFirstTyped type mismatch.

README updated with new method documentation and usage examples.