### PR TITLE
Add OperationResult.empty() companion factory method

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ OperationResult.fromParametersTyped<Patient>(parameters, primaryKey = "patient")
 // From a FHIR Bundle
 OperationResult.fromBundle(bundle)
 OperationResult.fromBundle(bundle) { entry -> entry.fullUrl }   // custom key strategy
+
+// Empty — no values, no typed head; useful for conditional pipelines or merge targets
+OperationResult.empty()
+OperationResult.empty(errorStrategy = ErrorStrategy.ACCUMULATE)
+```
+
+```kotlin
+// Start empty, conditionally add
+val result = OperationResult.empty()
+    .add("patient") { fetchPatient() }
+    .addOrSkip("coverage") { fetchCoverage() }
+
+// Valid even with no parameters
+OperationResult.empty().toParameters()  // empty Parameters resource
 ```
 
 ### Builder Methods

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -895,6 +895,26 @@ class OperationResult<T> private constructor(
             return OperationResult(params, null, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
         }
 
+        /**
+         * Creates an empty [OperationResult] with no parameters and no pipeline head.
+         *
+         * Useful for:
+         * - Starting a pipeline that conditionally adds parameters
+         * - Building a [Parameters] resource that may legitimately have zero entries
+         * - Serving as a merge target
+         *
+         * [getResult] will throw [IllegalStateException] until a value is added via [add] or similar.
+         * [toParameters] returns a valid empty [Parameters] resource.
+         */
+        fun empty(errorStrategy: ErrorStrategy = ErrorStrategy.FAIL_FAST): OperationResult<Base> =
+            OperationResult(
+                mutableMapOf(),
+                null,
+                mutableListOf(),
+                errorStrategy,
+                mutableMapOf()
+            )
+
         // ── Private helpers ───────────────────────────────────────────────────
 
         private fun buildParamsFrom(parameters: Parameters): MutableMap<String, MutableList<Base>> {

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import java.math.BigDecimal
 
 class OperationResultTest {
@@ -1421,6 +1422,80 @@ class OperationResultTest {
         val metaParam = params.parameter.first { it.name == "meta" }
         assertEquals(1, metaParam.part.size)
         assertEquals("test", (metaParam.part.first().value as StringType).value)
+    }
+
+    // ── Factory: empty() ─────────────────────────────────────────────────────
+
+    @Test
+    fun `empty creates result with no parameters`() {
+        val result = OperationResult.empty()
+
+        assertTrue(result.isEmpty())
+        assertEquals(0, result.totalCount())
+    }
+
+    @Test
+    fun `empty result is successful`() {
+        val result = OperationResult.empty()
+
+        assertTrue(result.isSuccessful())
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `empty toParameters returns valid empty Parameters`() {
+        val params = OperationResult.empty().toParameters()
+
+        assertTrue(params.parameter.isEmpty())
+    }
+
+    @Test
+    fun `empty getResult throws IllegalStateException`() {
+        val result = OperationResult.empty()
+
+        assertThrows(IllegalStateException::class.java) { result.getResult() }
+    }
+
+    @Test
+    fun `empty allows subsequent add calls`() {
+        val result = OperationResult.empty()
+            .add("patient") { patient() }
+
+        assertTrue(result.containsKey("patient"))
+    }
+
+    @Test
+    fun `empty with ACCUMULATE error strategy`() {
+        val result = OperationResult.empty(ErrorStrategy.ACCUMULATE)
+            .add { throw RuntimeException("induced failure") }
+            .add("patient") { patient() }
+
+        assertTrue(result.containsKey("patient"))
+        assertTrue(result.hasErrors())
+    }
+
+    @Test
+    fun `empty can be used as merge target`() {
+        val result = OperationResult.empty()
+            .merge(OperationResult.of(patient()))
+
+        assertTrue(result.containsKey("patient"))
+    }
+
+    @Test
+    fun `empty toTransactionBundle returns empty bundle`() {
+        val bundle = OperationResult.empty().toTransactionBundle()
+
+        assertTrue(bundle.entry.isEmpty())
+    }
+
+    @Test
+    fun `empty with timed returns metrics`() {
+        val result = OperationResult.empty()
+            .timed()
+            .add("p") { patient() }
+
+        assertEquals(1, result.getMetrics().size)
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Creates an OperationResult with no parameters and no typed head,
enabling conditional pipeline building from scratch. Includes 9
tests covering isEmpty, isSuccessful, toParameters, getResult throw,
add chaining, error strategy, merge target, toTransactionBundle,
and timed metrics. README Entry Points section updated with usage examples.