### PR TITLE
Add complex data type convenience methods to OperationResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,31 @@ val result = OperationResult.of(patient)
 val encounter: Encounter = result.getResult()  // still typed correctly
 ```
 
+#### Complex data type helpers
+
+Construct and store common FHIR complex types without manually building HAPI objects. Like primitive helpers, these methods preserve the pipeline head type `T` and use Pattern B error handling (WARNING outcome, head preserved).
+
+| Method | FHIR type | Key parameters |
+|---|---|---|
+| `addCoding(name, system, code, display?)` | `Coding` | `system`, `code`, optional `display` |
+| `addReference(name, reference)` | `Reference` | `reference` string (e.g. `"Patient/123"`) |
+| `addIdentifier(name, system, value)` | `Identifier` | `system`, `value` |
+| `addPeriod(name, start?, end?)` | `Period` | nullable FHIR dateTime strings |
+| `addQuantity(name, value, unit, system?, code?)` | `Quantity` | `BigDecimal` value, UCUM unit, optional system/code |
+| `addCodeableConcept(name, system, code, display?, text?)` | `CodeableConcept` | coding fields plus optional free-text |
+
+```kotlin
+val result = OperationResult.of(patient)
+    .addCoding("obs-code", "http://loinc.org", "8867-4", "Heart rate")
+    .addReference("subject", "Patient/123")
+    .addIdentifier("mrn", "http://hospital.org/mrn", "MRN-001")
+    .addPeriod("admission", "2024-01-15", "2024-01-20")
+    .addQuantity("weight", BigDecimal("70.5"), "kg", "http://unitsofmeasure.org", "kg")
+    .addCodeableConcept("category", "http://snomed.info/sct", "413839001", "Chronic lung disease")
+
+val p: Patient = result.getResult()  // head type unchanged
+```
+
 ### Error Strategy
 
 `OperationResult` supports two strategies, set at construction time via `of()`:

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -261,6 +261,58 @@ class OperationResult<T> private constructor(
     fun addDateTimeUsing(name: String, builder: (T) -> String): OperationResult<T>    = runPrimitiveStep(name) { DateTimeType(builder(getResult())) }
     fun addCanonicalUsing(name: String, builder: (T) -> String): OperationResult<T>   = runPrimitiveStep(name) { CanonicalType(builder(getResult())) }
 
+    // ── Complex data type convenience methods ────────────────────────────────
+
+    fun addCoding(name: String, system: String, code: String, display: String? = null): OperationResult<T> =
+        runPrimitiveStep(name) {
+            Coding().apply {
+                this.system = system
+                this.code = code
+                if (display != null) this.display = display
+            }
+        }
+
+    fun addReference(name: String, reference: String): OperationResult<T> =
+        runPrimitiveStep(name) { Reference(reference) }
+
+    fun addIdentifier(name: String, system: String, value: String): OperationResult<T> =
+        runPrimitiveStep(name) {
+            Identifier().apply {
+                this.system = system
+                this.value = value
+            }
+        }
+
+    fun addPeriod(name: String, start: String?, end: String?): OperationResult<T> =
+        runPrimitiveStep(name) {
+            Period().apply {
+                if (start != null) this.startElement = DateTimeType(start)
+                if (end != null) this.endElement = DateTimeType(end)
+            }
+        }
+
+    fun addQuantity(name: String, value: BigDecimal, unit: String, system: String? = null, code: String? = null): OperationResult<T> =
+        runPrimitiveStep(name) {
+            Quantity().apply {
+                this.value = value
+                this.unit = unit
+                if (system != null) this.system = system
+                if (code != null) this.code = code
+            }
+        }
+
+    fun addCodeableConcept(name: String, system: String, code: String, display: String? = null, text: String? = null): OperationResult<T> =
+        runPrimitiveStep(name) {
+            CodeableConcept().apply {
+                addCoding().apply {
+                    this.system = system
+                    this.code = code
+                    if (display != null) this.display = display
+                }
+                if (text != null) this.text = text
+            }
+        }
+
     // Query methods
 
     fun getAllParameters(): Map<String, List<Base>> =

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
@@ -1192,6 +1192,135 @@ class OperationResultTest {
         assertEquals(true, (active as BooleanType).value)
     }
 
+    // ── Complex data type convenience methods ────────────────────────────────
+
+    @Test
+    fun `addCoding stores Coding with system, code, and display`() {
+        val result = OperationResult.of(patient())
+            .addCoding("status", "http://loinc.org", "8867-4", "Heart rate")
+
+        assertTrue(result.containsKey("status"))
+        val stored = result.getAll("status").first() as Coding
+        assertEquals("http://loinc.org", stored.system)
+        assertEquals("8867-4", stored.code)
+        assertEquals("Heart rate", stored.display)
+    }
+
+    @Test
+    fun `addCoding without display omits display`() {
+        val result = OperationResult.of(patient())
+            .addCoding("status", "http://loinc.org", "8867-4")
+
+        val stored = result.getAll("status").first() as Coding
+        assertEquals("http://loinc.org", stored.system)
+        assertEquals("8867-4", stored.code)
+        assertEquals(null, if (stored.hasDisplay()) stored.display else null)
+    }
+
+    @Test
+    fun `addReference stores Reference with reference string`() {
+        val result = OperationResult.of(patient())
+            .addReference("subject", "Patient/123")
+
+        assertTrue(result.containsKey("subject"))
+        val stored = result.getAll("subject").first() as Reference
+        assertEquals("Patient/123", stored.reference)
+    }
+
+    @Test
+    fun `addIdentifier stores Identifier with system and value`() {
+        val result = OperationResult.of(patient())
+            .addIdentifier("mrn", "http://hospital.org/mrn", "MRN-001")
+
+        assertTrue(result.containsKey("mrn"))
+        val stored = result.getAll("mrn").first() as Identifier
+        assertEquals("http://hospital.org/mrn", stored.system)
+        assertEquals("MRN-001", stored.value)
+    }
+
+    @Test
+    fun `addPeriod stores Period with start and end`() {
+        val result = OperationResult.of(patient())
+            .addPeriod("window", "2024-01-01", "2024-12-31")
+
+        assertTrue(result.containsKey("window"))
+        val stored = result.getAll("window").first() as Period
+        assertEquals("2024-01-01", stored.startElement.valueAsString)
+        assertEquals("2024-12-31", stored.endElement.valueAsString)
+    }
+
+    @Test
+    fun `addPeriod with null start stores Period with only end`() {
+        val result = OperationResult.of(patient())
+            .addPeriod("window", null, "2024-12-31")
+
+        val stored = result.getAll("window").first() as Period
+        assertFalse(stored.hasStart())
+        assertEquals("2024-12-31", stored.endElement.valueAsString)
+    }
+
+    @Test
+    fun `addQuantity stores Quantity with all fields`() {
+        val result = OperationResult.of(patient())
+            .addQuantity("weight", BigDecimal("70.5"), "kg", "http://unitsofmeasure.org", "kg")
+
+        assertTrue(result.containsKey("weight"))
+        val stored = result.getAll("weight").first() as Quantity
+        assertEquals(BigDecimal("70.5"), stored.value)
+        assertEquals("kg", stored.unit)
+        assertEquals("http://unitsofmeasure.org", stored.system)
+        assertEquals("kg", stored.code)
+    }
+
+    @Test
+    fun `addQuantity without system and code omits them`() {
+        val result = OperationResult.of(patient())
+            .addQuantity("weight", BigDecimal("70.5"), "kg")
+
+        val stored = result.getAll("weight").first() as Quantity
+        assertEquals(BigDecimal("70.5"), stored.value)
+        assertEquals("kg", stored.unit)
+        assertEquals(null, if (stored.hasSystem()) stored.system else null)
+        assertEquals(null, if (stored.hasCode()) stored.code else null)
+    }
+
+    @Test
+    fun `addCodeableConcept stores CodeableConcept with coding and text`() {
+        val result = OperationResult.of(patient())
+            .addCodeableConcept("category", "http://snomed.info/sct", "413839001", "Chronic lung disease", "Chronic lung disease (disorder)")
+
+        assertTrue(result.containsKey("category"))
+        val stored = result.getAll("category").first() as CodeableConcept
+        val coding = stored.codingFirstRep
+        assertEquals("http://snomed.info/sct", coding.system)
+        assertEquals("413839001", coding.code)
+        assertEquals("Chronic lung disease", coding.display)
+        assertEquals("Chronic lung disease (disorder)", stored.text)
+    }
+
+    @Test
+    fun `addCoding preserves pipeline head type T`() {
+        val patient = patient()
+        val result: OperationResult<Patient> = OperationResult.of(patient)
+            .addCoding("status", "http://loinc.org", "8867-4", "Heart rate")
+
+        assertThat(result.getResult(), sameInstance(patient))
+    }
+
+    @Test
+    fun `complex types round-trip through toParameters and fromParameters`() {
+        val original = OperationResult.of(patient())
+            .addCoding("obs-code", "http://loinc.org", "8867-4", "Heart rate")
+
+        val params = original.toParameters()
+        val restored = OperationResult.fromParameters(params)
+
+        val stored = restored.getAll("obs-code").first()
+        assertThat(stored, instanceOf(Coding::class.java))
+        assertEquals("http://loinc.org", (stored as Coding).system)
+        assertEquals("8867-4", stored.code)
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private fun patient() = Patient().apply {


### PR DESCRIPTION
Adds addCoding, addReference, addIdentifier, addPeriod, addQuantity,
and addCodeableConcept methods that construct and store common FHIR
complex types without requiring manual HAPI object construction.
All methods delegate to runPrimitiveStep (Pattern B), preserving the
pipeline head type T and using WARNING-severity outcomes on failure.