### PR TITLE
Add FhirExtensionHelper — deep extension retrieval utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,61 @@ val result2 = OperationResult.of(patient)
     .addTimeUsingLocalTime("appt") { LocalTime.of(9, 0) }
 ```
 
+#### FhirExtensionHelper
+
+`FhirExtensionHelper` is a public Kotlin `object` in `dev.ratkay.operation` for retrieving FHIR extensions from any object that can carry them. All methods search **at every level** of the FHIR object graph — not just the top-level `.extension` list of the source — by recursively traversing FHIR child elements.
+
+Any object implementing `IBaseHasExtensions` is a valid source: FHIR resources (`Patient`, `Observation`, …), all primitive types (`StringType`, `BooleanType`, …), all complex datatypes (`Coding`, `Reference`, …), and `Extension` itself (for nested sub-extensions).
+
+Each retrieval method has two flavours:
+- **Kotlin nullable** — returns `T?`; idiomatic for Kotlin callers.
+- **Java Optional / `Class<T>`** — returns `Optional<T>` or takes a `Class<T>` parameter; idiomatic for Java callers.
+
+| Method | Returns | Description |
+|---|---|---|
+| `hasExtension(source, url)` | `Boolean` | Deep presence check |
+| `getByUrl(source, url)` | `Extension?` | First match at any depth |
+| `getByUrlOptional(source, url)` | `Optional<Extension>` | Java-friendly alias for `getByUrl` |
+| `getAllByUrl(source, url)` | `List<Extension>` | All matches at any depth |
+| `getValueAs<T>(source, url)` | `T?` | Typed value of first match; Kotlin reified |
+| `getValueAsOptional(source, url, Class<T>)` | `Optional<T>` | Java-friendly; pass `StringType::class.java` |
+| `getAllValuesAs<T>(source, url)` | `List<T>` | All typed values; Kotlin reified |
+| `getAllValuesAs(source, url, Class<T>)` | `List<T>` | Java-friendly overload |
+| `getNested(source, url, nestedUrl)` | `Extension?` | First nested sub-extension at any depth |
+| `getNestedOptional(source, url, nestedUrl)` | `Optional<Extension>` | Java-friendly alias for `getNested` |
+| `getAllNested(source, url, nestedUrl)` | `List<Extension>` | All nested sub-extensions at any depth |
+
+```kotlin
+import dev.ratkay.operation.FhirExtensionHelper
+
+val patient = Patient().apply {
+    // Extension lives on the nested HumanName element, not on Patient directly
+    addName().addExtension("http://example.com/nid", StringType("12345"))
+    // Complex nested extension (sub-extensions instead of a single value)
+    addExtension(Extension("http://example.com/address-info").apply {
+        addExtension("http://example.com/city",    StringType("Oslo"))
+        addExtension("http://example.com/country", StringType("NO"))
+    })
+}
+
+// Deep retrieval — finds extension on the nested HumanName
+val nid: StringType? = FhirExtensionHelper.getValueAs<StringType>(patient, "http://example.com/nid")
+// nid?.value == "12345"
+
+// Nested sub-extension
+val city: StringType? = FhirExtensionHelper.getValueAs<StringType>(
+    FhirExtensionHelper.getNested(patient, "http://example.com/address-info", "http://example.com/city")!!,
+    "http://example.com/city"
+)
+
+// Java-friendly Optional variants
+val nidOpt: Optional<StringType> =
+    FhirExtensionHelper.getValueAsOptional(patient, "http://example.com/nid", StringType::class.java)
+
+val cityExt: Optional<Extension> =
+    FhirExtensionHelper.getNestedOptional(patient, "http://example.com/address-info", "http://example.com/city")
+```
+
 #### Nested parameters (parts)
 
 `addPart` builds nested FHIR `Parameters.part` structures using a sub-pipeline builder lambda, without relying on dot-delimited key names in the parameter map.
@@ -925,14 +980,16 @@ fhirmason-core/
     │   ├── ReferenceLinkRule.kt            # Explicit reference linking rule descriptor
     │   ├── StepMetrics.kt                  # Per-step timing and outcome data
     │   ├── ErrorStrategy.kt                # FAIL_FAST / ACCUMULATE enum
-    │   └── OperationOutcomeExtensions.kt   # Exception → OperationOutcome helper
+    │   ├── OperationOutcomeExtensions.kt   # Exception → OperationOutcome helper
+    │   └── FhirExtensionHelper.kt          # Deep extension retrieval utility
     └── test/java/dev/ratkay/operation/
         ├── OperationResultTest.kt
         ├── OperationResultFromTest.kt
         ├── OperationResultLinkReferencesTest.kt
         ├── OperationResultMetricsTest.kt
         ├── AsyncOperationResultTest.kt
-        └── AsyncOperationResultMetricsTest.kt
+        ├── AsyncOperationResultMetricsTest.kt
+        └── FhirExtensionHelperTest.kt
 
 fhirmason-spring/
 └── src/

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/FhirExtensionHelper.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/FhirExtensionHelper.kt
@@ -1,0 +1,206 @@
+package dev.ratkay.operation
+
+import org.hl7.fhir.instance.model.api.IBaseHasExtensions
+import org.hl7.fhir.r4.model.Base
+import org.hl7.fhir.r4.model.Extension
+import org.hl7.fhir.r4.model.Type
+import java.util.Optional
+
+/**
+ * Utility object for retrieving FHIR extensions from any object that can carry them.
+ *
+ * In HAPI FHIR R4, objects that implement [IBaseHasExtensions] include:
+ * - All primitive types (`StringType`, `BooleanType`, `DateType`, …) — extend `Element`
+ * - All complex datatypes (`Coding`, `Reference`, `Identifier`, `Period`, …) — extend `Element`
+ * - All FHIR resources (`Patient`, `Observation`, …) — `DomainResource` implements `IBaseHasExtensions`
+ * - `Extension` itself — carries nested sub-extensions via its own `.extension` list
+ *
+ * ### Deep traversal
+ * Every method searches **at every level** of the FHIR object graph, not just the top-level
+ * `.extension` list of the source. The internal [collectDeepByUrl] helper recurses through all
+ * FHIR children via [Base.children], mirroring the same traversal used by
+ * [OperationResult.linkReferences].
+ *
+ * ### Java interop
+ * Methods that return a nullable Kotlin type (`T?`) have a parallel `*Optional` variant that
+ * returns [Optional] instead. Reified generic methods (`getValueAs`, `getAllValuesAs`) have
+ * `Class<T>`-parameter overloads that are callable from Java without the inline/reified machinery.
+ *
+ * ### Usage
+ * ```kotlin
+ * val patient = Patient().apply {
+ *     addName().apply { addExtension("http://example.com/nid", StringType("12345")) }
+ * }
+ * // Deep: finds the extension on the nested HumanName element
+ * val nid: StringType? = FhirExtensionHelper.getValueAs<StringType>(patient, "http://example.com/nid")
+ *
+ * // Java-friendly Optional variant
+ * val nidOpt: Optional<StringType> =
+ *     FhirExtensionHelper.getValueAsOptional(patient, "http://example.com/nid", StringType::class.java)
+ * ```
+ */
+object FhirExtensionHelper {
+
+    // ── Presence check ────────────────────────────────────────────────────
+
+    /**
+     * Returns `true` if [source] or any of its FHIR descendants has at least one extension
+     * whose URL equals [url].
+     */
+    fun hasExtension(source: IBaseHasExtensions, url: String): Boolean =
+        getAllByUrl(source, url).isNotEmpty()
+
+    // ── Single retrieval ──────────────────────────────────────────────────
+
+    /**
+     * Returns the first [Extension] matching [url] found at any depth in [source],
+     * or `null` if none is present.
+     */
+    fun getByUrl(source: IBaseHasExtensions, url: String): Extension? =
+        getAllByUrl(source, url).firstOrNull()
+
+    /**
+     * Returns the first [Extension] matching [url] found at any depth in [source],
+     * wrapped in an [Optional]. Returns [Optional.empty] if none is present.
+     *
+     * Java callers may prefer this over [getByUrl].
+     */
+    fun getByUrlOptional(source: IBaseHasExtensions, url: String): Optional<Extension> =
+        Optional.ofNullable(getByUrl(source, url))
+
+    // ── All retrieval ─────────────────────────────────────────────────────
+
+    /**
+     * Returns all [Extension]s matching [url] found at any depth in [source].
+     * Returns an empty list if none are present.
+     */
+    fun getAllByUrl(source: IBaseHasExtensions, url: String): List<Extension> {
+        val results = mutableListOf<Extension>()
+        collectDeepByUrl(source as Base, url, results, mutableSetOf())
+        return results
+    }
+
+    // ── Typed value extraction ────────────────────────────────────────────
+
+    /**
+     * Returns the value of the first [Extension] matching [url] at any depth, cast to [T],
+     * or `null` if:
+     * - no extension with that URL exists, or
+     * - the extension has no value, or
+     * - the value is not an instance of [T].
+     *
+     * [T] must be a concrete FHIR R4 [Type] (`StringType`, `BooleanType`, `Coding`, …).
+     */
+    inline fun <reified T : Type> getValueAs(source: IBaseHasExtensions, url: String): T? =
+        getByUrl(source, url)?.value as? T
+
+    /**
+     * Returns the value of the first [Extension] matching [url] at any depth, cast to [type],
+     * wrapped in an [Optional]. Returns [Optional.empty] if absent or the wrong type.
+     *
+     * Java-friendly alternative to [getValueAs] — pass `StringType::class.java` instead of a
+     * reified type parameter.
+     */
+    fun <T : Type> getValueAsOptional(
+        source: IBaseHasExtensions,
+        url: String,
+        type: Class<T>
+    ): Optional<T> {
+        val value = getByUrl(source, url)?.value ?: return Optional.empty()
+        return Optional.ofNullable(if (type.isInstance(value)) type.cast(value) else null)
+    }
+
+    /**
+     * Returns the values of all [Extension]s matching [url] at any depth that are instances of [T].
+     * Extensions that exist but carry a different value type (or no value) are silently skipped.
+     */
+    inline fun <reified T : Type> getAllValuesAs(source: IBaseHasExtensions, url: String): List<T> =
+        getAllByUrl(source, url).mapNotNull { it.value as? T }
+
+    /**
+     * Java-friendly overload of [getAllValuesAs]: pass [type] as `StringType::class.java` instead
+     * of a reified type parameter.
+     *
+     * The extra [type] parameter makes this overload unambiguous from the reified variant after
+     * JVM type erasure — no `@JvmName` workaround is needed.
+     */
+    fun <T : Type> getAllValuesAs(
+        source: IBaseHasExtensions,
+        url: String,
+        type: Class<T>
+    ): List<T> = getAllByUrl(source, url).mapNotNull { ext ->
+        val v = ext.value ?: return@mapNotNull null
+        if (type.isInstance(v)) type.cast(v) else null
+    }
+
+    // ── Nested extension retrieval ────────────────────────────────────────
+
+    /**
+     * Returns the first *nested* extension found at any depth: locates the first [Extension]
+     * matching [url] in [source], then returns the first sub-extension inside it whose URL
+     * equals [nestedUrl].
+     *
+     * Returns `null` if the parent extension or the nested extension is absent.
+     *
+     * In FHIR, an [Extension] can itself carry child extensions in its own `.extension` list,
+     * used when a complex structure is needed instead of a single `value[x]`.
+     */
+    fun getNested(source: IBaseHasExtensions, url: String, nestedUrl: String): Extension? =
+        getByUrl(source, url)?.let { parent -> getByUrl(parent, nestedUrl) }
+
+    /**
+     * Returns the first nested extension (matching [url] → [nestedUrl]) at any depth,
+     * wrapped in an [Optional]. Returns [Optional.empty] if absent.
+     *
+     * Java-friendly alternative to [getNested].
+     */
+    fun getNestedOptional(
+        source: IBaseHasExtensions,
+        url: String,
+        nestedUrl: String
+    ): Optional<Extension> = Optional.ofNullable(getNested(source, url, nestedUrl))
+
+    /**
+     * Returns all nested extensions inside the first [Extension] matching [url] at any depth
+     * whose URL equals [nestedUrl]. Returns an empty list if the parent is absent.
+     */
+    fun getAllNested(source: IBaseHasExtensions, url: String, nestedUrl: String): List<Extension> {
+        val parent = getByUrl(source, url) ?: return emptyList()
+        return getAllByUrl(parent, nestedUrl)
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────
+
+    /**
+     * Recursively collects all [Extension]s matching [url] anywhere in the FHIR object graph
+     * rooted at [node].
+     *
+     * Algorithm:
+     * 1. Guard against object-graph cycles with an identity-based [visited] set.
+     * 2. If [node] implements [IBaseHasExtensions], inspect its direct `.extension` list and
+     *    add any whose URL equals [url].
+     * 3. Recurse into all FHIR children exposed by [Base.children], which covers element
+     *    properties, nested resources, and the extension list itself (allowing sub-extensions
+     *    of a matched parent to also be visited).
+     */
+    private fun collectDeepByUrl(
+        node: Base,
+        url: String,
+        results: MutableList<Extension>,
+        visited: MutableSet<Int>
+    ) {
+        if (!visited.add(System.identityHashCode(node))) return
+
+        if (node is IBaseHasExtensions) {
+            node.extension.filterIsInstance<Extension>()
+                .filter { it.url == url }
+                .forEach { results.add(it) }
+        }
+
+        for (property in node.children()) {
+            for (child in property.values) {
+                collectDeepByUrl(child, url, results, visited)
+            }
+        }
+    }
+}

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/FhirExtensionHelperTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/FhirExtensionHelperTest.kt
@@ -1,0 +1,379 @@
+package dev.ratkay.operation
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.empty
+import org.hamcrest.Matchers.hasSize
+import org.hl7.fhir.r4.model.BooleanType
+import org.hl7.fhir.r4.model.CodeableConcept
+import org.hl7.fhir.r4.model.Coding
+import org.hl7.fhir.r4.model.Extension
+import org.hl7.fhir.r4.model.HumanName
+import org.hl7.fhir.r4.model.IntegerType
+import org.hl7.fhir.r4.model.Patient
+import org.hl7.fhir.r4.model.StringType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.Optional
+
+class FhirExtensionHelperTest {
+
+    private val URL_A = "http://example.com/ext-a"
+    private val URL_B = "http://example.com/ext-b"
+    private val URL_NESTED = "http://example.com/nested"
+
+    // ── hasExtension ──────────────────────────────────────────────────────
+
+    @Test
+    fun `hasExtension returns true when URL present at root`() {
+        val patient = Patient().apply { addExtension(URL_A, StringType("v")) }
+        assertTrue(FhirExtensionHelper.hasExtension(patient, URL_A))
+    }
+
+    @Test
+    fun `hasExtension returns false when URL absent`() {
+        val patient = Patient().apply { addExtension(URL_B, StringType("v")) }
+        assertFalse(FhirExtensionHelper.hasExtension(patient, URL_A))
+    }
+
+    @Test
+    fun `hasExtension returns false when source has no extensions`() {
+        assertFalse(FhirExtensionHelper.hasExtension(Patient(), URL_A))
+    }
+
+    @Test
+    fun `hasExtension returns true when URL present on nested child element`() {
+        val patient = Patient().apply {
+            addName().addExtension(URL_A, StringType("nameExt"))
+        }
+        assertTrue(FhirExtensionHelper.hasExtension(patient, URL_A))
+    }
+
+    // ── getByUrl ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `getByUrl returns extension when present at root`() {
+        val patient = Patient().apply { addExtension(URL_A, StringType("hello")) }
+        val ext = FhirExtensionHelper.getByUrl(patient, URL_A)
+        assertEquals(URL_A, ext?.url)
+        assertEquals("hello", (ext?.value as? StringType)?.value)
+    }
+
+    @Test
+    fun `getByUrl returns null when URL absent`() {
+        val patient = Patient().apply { addExtension(URL_B, StringType("v")) }
+        assertNull(FhirExtensionHelper.getByUrl(patient, URL_A))
+    }
+
+    @Test
+    fun `getByUrl returns first extension when multiple with same URL`() {
+        val patient = Patient().apply {
+            addExtension(URL_A, StringType("first"))
+            addExtension(URL_A, StringType("second"))
+        }
+        assertEquals("first", (FhirExtensionHelper.getByUrl(patient, URL_A)?.value as? StringType)?.value)
+    }
+
+    @Test
+    fun `getByUrl finds extension on nested child element`() {
+        val patient = Patient().apply {
+            addName().addExtension(URL_A, StringType("nameExt"))
+        }
+        val ext = FhirExtensionHelper.getByUrl(patient, URL_A)
+        assertEquals(URL_A, ext?.url)
+    }
+
+    // ── getAllByUrl ───────────────────────────────────────────────────────
+
+    @Test
+    fun `getAllByUrl returns all root-level matches`() {
+        val patient = Patient().apply {
+            addExtension(URL_A, StringType("v1"))
+            addExtension(URL_A, StringType("v2"))
+            addExtension(URL_B, StringType("other"))
+        }
+        val results = FhirExtensionHelper.getAllByUrl(patient, URL_A)
+        assertThat(results, hasSize(2))
+        assertEquals("v1", (results[0].value as StringType).value)
+        assertEquals("v2", (results[1].value as StringType).value)
+    }
+
+    @Test
+    fun `getAllByUrl returns empty list when URL absent`() {
+        val patient = Patient().apply { addExtension(URL_B, StringType("v")) }
+        assertThat(FhirExtensionHelper.getAllByUrl(patient, URL_A), empty())
+    }
+
+    @Test
+    fun `getAllByUrl finds matches at multiple depths`() {
+        val patient = Patient().apply {
+            addExtension(URL_A, StringType("root"))
+            addName().addExtension(URL_A, StringType("name"))
+        }
+        val results = FhirExtensionHelper.getAllByUrl(patient, URL_A)
+        assertThat(results, hasSize(2))
+    }
+
+    // ── getByUrlOptional ──────────────────────────────────────────────────
+
+    @Test
+    fun `getByUrlOptional returns non-empty Optional when present`() {
+        val patient = Patient().apply { addExtension(URL_A, StringType("v")) }
+        val opt = FhirExtensionHelper.getByUrlOptional(patient, URL_A)
+        assertTrue(opt.isPresent)
+        assertEquals(URL_A, opt.get().url)
+    }
+
+    @Test
+    fun `getByUrlOptional returns empty Optional when absent`() {
+        assertEquals(Optional.empty<Extension>(), FhirExtensionHelper.getByUrlOptional(Patient(), URL_A))
+    }
+
+    // ── getValueAs (reified) ──────────────────────────────────────────────
+
+    @Test
+    fun `getValueAs returns correctly typed value`() {
+        val patient = Patient().apply { addExtension(URL_A, StringType("hello")) }
+        val value = FhirExtensionHelper.getValueAs<StringType>(patient, URL_A)
+        assertEquals("hello", value?.value)
+    }
+
+    @Test
+    fun `getValueAs returns null when extension absent`() {
+        assertNull(FhirExtensionHelper.getValueAs<StringType>(Patient(), URL_A))
+    }
+
+    @Test
+    fun `getValueAs returns null when value is wrong type`() {
+        val patient = Patient().apply { addExtension(URL_A, BooleanType(true)) }
+        assertNull(FhirExtensionHelper.getValueAs<StringType>(patient, URL_A))
+    }
+
+    @Test
+    fun `getValueAs returns null when extension has no value`() {
+        val ext = Extension(URL_A)
+        val patient = Patient().apply { addExtension(ext) }
+        assertNull(FhirExtensionHelper.getValueAs<StringType>(patient, URL_A))
+    }
+
+    // ── getValueAsOptional ────────────────────────────────────────────────
+
+    @Test
+    fun `getValueAsOptional returns non-empty Optional with correct value`() {
+        val patient = Patient().apply { addExtension(URL_A, StringType("hello")) }
+        val opt = FhirExtensionHelper.getValueAsOptional(patient, URL_A, StringType::class.java)
+        assertTrue(opt.isPresent)
+        assertEquals("hello", opt.get().value)
+    }
+
+    @Test
+    fun `getValueAsOptional returns empty Optional when absent`() {
+        val opt = FhirExtensionHelper.getValueAsOptional(Patient(), URL_A, StringType::class.java)
+        assertFalse(opt.isPresent)
+    }
+
+    @Test
+    fun `getValueAsOptional returns empty Optional when value is wrong type`() {
+        val patient = Patient().apply { addExtension(URL_A, BooleanType(true)) }
+        val opt = FhirExtensionHelper.getValueAsOptional(patient, URL_A, StringType::class.java)
+        assertFalse(opt.isPresent)
+    }
+
+    // ── getAllValuesAs (reified) ───────────────────────────────────────────
+
+    @Test
+    fun `getAllValuesAs reified returns all typed values`() {
+        val patient = Patient().apply {
+            addExtension(URL_A, StringType("a"))
+            addExtension(URL_A, StringType("b"))
+        }
+        val values = FhirExtensionHelper.getAllValuesAs<StringType>(patient, URL_A)
+        assertThat(values, hasSize(2))
+        assertEquals("a", values[0].value)
+        assertEquals("b", values[1].value)
+    }
+
+    @Test
+    fun `getAllValuesAs reified skips wrong-typed entries`() {
+        val patient = Patient().apply {
+            addExtension(URL_A, StringType("ok"))
+            addExtension(URL_A, BooleanType(true))
+        }
+        val values = FhirExtensionHelper.getAllValuesAs<StringType>(patient, URL_A)
+        assertThat(values, hasSize(1))
+        assertEquals("ok", values[0].value)
+    }
+
+    @Test
+    fun `getAllValuesAs reified returns empty list when none match`() {
+        assertThat(FhirExtensionHelper.getAllValuesAs<StringType>(Patient(), URL_A), empty())
+    }
+
+    // ── getAllValuesAs (Class param) ───────────────────────────────────────
+
+    @Test
+    fun `getAllValuesAs Class param returns all typed values`() {
+        val patient = Patient().apply {
+            addExtension(URL_A, StringType("x"))
+            addExtension(URL_A, StringType("y"))
+        }
+        val values = FhirExtensionHelper.getAllValuesAs(patient, URL_A, StringType::class.java)
+        assertThat(values, hasSize(2))
+    }
+
+    @Test
+    fun `getAllValuesAs Class param skips wrong-typed entries`() {
+        val patient = Patient().apply {
+            addExtension(URL_A, StringType("ok"))
+            addExtension(URL_A, IntegerType(42))
+        }
+        val values = FhirExtensionHelper.getAllValuesAs(patient, URL_A, StringType::class.java)
+        assertThat(values, hasSize(1))
+        assertEquals("ok", values[0].value)
+    }
+
+    @Test
+    fun `getAllValuesAs Class param returns empty list when none match`() {
+        assertThat(FhirExtensionHelper.getAllValuesAs(Patient(), URL_A, StringType::class.java), empty())
+    }
+
+    // ── getNested ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `getNested returns nested sub-extension`() {
+        val patient = Patient().apply {
+            addExtension(Extension(URL_A).apply {
+                addExtension(URL_NESTED, StringType("nestedValue"))
+            })
+        }
+        val nested = FhirExtensionHelper.getNested(patient, URL_A, URL_NESTED)
+        assertEquals(URL_NESTED, nested?.url)
+        assertEquals("nestedValue", (nested?.value as? StringType)?.value)
+    }
+
+    @Test
+    fun `getNested returns null when parent extension absent`() {
+        assertNull(FhirExtensionHelper.getNested(Patient(), URL_A, URL_NESTED))
+    }
+
+    @Test
+    fun `getNested returns null when nested extension absent`() {
+        val patient = Patient().apply { addExtension(URL_A, StringType("v")) }
+        assertNull(FhirExtensionHelper.getNested(patient, URL_A, URL_NESTED))
+    }
+
+    // ── getNestedOptional ─────────────────────────────────────────────────
+
+    @Test
+    fun `getNestedOptional returns non-empty Optional when nested present`() {
+        val patient = Patient().apply {
+            addExtension(Extension(URL_A).apply {
+                addExtension(URL_NESTED, StringType("v"))
+            })
+        }
+        val opt = FhirExtensionHelper.getNestedOptional(patient, URL_A, URL_NESTED)
+        assertTrue(opt.isPresent)
+        assertEquals(URL_NESTED, opt.get().url)
+    }
+
+    @Test
+    fun `getNestedOptional returns empty Optional when absent`() {
+        assertFalse(FhirExtensionHelper.getNestedOptional(Patient(), URL_A, URL_NESTED).isPresent)
+    }
+
+    // ── getAllNested ──────────────────────────────────────────────────────
+
+    @Test
+    fun `getAllNested returns all nested sub-extensions`() {
+        val patient = Patient().apply {
+            addExtension(Extension(URL_A).apply {
+                addExtension(URL_NESTED, StringType("n1"))
+                addExtension(URL_NESTED, StringType("n2"))
+                addExtension(URL_B, StringType("other"))
+            })
+        }
+        val nested = FhirExtensionHelper.getAllNested(patient, URL_A, URL_NESTED)
+        assertThat(nested, hasSize(2))
+        assertEquals("n1", (nested[0].value as StringType).value)
+        assertEquals("n2", (nested[1].value as StringType).value)
+    }
+
+    @Test
+    fun `getAllNested returns empty list when parent extension absent`() {
+        assertThat(FhirExtensionHelper.getAllNested(Patient(), URL_A, URL_NESTED), empty())
+    }
+
+    // ── Deep traversal ────────────────────────────────────────────────────
+
+    @Test
+    fun `finds extension on HumanName child element of Patient`() {
+        val patient = Patient().apply {
+            addName().addExtension(URL_A, StringType("nameExt"))
+        }
+        val ext = FhirExtensionHelper.getByUrl(patient, URL_A)
+        assertEquals(URL_A, ext?.url)
+        assertEquals("nameExt", (ext?.value as? StringType)?.value)
+    }
+
+    @Test
+    fun `finds extension on Coding inside a CodeableConcept child`() {
+        val patient = Patient().apply {
+            maritalStatus = CodeableConcept().apply {
+                addCoding(Coding().apply {
+                    system = "http://example.com"
+                    code = "M"
+                    addExtension(URL_A, StringType("codingExt"))
+                })
+            }
+        }
+        val ext = FhirExtensionHelper.getByUrl(patient, URL_A)
+        assertEquals(URL_A, ext?.url)
+    }
+
+    @Test
+    fun `getAllByUrl collects extensions from multiple depths in the same traversal`() {
+        val patient = Patient().apply {
+            addExtension(URL_A, StringType("root"))
+            addName().addExtension(URL_A, StringType("name"))
+            maritalStatus = CodeableConcept().apply {
+                addExtension(URL_A, StringType("concept"))
+            }
+        }
+        assertThat(FhirExtensionHelper.getAllByUrl(patient, URL_A), hasSize(3))
+    }
+
+    // ── Source type coverage ──────────────────────────────────────────────
+
+    @Test
+    fun `works on DomainResource (Patient)`() {
+        val patient = Patient().apply { addExtension(URL_A, StringType("v")) }
+        assertTrue(FhirExtensionHelper.hasExtension(patient, URL_A))
+    }
+
+    @Test
+    fun `works on Element primitive type (StringType)`() {
+        val str = StringType("hello").apply { addExtension(URL_A, StringType("meta")) }
+        assertTrue(FhirExtensionHelper.hasExtension(str, URL_A))
+        assertEquals("meta", FhirExtensionHelper.getValueAs<StringType>(str, URL_A)?.value)
+    }
+
+    @Test
+    fun `works on complex type (Coding)`() {
+        val coding = Coding().apply {
+            system = "http://example.com"
+            addExtension(URL_A, StringType("v"))
+        }
+        assertTrue(FhirExtensionHelper.hasExtension(coding, URL_A))
+    }
+
+    @Test
+    fun `works on HumanName directly`() {
+        val name = HumanName().apply {
+            family = "Smith"
+            addExtension(URL_A, StringType("nameExt"))
+        }
+        assertEquals("nameExt", FhirExtensionHelper.getValueAs<StringType>(name, URL_A)?.value)
+    }
+}


### PR DESCRIPTION
Introduces FhirExtensionHelper, a stateless Kotlin object that reads FHIR
extensions from any IBaseHasExtensions source (resources, primitive types,
complex datatypes) by recursively traversing the full FHIR object graph via
Base.children(), so extensions at any nesting depth are found automatically.

API (11 methods):
- hasExtension / getByUrl / getAllByUrl — presence and retrieval
- getValueAs<T> / getAllValuesAs<T> — typed Kotlin reified variants
- getValueAsOptional / getAllValuesAs(Class<T>) — Java-friendly overloads
- getNested / getNestedOptional / getAllNested — nested sub-extension access
- getByUrlOptional — Java Optional alias for getByUrl

Adds FhirExtensionHelperTest (40 tests) covering all methods, all source
types (DomainResource, Element, complex type), deep traversal, Optional
variants, and wrong-type/absent edge cases. Updates README and Project
Structure.