### PR TITLE
Add addWithExtension for attaching FHIR extensions to parameter entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ val result = OperationResult.of(patient)
 
 Extensions on dot-delimited (nested) keys work correctly — `buildParameterComponents` tracks the full key path during recursion and attaches extensions to the appropriate nested part.
 
-> **Note:** Extensions are serialized by `toParameters()` but are **not** deserialized by `fromParameters()`. A round-trip via `fromParameters` will lose the extension metadata on the parameter components.
+> **Note:** Extensions on resource parameters (where `setResource` is used instead of `setValue`) are not captured by `fromParameters()` — the resource already carries its own extension list natively. Extensions on value parameters round-trip correctly.
 
 ### Error Strategy
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,48 @@ val result = OperationResult.of(patient)
 //       part: name="leaf", valueString="deep"
 ```
 
+#### Extensions on parameters
+
+`addWithExtension` attaches one or more FHIR `Extension` objects to an individual parameter entry. When serialized via `toParameters()`, the extensions are emitted on the corresponding `ParametersParameterComponent`.
+
+```kotlin
+fun <R : Base> addWithExtension(
+    name: String,
+    value: R,
+    vararg exts: Extension
+): OperationResult<T>
+```
+
+The pipeline head type `T` is preserved (behaves like `addOrSkip`). An `IdentityHashMap` is used internally so that two distinct instances that are `.equals()` each keep independent extension lists.
+
+```kotlin
+val flagExt = Extension("http://example.com/flag", BooleanType(true))
+
+val result = OperationResult.of(patient)
+    .addWithExtension("status", StringType("active"), flagExt)
+
+// toParameters() produces:
+// Parameters
+//   parameter: name="status", valueString="active"
+//     extension: url="http://example.com/flag", valueBoolean=true
+```
+
+Multiple extensions are supported:
+
+```kotlin
+val result = OperationResult.of(patient)
+    .addWithExtension(
+        "obs",
+        CodeType("8867-4"),
+        Extension("http://example.com/ext1", StringType("v1")),
+        Extension("http://example.com/ext2", StringType("v2"))
+    )
+```
+
+Extensions on dot-delimited (nested) keys work correctly — `buildParameterComponents` tracks the full key path during recursion and attaches extensions to the appropriate nested part.
+
+> **Note:** Extensions are serialized by `toParameters()` but are **not** deserialized by `fromParameters()`. A round-trip via `fromParameters` will lose the extension metadata on the parameter components.
+
 ### Error Strategy
 
 `OperationResult` supports two strategies, set at construction time via `of()`:

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -865,8 +865,8 @@ class OperationResult<T> private constructor(
          * [fromParametersTyped] when a typed head is required.
          */
         fun fromParameters(parameters: Parameters): OperationResult<Base> {
-            val params = buildParamsFrom(parameters)
-            return OperationResult(params, null, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
+            val (params, exts) = buildParamsFrom(parameters)
+            return OperationResult(params, null, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf(), extensions = exts)
         }
 
         /**
@@ -880,14 +880,14 @@ class OperationResult<T> private constructor(
             primaryKey: String,
             type: KClass<T>
         ): OperationResult<T> {
-            val params = buildParamsFrom(parameters)
+            val (params, exts) = buildParamsFrom(parameters)
             val primary = params[primaryKey]
                 ?.filterIsInstance(type.java)
                 ?.firstOrNull()
                 ?: throw IllegalArgumentException(
                     "No value of type '${type.simpleName}' found under key '$primaryKey'"
                 )
-            return OperationResult(params, primary, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
+            return OperationResult(params, primary, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf(), extensions = exts)
         }
 
         /** Reified overload of [fromParametersTyped] — no [KClass] argument needed at call sites. */
@@ -961,30 +961,46 @@ class OperationResult<T> private constructor(
 
         // ── Private helpers ───────────────────────────────────────────────────
 
-        private fun buildParamsFrom(parameters: Parameters): MutableMap<String, MutableList<Base>> {
+        private fun buildParamsFrom(
+            parameters: Parameters
+        ): Pair<MutableMap<String, MutableList<Base>>, MutableMap<String, MutableMap<Base, List<Extension>>>> {
             val params = mutableMapOf<String, MutableList<Base>>()
-            parameters.parameter.forEach { param -> populateFromParam(params, param) }
-            return params
+            val exts = mutableMapOf<String, MutableMap<Base, List<Extension>>>()
+            parameters.parameter.forEach { param -> populateFromParam(params, exts, param) }
+            return params to exts
         }
 
         /**
-         * Recursively populates [params] from a single [Parameters.ParametersParameterComponent].
+         * Recursively populates [params] and [exts] from a single [Parameters.ParametersParameterComponent].
          *
-         * - Resource parameter  → stored under [keyPrefix]`.<name>` (or just `<name>` at root)
-         * - Value parameter     → stored under [keyPrefix]`.<name>`
+         * - Resource parameter  → stored under [keyPrefix]`.<name>` (or just `<name>` at root);
+         *                         component-level extensions on resource parameters are not captured
+         *                         because the resource already carries its own extension list.
+         * - Value parameter     → stored under [keyPrefix]`.<name>`; any component-level extensions
+         *                         (i.e. [Parameters.ParametersParameterComponent.extension]) are
+         *                         preserved in [exts] so that a subsequent [toParameters] call
+         *                         re-emits them on the same component.
          * - Parts-only entry    → each part is processed recursively with the current key as prefix
          */
         private fun populateFromParam(
             params: MutableMap<String, MutableList<Base>>,
+            exts: MutableMap<String, MutableMap<Base, List<Extension>>>,
             param: Parameters.ParametersParameterComponent,
             keyPrefix: String = ""
         ) {
             val key = if (keyPrefix.isEmpty()) param.name else "$keyPrefix.${param.name}"
             when {
                 param.hasResource() -> params.getOrPut(key) { mutableListOf() }.add(param.resource)
-                param.hasValue()    -> params.getOrPut(key) { mutableListOf() }.add(param.value)
-                param.hasPart()     -> param.part.forEach { part ->
-                    populateFromParam(params, part, key)
+                param.hasValue() -> {
+                    val value = param.value
+                    params.getOrPut(key) { mutableListOf() }.add(value)
+                    if (param.hasExtension()) {
+                        val innerMap = exts.getOrPut(key) { IdentityHashMap() }
+                        innerMap[value] = param.extension.toList()
+                    }
+                }
+                param.hasPart() -> param.part.forEach { part ->
+                    populateFromParam(params, exts, part, key)
                 }
             }
         }

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -5,6 +5,7 @@ import ca.uhn.fhir.rest.server.exceptions.InternalErrorException
 import org.hl7.fhir.r4.model.*
 import org.slf4j.LoggerFactory
 import java.math.BigDecimal
+import java.util.IdentityHashMap
 import kotlin.reflect.KClass
 
 /**
@@ -23,7 +24,8 @@ class OperationResult<T> private constructor(
     private val errorStrategy: ErrorStrategy,
     private val failedTasks: MutableMap<String, OperationOutcome>,
     private val timingEnabled: Boolean = false,
-    private val metrics: MutableList<StepMetrics> = mutableListOf()
+    private val metrics: MutableList<StepMetrics> = mutableListOf(),
+    private val extensions: MutableMap<String, MutableMap<Base, List<Extension>>> = mutableMapOf()
 ) {
 
     // Error state
@@ -66,11 +68,17 @@ class OperationResult<T> private constructor(
     private fun <R> copyWith(
         result: R?,
         params: MutableMap<String, MutableList<Base>> = parameters,
-        timingEnabled: Boolean = this.timingEnabled
-    ): OperationResult<R> = OperationResult(params, result, outcomes, errorStrategy, failedTasks, timingEnabled, metrics)
+        timingEnabled: Boolean = this.timingEnabled,
+        extensions: MutableMap<String, MutableMap<Base, List<Extension>>> = this.extensions
+    ): OperationResult<R> = OperationResult(params, result, outcomes, errorStrategy, failedTasks, timingEnabled, metrics, extensions)
 
     private fun shallowCopyParams(): MutableMap<String, MutableList<Base>> =
         parameters.mapValues { (_, values) -> values.toMutableList() }.toMutableMap()
+
+    private fun shallowCopyExtensions(): MutableMap<String, MutableMap<Base, List<Extension>>> =
+        extensions.mapValues { (_, inner) ->
+            IdentityHashMap<Base, List<Extension>>(inner)
+        }.toMutableMap()
 
     // Metrics and timing
 
@@ -348,6 +356,37 @@ class OperationResult<T> private constructor(
         return copyWith(result)
     }
 
+    // ── Extension support ──────────────────────────────────────────────
+
+    /**
+     * Adds [value] to the parameter map under [name] with FHIR [exts] attached.
+     * When serialized via [toParameters], the extensions are added to the emitted
+     * [Parameters.ParametersParameterComponent].
+     *
+     * Uses an [IdentityHashMap] for the inner extension lookup so that two different
+     * instances that are `.equals()` but not the same object each keep independent
+     * extension lists.
+     *
+     * Returns [OperationResult<T>] (unchanged head), like [addOrSkip].
+     */
+    fun <R : Base> addWithExtension(
+        name: String,
+        value: R,
+        vararg exts: Extension
+    ): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val start = System.currentTimeMillis()
+        parameters.getOrPut(name) { mutableListOf() }.add(value)
+        if (exts.isNotEmpty()) {
+            val innerMap = extensions.getOrPut(name) { IdentityHashMap() }
+            innerMap[value] = exts.toList()
+        }
+        val durationMs = System.currentTimeMillis() - start
+        recordMetric(name, value.fhirType(), durationMs, true)
+        logStep(name, value.fhirType(), durationMs)
+        return copyWith(result)
+    }
+
     // Query methods
 
     fun getAllParameters(): Map<String, List<Base>> =
@@ -435,7 +474,7 @@ class OperationResult<T> private constructor(
         inner.parameters.forEach { (key, values) ->
             newParams.getOrPut(key) { mutableListOf() }.addAll(values)
         }
-        return copyWith(inner.result, params = newParams)
+        return copyWith(inner.result, params = newParams, extensions = shallowCopyExtensions())
     }
 
     /**
@@ -447,14 +486,14 @@ class OperationResult<T> private constructor(
         other.parameters.forEach { (key, values) ->
             newParams.getOrPut(key) { mutableListOf() }.addAll(values)
         }
-        return copyWith(result, params = newParams)
+        return copyWith(result, params = newParams, extensions = shallowCopyExtensions())
     }
 
     /** Returns a new [OperationResult] without the entry for [name]. No-op if [name] is absent. */
     fun remove(name: String): OperationResult<T> {
         val newParams = shallowCopyParams()
         newParams.remove(name)
-        return copyWith(result, params = newParams)
+        return copyWith(result, params = newParams, extensions = shallowCopyExtensions())
     }
 
     /**
@@ -468,7 +507,7 @@ class OperationResult<T> private constructor(
         if (values != null) {
             newParams.getOrPut(newName) { mutableListOf() }.addAll(values)
         }
-        return copyWith(result, params = newParams)
+        return copyWith(result, params = newParams, extensions = shallowCopyExtensions())
     }
 
     /**
@@ -712,6 +751,7 @@ class OperationResult<T> private constructor(
      */
     private fun buildParameterComponents(
         entries: Map<String, List<Base>>,
+        keyPrefix: String = "",
         addComponent: (String) -> Parameters.ParametersParameterComponent
     ) {
         // Unique top-level segments in insertion order
@@ -724,6 +764,8 @@ class OperationResult<T> private constructor(
                 .filterKeys { it.startsWith("$segment.") }
                 .mapKeys { (key, _) -> key.removePrefix("$segment.") }
 
+            val fullKey = if (keyPrefix.isEmpty()) segment else "$keyPrefix.$segment"
+
             if (childEntries.isEmpty()) {
                 // Leaf: one component per value
                 directValues?.forEach { value ->
@@ -732,12 +774,14 @@ class OperationResult<T> private constructor(
                             is Type     -> setValue(value)
                             is Resource -> setResource(value)
                         }
+                        val valueExts = extensions[fullKey]?.get(value)
+                        valueExts?.forEach { ext -> addExtension(ext) }
                     }
                 }
             } else {
                 // Branch: single parent component whose children are built recursively
                 val parent = addComponent(segment)
-                buildParameterComponents(childEntries) { childName ->
+                buildParameterComponents(childEntries, fullKey) { childName ->
                     parent.addPart().also { it.name = childName }
                 }
             }

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
@@ -1567,20 +1567,47 @@ class OperationResultTest {
     }
 
     @Test
-    fun `extensions survive round-trip serialization`() {
+    fun `extensions survive full round-trip via fromParameters`() {
         val value = StringType("hello")
         val ext = Extension("http://example.com/ext", StringType("extValue"))
 
-        val params = OperationResult.of(patient())
+        val params1 = OperationResult.of(patient())
             .addWithExtension("greeting", value, ext)
             .toParameters()
 
-        // Verify extension is present in the serialized Parameters
-        val param = params.parameter.first { it.name == "greeting" }
+        val params2 = OperationResult.fromParameters(params1).toParameters()
+
+        val param = params2.parameter.first { it.name == "greeting" }
         assertEquals(1, param.extension.size)
         assertEquals("http://example.com/ext", param.extension.first().url)
-        // Note: extensions are serialized but not deserialized by fromParameters;
-        // a round-trip via fromParameters loses extension metadata on the parameter components.
+        assertEquals("extValue", (param.extension.first().value as StringType).value)
+    }
+
+    @Test
+    fun `fromParameters preserves existing extensions and addWithExtension adds new ones`() {
+        // Build an initial Parameters with one extension on "greeting"
+        val original = Extension("http://example.com/original", StringType("orig"))
+        val params1 = OperationResult.of(patient())
+            .addWithExtension("greeting", StringType("hello"), original)
+            .toParameters()
+
+        // Round-trip through fromParameters, then attach an additional extension on a new key
+        val added = Extension("http://example.com/added", StringType("new"))
+        val params2 = OperationResult.fromParameters(params1)
+            .addWithExtension("status", StringType("active"), added)
+            .toParameters()
+
+        // Original extension on "greeting" is preserved
+        val greetingParam = params2.parameter.first { it.name == "greeting" }
+        assertEquals(1, greetingParam.extension.size)
+        assertEquals("http://example.com/original", greetingParam.extension.first().url)
+        assertEquals("orig", (greetingParam.extension.first().value as StringType).value)
+
+        // Newly added extension on "status" is present
+        val statusParam = params2.parameter.first { it.name == "status" }
+        assertEquals(1, statusParam.extension.size)
+        assertEquals("http://example.com/added", statusParam.extension.first().url)
+        assertEquals("new", (statusParam.extension.first().value as StringType).value)
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
@@ -1498,6 +1498,91 @@ class OperationResultTest {
         assertEquals(1, result.getMetrics().size)
     }
 
+    // ── Extension support ──────────────────────────────────────────────
+
+    @Test
+    fun `addWithExtension stores value with extension`() {
+        val value = StringType("hello")
+        val ext = Extension("http://example.com/ext", StringType("extValue"))
+
+        val result = OperationResult.of(patient())
+            .addWithExtension("greeting", value, ext)
+
+        assertTrue(result.containsKey("greeting"))
+        assertEquals(1, result.count("greeting"))
+        assertThat(result.getAll("greeting").first(), sameInstance(value))
+    }
+
+    @Test
+    fun `addWithExtension extensions appear in toParameters output`() {
+        val value = StringType("hello")
+        val ext = Extension("http://example.com/ext", StringType("extValue"))
+
+        val params = OperationResult.of(patient())
+            .addWithExtension("greeting", value, ext)
+            .toParameters()
+
+        val param = params.parameter.first { it.name == "greeting" }
+        assertEquals(1, param.extension.size)
+        assertEquals("http://example.com/ext", param.extension.first().url)
+        assertEquals("extValue", (param.extension.first().value as StringType).value)
+    }
+
+    @Test
+    fun `addWithExtension with multiple extensions`() {
+        val value = StringType("hello")
+        val ext1 = Extension("http://example.com/ext1", StringType("v1"))
+        val ext2 = Extension("http://example.com/ext2", StringType("v2"))
+
+        val params = OperationResult.of(patient())
+            .addWithExtension("greeting", value, ext1, ext2)
+            .toParameters()
+
+        val param = params.parameter.first { it.name == "greeting" }
+        assertEquals(2, param.extension.size)
+        assertEquals("http://example.com/ext1", param.extension[0].url)
+        assertEquals("http://example.com/ext2", param.extension[1].url)
+    }
+
+    @Test
+    fun `addWithExtension preserves pipeline head type T`() {
+        val patient = patient()
+        val result: OperationResult<Patient> = OperationResult.of(patient)
+            .addWithExtension("greeting", StringType("hello"), Extension("http://example.com/ext", StringType("v")))
+
+        assertThat(result.getResult(), sameInstance(patient))
+    }
+
+    @Test
+    fun `addWithExtension without extensions behaves like addOrSkip`() {
+        val value = StringType("hello")
+
+        val params = OperationResult.of(patient())
+            .addWithExtension("greeting", value)
+            .toParameters()
+
+        val param = params.parameter.first { it.name == "greeting" }
+        assertTrue(param.extension.isEmpty())
+        assertEquals("hello", (param.value as StringType).value)
+    }
+
+    @Test
+    fun `extensions survive round-trip serialization`() {
+        val value = StringType("hello")
+        val ext = Extension("http://example.com/ext", StringType("extValue"))
+
+        val params = OperationResult.of(patient())
+            .addWithExtension("greeting", value, ext)
+            .toParameters()
+
+        // Verify extension is present in the serialized Parameters
+        val param = params.parameter.first { it.name == "greeting" }
+        assertEquals(1, param.extension.size)
+        assertEquals("http://example.com/ext", param.extension.first().url)
+        // Note: extensions are serialized but not deserialized by fromParameters;
+        // a round-trip via fromParameters loses extension metadata on the parameter components.
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private fun patient() = Patient().apply {


### PR DESCRIPTION
Adds the ability to attach FHIR Extension objects to individual parameter
entries so that toParameters() emits them on the corresponding
ParametersParameterComponent.

- Add `extensions` field (MutableMap with IdentityHashMap inner map) to
  OperationResult constructor and copyWith
- Add shallowCopyExtensions() helper; update flatMap/merge/remove/rename
  to call it alongside shallowCopyParams()
- Add addWithExtension(name, value, vararg exts) builder method that
  preserves the pipeline head type T (Pattern B behaviour)
- Update buildParameterComponents to accept a keyPrefix parameter so
  extensions can be resolved by their full dot-delimited key during
  recursive nested-part serialisation
- Add 6 tests under the "Extension support" section
- Document addWithExtension in README with signature and code example

Note: extensions are serialized by toParameters() but not deserialized
by fromParameters() — documented as a known limitation.
