### PR TITLE
Add primitive value convenience methods to OperationResult

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,53 @@ src/test/java/dev/ratkay/operation/
 - Validate with `require()` and `error()` — no checked exceptions
 - `AsyncOperationResult` uses sealed classes for DAG task nodes with cycle detection at registration time
 
+## Exception Handling Rules
+
+Every builder method that catches exceptions must follow one of two established patterns. Do not invent new patterns.
+
+### Pattern A — head-changing steps (`runBuilderStep`)
+
+Used by `add`, `addUsing`, `addAll`, `addAllUsing`, `addFrom`, `addAllFrom`, `flatMap`.
+Records an **ERROR**-severity `OperationOutcome` and skips the head value (`skippedResult()`).
+
+```kotlin
+catch (e: Exception) {
+    val durationMs = System.currentTimeMillis() - start
+    recordMetric(name ?: "unknown", "", durationMs, false)
+    outcomes.add(when (e) {
+        is BaseServerResponseException -> e.toOperationOutcome()   // preserves embedded rich outcome
+        else                           -> e.toOperationOutcome()   // creates generic ERROR outcome
+    })
+    skippedResult()
+}
+```
+
+### Pattern B — head-preserving steps (`runPrimitiveStep`, `addOrSkip`, `addOrDefault`)
+
+Used by `addOrSkip`, `addOrDefault`, and all primitive-value convenience methods (`addString`, `addBoolean`, …).
+Records a **WARNING**-severity `OperationOutcome` and preserves the current head type `T`.
+
+```kotlin
+catch (e: Exception) {
+    val durationMs = System.currentTimeMillis() - start
+    logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+    recordMetric(name, "", durationMs, false)
+    val outcome = when (e) {
+        is BaseServerResponseException -> e.toOperationOutcome()   // preserves embedded rich outcome
+        else                           -> e.toOperationOutcome()   // creates generic ERROR outcome
+    }
+    outcome.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
+    outcomes.add(outcome)
+    copyWith(result)
+}
+```
+
+**Key rules:**
+- Always dispatch on `BaseServerResponseException` first — this extracts the embedded `OperationOutcome` from the HAPI exception rather than discarding it.
+- Head-changing steps use `skippedResult()` (result becomes `null`); head-preserving steps use `copyWith(result)`.
+- Primitive convenience methods must delegate to `runPrimitiveStep` (Pattern B) — never duplicate the try/catch inline.
+- Do not add new catch patterns without updating this section.
+
 ## README Maintenance
 
 Keep `README.md` up to date on every branch. When a branch adds or changes a feature, update the relevant section(s) of the README before committing:

