### PR TITLE
Add addPart method for explicit nested parameter construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,47 @@ val result = OperationResult.of(patient)
 val p: Patient = result.getResult()  // head type unchanged
 ```
 
+#### Nested parameters (parts)
+
+`addPart` builds nested FHIR `Parameters.part` structures using a sub-pipeline builder lambda, without relying on dot-delimited key names in the parameter map.
+
+```kotlin
+fun addPart(name: String, builder: OperationResult<T>.() -> OperationResult<*>): OperationResult<T>
+```
+
+The sub-pipeline receives its own empty parameter map so the parent map is not polluted. Entries produced by the builder are prefixed with `"name."` and stored in the parent map, where `toParameters()` reconstructs the nested `part` structure automatically. The pipeline head type `T` is preserved. Outcomes/errors from the sub-pipeline are not propagated to the parent.
+
+```kotlin
+val result = OperationResult.of(patient)
+    .addPart("address") {
+        addString("city", "Springfield")
+            .addString("country", "US")
+    }
+
+// toParameters() produces:
+// Parameters
+//   parameter: name="address"
+//     part: name="city",    valueString="Springfield"
+//     part: name="country", valueString="US"
+```
+
+Parts can be nested arbitrarily deep:
+
+```kotlin
+val result = OperationResult.of(patient)
+    .addPart("outer") {
+        addPart("inner") {
+            addString("leaf", "deep")
+        }
+    }
+
+// toParameters() produces:
+// Parameters
+//   parameter: name="outer"
+//     part: name="inner"
+//       part: name="leaf", valueString="deep"
+```
+
 ### Error Strategy
 
 `OperationResult` supports two strategies, set at construction time via `of()`:

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -313,6 +313,41 @@ class OperationResult<T> private constructor(
             }
         }
 
+    // ── Nested parameter construction (parts) ───────────────────────────────
+
+    /**
+     * Builds a nested FHIR `Parameters.part` structure using a sub-pipeline builder lambda,
+     * without relying on dot-delimited key names.
+     *
+     * The sub-pipeline receives its own empty parameter map so the parent map is not polluted.
+     * Entries produced by the builder are prefixed with `"name."` and stored in the parent map.
+     * [toParameters] then reconstructs the nested `part` structure automatically from these
+     * dot-delimited keys.
+     *
+     * The sub-pipeline's outcomes/errors are NOT merged into the parent — only parameter map
+     * entries are merged. The pipeline head type [T] is preserved.
+     */
+    fun addPart(name: String, builder: OperationResult<T>.() -> OperationResult<*>): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+
+        val subPipeline = OperationResult<T>(
+            mutableMapOf(), result, mutableListOf(), errorStrategy, mutableMapOf(), timingEnabled, mutableListOf()
+        )
+
+        val built = builder(subPipeline)
+
+        built.getAllParameters().forEach { (childKey, values) ->
+            val prefixedKey = "$name.$childKey"
+            parameters.getOrPut(prefixedKey) { mutableListOf() }.addAll(values)
+        }
+
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, "part", durationMs, true)
+        logStep(name, "part", durationMs)
+        return copyWith(result)
+    }
+
     // Query methods
 
     fun getAllParameters(): Map<String, List<Base>> =

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
@@ -1321,6 +1321,108 @@ class OperationResultTest {
         assertEquals("8867-4", stored.code)
     }
 
+    // ── addPart (nested parameter construction) ──────────────────────────────
+
+    @Test
+    fun `addPart creates dot-prefixed keys in parameter map`() {
+        val result = OperationResult.of(patient())
+            .addPart("address") { addString("city", "Springfield").addString("country", "US") }
+
+        assertTrue(result.containsKey("address.city"))
+        assertTrue(result.containsKey("address.country"))
+        assertEquals("Springfield", (result.getAll("address.city").first() as StringType).value)
+        assertEquals("US", (result.getAll("address.country").first() as StringType).value)
+    }
+
+    @Test
+    fun `addPart produces nested parts in toParameters output`() {
+        val result = OperationResult.of(patient())
+            .addPart("address") { addString("city", "Springfield").addString("country", "US") }
+
+        val params = result.toParameters()
+
+        val addressParam = params.parameter.filter { it.name == "address" }
+        assertEquals(1, addressParam.size, "Expected exactly one 'address' parameter")
+        assertFalse(params.parameter.any { it.name == "address.city" }, "Flat dot-key should not appear at top level")
+
+        val parts = addressParam.first().part
+        assertEquals(2, parts.size)
+        val cityPart = parts.first { it.name == "city" }
+        val countryPart = parts.first { it.name == "country" }
+        assertEquals("Springfield", (cityPart.value as StringType).value)
+        assertEquals("US", (countryPart.value as StringType).value)
+    }
+
+    @Test
+    fun `addPart preserves pipeline head type T`() {
+        val result: OperationResult<Patient> = OperationResult.of(patient())
+            .addPart("address") { addString("city", "Springfield") }
+
+        assertThat(result.getResult(), instanceOf(Patient::class.java))
+    }
+
+    @Test
+    fun `addPart with deeply nested sub-parts`() {
+        val result = OperationResult.of(patient())
+            .addPart("outer") { addPart("inner") { addString("leaf", "deep") } }
+
+        assertTrue(result.containsKey("outer.inner.leaf"))
+        assertEquals("deep", (result.getAll("outer.inner.leaf").first() as StringType).value)
+
+        val params = result.toParameters()
+        val outerParam = params.parameter.first { it.name == "outer" }
+        val innerPart = outerParam.part.first { it.name == "inner" }
+        val leafPart = innerPart.part.first { it.name == "leaf" }
+        assertEquals("deep", (leafPart.value as StringType).value)
+    }
+
+    @Test
+    fun `addPart round-trips through fromParameters toParameters`() {
+        val original = OperationResult.of(patient())
+            .addPart("address") { addString("city", "Springfield").addString("country", "US") }
+
+        val params1 = original.toParameters()
+        val restored = OperationResult.fromParameters(params1)
+        val params2 = restored.toParameters()
+
+        val addressParam1 = params1.parameter.first { it.name == "address" }
+        val addressParam2 = params2.parameter.first { it.name == "address" }
+        assertEquals(addressParam1.part.size, addressParam2.part.size)
+        assertEquals(
+            addressParam1.part.first { it.name == "city" }.value.primitiveValue(),
+            addressParam2.part.first { it.name == "city" }.value.primitiveValue()
+        )
+        assertEquals(
+            addressParam1.part.first { it.name == "country" }.value.primitiveValue(),
+            addressParam2.part.first { it.name == "country" }.value.primitiveValue()
+        )
+    }
+
+    @Test
+    fun `addPart is skipped when pipeline has errors in FAIL_FAST`() {
+        val result = OperationResult.of(patient(), errorStrategy = ErrorStrategy.FAIL_FAST)
+            .add { throw RuntimeException("induced failure") }
+            .addPart("address") { addString("city", "Springfield") }
+
+        assertFalse(result.containsKey("address.city"))
+    }
+
+    @Test
+    fun `addPart alongside flat parameters`() {
+        val p = patient()
+        val result = OperationResult.of(p)
+            .addPart("meta") { addString("tag", "test") }
+
+        assertTrue(result.containsKey("patient"))
+        assertTrue(result.containsKey("meta.tag"))
+
+        val params = result.toParameters()
+        assertTrue(params.parameter.any { it.name == "patient" })
+        val metaParam = params.parameter.first { it.name == "meta" }
+        assertEquals(1, metaParam.part.size)
+        assertEquals("test", (metaParam.part.first().value as StringType).value)
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private fun patient() = Patient().apply {


### PR DESCRIPTION
Adds addPart(name, builder) to OperationResult<T> that builds nested
FHIR Parameters.part structures using a sub-pipeline lambda, without
relying on dot-delimited key names at the call site. Internally prefixes
sub-pipeline keys with "name." so the existing toParameters() dot-key
reconstruction produces the correct nested part hierarchy.

- Sub-pipeline gets its own empty parameter map (parent not polluted)
- Sub-pipeline outcomes/errors are not propagated to parent
- Pipeline head type T is preserved; supports arbitrary nesting depth
- Skipped when FAIL_FAST and pipeline has errors (shouldSkip check)
- 7 new tests covering keys, toParameters nesting, head-type preservation,
  deep nesting, round-trip, FAIL_FAST skip, and mixed flat+part parameters
- README updated with "Nested parameters (parts)" subsection