--- a/README.md
+++ b/README.md
@@ -121,6 +121,34 @@ val result = OperationResult.of(patient)
     .addOrDefault("score", defaultScore) { computeRiskScore() }
 ```
 
+#### Primitive value helpers
+
+Store raw Kotlin/Java primitives as FHIR types without changing the pipeline head. These methods always return `OperationResult<T>` (the current head type is preserved) because primitives are metadata or configuration, not pipeline resources.
+
+| Method | Kotlin type | FHIR wrapper | Using variant |
+|---|---|---|---|
+| `addString(name, value)` | `String` | `StringType` | `addStringUsing(name) { t -> String }` |
+| `addBoolean(name, value)` | `Boolean` | `BooleanType` | `addBooleanUsing(name) { t -> Boolean }` |
+| `addInteger(name, value)` | `Int` | `IntegerType` | `addIntegerUsing(name) { t -> Int }` |
+| `addDecimal(name, value)` | `BigDecimal` | `DecimalType` | `addDecimalUsing(name) { t -> BigDecimal }` |
+| `addCode(name, value)` | `String` | `CodeType` | `addCodeUsing(name) { t -> String }` |
+| `addUri(name, value)` | `String` | `UriType` | `addUriUsing(name) { t -> String }` |
+| `addDate(name, value)` | `String` (FHIR date) | `DateType` | `addDateUsing(name) { t -> String }` |
+| `addDateTime(name, value)` | `String` (FHIR dateTime) | `DateTimeType` | `addDateTimeUsing(name) { t -> String }` |
+| `addCanonical(name, value)` | `String` | `CanonicalType` | `addCanonicalUsing(name) { t -> String }` |
+
+`addDate` and `addDateTime` accept FHIR-format strings (e.g. `"2024-01-15"`, `"2024-01-15T10:30:00"`) — HAPI's `DateType(String)` and `DateTimeType(String)` constructors handle parsing. `addDecimal` takes `java.math.BigDecimal` to avoid floating-point precision issues.
+
+```kotlin
+val result = OperationResult.of(patient)
+    .addString("label", "priority")            // raw value — head stays Patient
+    .addBoolean("active", true)
+    .addStringUsing("patientId") { p -> p.idElement.idPart }  // derived from current result
+    .add("encounter") { fetchEncounter() }     // head changes to Encounter
+
+val encounter: Encounter = result.getResult()  // still typed correctly
+```
+
 ### Error Strategy
 
 `OperationResult` supports two strategies, set at construction time via `of()`:

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -121,6 +121,39 @@ class OperationResult<T> private constructor(
         return copyWith(value)
     }
 
+    /**
+     * Shared try/catch shell for all primitive-value convenience methods.
+     *
+     * On success: stores the FHIR value, records a metric, and logs the step.
+     * On exception: logs a WARN, records a failed metric, and adds a WARNING-severity
+     * [OperationOutcome] — preserving the rich embedded outcome from a
+     * [BaseServerResponseException] rather than discarding it in favour of a plain message.
+     * The pipeline head type [T] is never changed; [shouldSkip] is checked first.
+     */
+    private fun runPrimitiveStep(name: String, build: () -> Base): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        return try {
+            val fhirValue = build()
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            val outcome = when (e) {
+                is BaseServerResponseException -> e.toOperationOutcome()
+                else -> e.toOperationOutcome()
+            }
+            outcome.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
+            outcomes.add(outcome)
+            copyWith(result)
+        }
+    }
+
     private fun <R : Base> storeListAndCopy(name: String?, values: List<R>, start: Long): OperationResult<List<R>> {
         val durationMs = System.currentTimeMillis() - start
         addToParameters(values, name)
@@ -208,347 +241,25 @@ class OperationResult<T> private constructor(
 
     // ── Primitive value convenience methods ──────────────────────────────────
 
-    fun addString(name: String, value: String): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = StringType(value)
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
+    fun addString(name: String, value: String): OperationResult<T>       = runPrimitiveStep(name) { StringType(value) }
+    fun addBoolean(name: String, value: Boolean): OperationResult<T>     = runPrimitiveStep(name) { BooleanType(value) }
+    fun addInteger(name: String, value: Int): OperationResult<T>         = runPrimitiveStep(name) { IntegerType(value) }
+    fun addDecimal(name: String, value: BigDecimal): OperationResult<T>  = runPrimitiveStep(name) { DecimalType(value) }
+    fun addCode(name: String, value: String): OperationResult<T>         = runPrimitiveStep(name) { CodeType(value) }
+    fun addUri(name: String, value: String): OperationResult<T>          = runPrimitiveStep(name) { UriType(value) }
+    fun addDate(name: String, value: String): OperationResult<T>         = runPrimitiveStep(name) { DateType(value) }
+    fun addDateTime(name: String, value: String): OperationResult<T>     = runPrimitiveStep(name) { DateTimeType(value) }
+    fun addCanonical(name: String, value: String): OperationResult<T>    = runPrimitiveStep(name) { CanonicalType(value) }
 
-    fun addBoolean(name: String, value: Boolean): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = BooleanType(value)
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
-
-    fun addInteger(name: String, value: Int): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = IntegerType(value)
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
-
-    fun addDecimal(name: String, value: BigDecimal): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = DecimalType(value)
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
-
-    fun addCode(name: String, value: String): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = CodeType(value)
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
-
-    fun addUri(name: String, value: String): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = UriType(value)
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
-
-    fun addDate(name: String, value: String): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = DateType(value)
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
-
-    fun addDateTime(name: String, value: String): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = DateTimeType(value)
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
-
-    fun addCanonical(name: String, value: String): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = CanonicalType(value)
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
-
-    fun addStringUsing(name: String, builder: (T) -> String): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = StringType(builder(getResult()))
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
-
-    fun addBooleanUsing(name: String, builder: (T) -> Boolean): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = BooleanType(builder(getResult()))
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
-
-    fun addIntegerUsing(name: String, builder: (T) -> Int): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = IntegerType(builder(getResult()))
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
-
-    fun addDecimalUsing(name: String, builder: (T) -> BigDecimal): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = DecimalType(builder(getResult()))
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
-
-    fun addCodeUsing(name: String, builder: (T) -> String): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = CodeType(builder(getResult()))
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
-
-    fun addUriUsing(name: String, builder: (T) -> String): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = UriType(builder(getResult()))
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
-
-    fun addDateUsing(name: String, builder: (T) -> String): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = DateType(builder(getResult()))
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
-
-    fun addDateTimeUsing(name: String, builder: (T) -> String): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = DateTimeType(builder(getResult()))
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
-
-    fun addCanonicalUsing(name: String, builder: (T) -> String): OperationResult<T> {
-        if (shouldSkip()) return copyWith(result)
-        val start = System.currentTimeMillis()
-        return try {
-            val fhirValue = CanonicalType(builder(getResult()))
-            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-            val durationMs = System.currentTimeMillis() - start
-            recordMetric(name, fhirValue.fhirType(), durationMs, true)
-            logStep(name, fhirValue.fhirType(), durationMs)
-            copyWith(result)
-        } catch (e: Exception) {
-            val durationMs = System.currentTimeMillis() - start
-            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
-            recordMetric(name, "", durationMs, false)
-            outcomes.add(warningOutcome(e))
-            copyWith(result)
-        }
-    }
+    fun addStringUsing(name: String, builder: (T) -> String): OperationResult<T>      = runPrimitiveStep(name) { StringType(builder(getResult())) }
+    fun addBooleanUsing(name: String, builder: (T) -> Boolean): OperationResult<T>    = runPrimitiveStep(name) { BooleanType(builder(getResult())) }
+    fun addIntegerUsing(name: String, builder: (T) -> Int): OperationResult<T>        = runPrimitiveStep(name) { IntegerType(builder(getResult())) }
+    fun addDecimalUsing(name: String, builder: (T) -> BigDecimal): OperationResult<T> = runPrimitiveStep(name) { DecimalType(builder(getResult())) }
+    fun addCodeUsing(name: String, builder: (T) -> String): OperationResult<T>        = runPrimitiveStep(name) { CodeType(builder(getResult())) }
+    fun addUriUsing(name: String, builder: (T) -> String): OperationResult<T>         = runPrimitiveStep(name) { UriType(builder(getResult())) }
+    fun addDateUsing(name: String, builder: (T) -> String): OperationResult<T>        = runPrimitiveStep(name) { DateType(builder(getResult())) }
+    fun addDateTimeUsing(name: String, builder: (T) -> String): OperationResult<T>    = runPrimitiveStep(name) { DateTimeType(builder(getResult())) }
+    fun addCanonicalUsing(name: String, builder: (T) -> String): OperationResult<T>   = runPrimitiveStep(name) { CanonicalType(builder(getResult())) }
 
     // Query methods
 

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -4,6 +4,7 @@ import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException
 import org.hl7.fhir.r4.model.*
 import org.slf4j.LoggerFactory
+import java.math.BigDecimal
 import kotlin.reflect.KClass
 
 /**
@@ -203,6 +204,206 @@ class OperationResult<T> private constructor(
             parameters.getOrPut(key) { mutableListOf() }.add(default)
             copyWith(default)
         }
+    }
+
+    // ── Primitive value convenience methods ──────────────────────────────────
+
+    fun addString(name: String, value: String): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = StringType(value)
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addBoolean(name: String, value: Boolean): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = BooleanType(value)
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addInteger(name: String, value: Int): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = IntegerType(value)
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addDecimal(name: String, value: BigDecimal): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = DecimalType(value)
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addCode(name: String, value: String): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = CodeType(value)
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addUri(name: String, value: String): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = UriType(value)
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addDate(name: String, value: String): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = DateType(value)
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addDateTime(name: String, value: String): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = DateTimeType(value)
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addCanonical(name: String, value: String): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = CanonicalType(value)
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addStringUsing(name: String, builder: (T) -> String): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = StringType(builder(getResult()))
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addBooleanUsing(name: String, builder: (T) -> Boolean): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = BooleanType(builder(getResult()))
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addIntegerUsing(name: String, builder: (T) -> Int): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = IntegerType(builder(getResult()))
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addDecimalUsing(name: String, builder: (T) -> BigDecimal): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = DecimalType(builder(getResult()))
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addCodeUsing(name: String, builder: (T) -> String): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = CodeType(builder(getResult()))
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addUriUsing(name: String, builder: (T) -> String): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = UriType(builder(getResult()))
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addDateUsing(name: String, builder: (T) -> String): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = DateType(builder(getResult()))
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addDateTimeUsing(name: String, builder: (T) -> String): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = DateTimeType(builder(getResult()))
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
+    fun addCanonicalUsing(name: String, builder: (T) -> String): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val fhirValue = CanonicalType(builder(getResult()))
+        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, fhirValue.fhirType(), durationMs, true)
+        logStep(name, fhirValue.fhirType(), durationMs)
+        return copyWith(result)
     }
 
     // Query methods

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -211,199 +211,343 @@ class OperationResult<T> private constructor(
     fun addString(name: String, value: String): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = StringType(value)
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = StringType(value)
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addBoolean(name: String, value: Boolean): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = BooleanType(value)
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = BooleanType(value)
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addInteger(name: String, value: Int): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = IntegerType(value)
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = IntegerType(value)
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addDecimal(name: String, value: BigDecimal): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = DecimalType(value)
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = DecimalType(value)
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addCode(name: String, value: String): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = CodeType(value)
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = CodeType(value)
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addUri(name: String, value: String): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = UriType(value)
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = UriType(value)
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addDate(name: String, value: String): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = DateType(value)
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = DateType(value)
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addDateTime(name: String, value: String): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = DateTimeType(value)
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = DateTimeType(value)
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addCanonical(name: String, value: String): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = CanonicalType(value)
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = CanonicalType(value)
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addStringUsing(name: String, builder: (T) -> String): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = StringType(builder(getResult()))
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = StringType(builder(getResult()))
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addBooleanUsing(name: String, builder: (T) -> Boolean): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = BooleanType(builder(getResult()))
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = BooleanType(builder(getResult()))
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addIntegerUsing(name: String, builder: (T) -> Int): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = IntegerType(builder(getResult()))
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = IntegerType(builder(getResult()))
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addDecimalUsing(name: String, builder: (T) -> BigDecimal): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = DecimalType(builder(getResult()))
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = DecimalType(builder(getResult()))
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addCodeUsing(name: String, builder: (T) -> String): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = CodeType(builder(getResult()))
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = CodeType(builder(getResult()))
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addUriUsing(name: String, builder: (T) -> String): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = UriType(builder(getResult()))
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = UriType(builder(getResult()))
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addDateUsing(name: String, builder: (T) -> String): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = DateType(builder(getResult()))
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = DateType(builder(getResult()))
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addDateTimeUsing(name: String, builder: (T) -> String): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = DateTimeType(builder(getResult()))
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = DateTimeType(builder(getResult()))
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     fun addCanonicalUsing(name: String, builder: (T) -> String): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val start = System.currentTimeMillis()
-        val fhirValue = CanonicalType(builder(getResult()))
-        parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
-        val durationMs = System.currentTimeMillis() - start
-        recordMetric(name, fhirValue.fhirType(), durationMs, true)
-        logStep(name, fhirValue.fhirType(), durationMs)
-        return copyWith(result)
+        return try {
+            val fhirValue = CanonicalType(builder(getResult()))
+            parameters.getOrPut(name) { mutableListOf() }.add(fhirValue)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric(name, fhirValue.fhirType(), durationMs, true)
+            logStep(name, fhirValue.fhirType(), durationMs)
+            copyWith(result)
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
+            recordMetric(name, "", durationMs, false)
+            outcomes.add(warningOutcome(e))
+            copyWith(result)
+        }
     }
 
     // Query methods

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertEquals
+import java.math.BigDecimal
 
 class OperationResultTest {
 
@@ -1010,6 +1011,161 @@ class OperationResultTest {
         val result = OperationResult.of(patient(), "patient")
 
         assertEquals(null, result.takeFirstTyped<Appointment>("missing"))
+    }
+
+    // ── Primitive value convenience methods ──────────────────────────────────
+
+    @Test
+    fun `addString stores StringType under given name`() {
+        val result = OperationResult.of(patient())
+            .addString("label", "hello")
+
+        assertTrue(result.containsKey("label"))
+        val stored = result.getAll("label").first()
+        assertThat(stored, instanceOf(StringType::class.java))
+        assertEquals("hello", (stored as StringType).value)
+    }
+
+    @Test
+    fun `addBoolean stores BooleanType under given name`() {
+        val result = OperationResult.of(patient())
+            .addBoolean("active", true)
+
+        assertTrue(result.containsKey("active"))
+        val stored = result.getAll("active").first()
+        assertThat(stored, instanceOf(BooleanType::class.java))
+        assertEquals(true, (stored as BooleanType).value)
+    }
+
+    @Test
+    fun `addInteger stores IntegerType under given name`() {
+        val result = OperationResult.of(patient())
+            .addInteger("count", 42)
+
+        assertTrue(result.containsKey("count"))
+        val stored = result.getAll("count").first()
+        assertThat(stored, instanceOf(IntegerType::class.java))
+        assertEquals(42, (stored as IntegerType).value)
+    }
+
+    @Test
+    fun `addDecimal stores DecimalType under given name`() {
+        val result = OperationResult.of(patient())
+            .addDecimal("score", BigDecimal("3.14"))
+
+        assertTrue(result.containsKey("score"))
+        val stored = result.getAll("score").first()
+        assertThat(stored, instanceOf(DecimalType::class.java))
+        assertEquals(BigDecimal("3.14"), (stored as DecimalType).value)
+    }
+
+    @Test
+    fun `addCode stores CodeType under given name`() {
+        val result = OperationResult.of(patient())
+            .addCode("status", "active")
+
+        assertTrue(result.containsKey("status"))
+        val stored = result.getAll("status").first()
+        assertThat(stored, instanceOf(CodeType::class.java))
+        assertEquals("active", (stored as CodeType).value)
+    }
+
+    @Test
+    fun `addUri stores UriType under given name`() {
+        val result = OperationResult.of(patient())
+            .addUri("profile", "http://hl7.org/fhir/StructureDefinition/Patient")
+
+        assertTrue(result.containsKey("profile"))
+        val stored = result.getAll("profile").first()
+        assertThat(stored, instanceOf(UriType::class.java))
+        assertEquals("http://hl7.org/fhir/StructureDefinition/Patient", (stored as UriType).value)
+    }
+
+    @Test
+    fun `addDate stores DateType under given name`() {
+        val result = OperationResult.of(patient())
+            .addDate("dob", "2024-01-15")
+
+        assertTrue(result.containsKey("dob"))
+        val stored = result.getAll("dob").first()
+        assertThat(stored, instanceOf(DateType::class.java))
+        assertEquals("2024-01-15", (stored as DateType).valueAsString)
+    }
+
+    @Test
+    fun `addDateTime stores DateTimeType under given name`() {
+        val result = OperationResult.of(patient())
+            .addDateTime("recorded", "2024-01-15T10:30:00")
+
+        assertTrue(result.containsKey("recorded"))
+        val stored = result.getAll("recorded").first()
+        assertThat(stored, instanceOf(DateTimeType::class.java))
+    }
+
+    @Test
+    fun `addCanonical stores CanonicalType under given name`() {
+        val result = OperationResult.of(patient())
+            .addCanonical("questionnaire", "http://example.org/Questionnaire/q1")
+
+        assertTrue(result.containsKey("questionnaire"))
+        val stored = result.getAll("questionnaire").first()
+        assertThat(stored, instanceOf(CanonicalType::class.java))
+        assertEquals("http://example.org/Questionnaire/q1", (stored as CanonicalType).value)
+    }
+
+    @Test
+    fun `addString preserves pipeline head type T`() {
+        val patient = patient()
+        val result: OperationResult<Patient> = OperationResult.of(patient)
+            .addString("label", "test")
+
+        assertThat(result.getResult(), sameInstance(patient))
+    }
+
+    @Test
+    fun `addString accumulates alongside existing parameters`() {
+        val result = OperationResult.of(patient())
+            .addString("label", "test")
+
+        assertTrue(result.containsKey("patient"))
+        assertTrue(result.containsKey("label"))
+    }
+
+    @Test
+    fun `addStringUsing receives current result`() {
+        val result = OperationResult.of(Patient().apply { id = "p1" })
+            .addStringUsing("id") { p -> p.idElement.idPart }
+
+        assertTrue(result.containsKey("id"))
+        val stored = result.getAll("id").first()
+        assertEquals("p1", (stored as StringType).value)
+    }
+
+    @Test
+    fun `addString is skipped when pipeline has errors in FAIL_FAST`() {
+        val result = OperationResult.of(patient())
+            .add { error("boom") }
+            .addString("label", "test")
+
+        assertFalse(result.containsKey("label"))
+    }
+
+    @Test
+    fun `primitive values round-trip through toParameters and fromParameters`() {
+        val original = OperationResult.of(patient())
+            .addString("label", "hello")
+            .addBoolean("active", true)
+
+        val params = original.toParameters()
+        val restored = OperationResult.fromParameters(params)
+
+        val label = restored.getAll("label").first()
+        assertThat(label, instanceOf(StringType::class.java))
+        assertEquals("hello", (label as StringType).value)
+
+        val active = restored.getAll("active").first()
+        assertThat(active, instanceOf(BooleanType::class.java))
+        assertEquals(true, (active as BooleanType).value)
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
@@ -1151,6 +1151,30 @@ class OperationResultTest {
     }
 
     @Test
+    fun `addStringUsing - exception in lambda records WARNING outcome and preserves head`() {
+        val patient = patient()
+        val result = OperationResult.of(patient)
+            .addStringUsing("label") { error("bad label") }
+
+        assertTrue(result.hasErrors())
+        assertEquals(OperationOutcome.IssueSeverity.WARNING, result.getOutcomes().first().issueFirstRep.severity)
+        assertFalse(result.containsKey("label"))
+        assertThat(result.getResult(), sameInstance(patient))
+    }
+
+    @Test
+    fun `addString - pipeline continues in ACCUMULATE after exception and head is preserved`() {
+        val patient = patient()
+        val result = OperationResult.of(patient, errorStrategy = ErrorStrategy.ACCUMULATE)
+            .addStringUsing("label") { error("boom") }
+            .addString("other", "ok")
+
+        assertTrue(result.hasErrors())
+        assertTrue(result.containsKey("other"))
+        assertThat(result.getResult(), sameInstance(patient))
+    }
+
+    @Test
     fun `primitive values round-trip through toParameters and fromParameters`() {
         val original = OperationResult.of(patient())
             .addString("label", "hello")


### PR DESCRIPTION
Add 9 typed methods (addString, addBoolean, addInteger, addDecimal,
addCode, addUri, addDate, addDateTime, addCanonical) plus matching
Using variants that derive the value from the current pipeline head.
All methods return OperationResult<T> preserving the head type,
follow the same timing/metrics/logging pattern as addOrSkip, and
respect FAIL_FAST skip semantics.

Also add 15 tests covering each type, head-type preservation,
skip-on-error behaviour, and round-trip through toParameters/fromParameters.
README updated with a Primitive value