### PR TITLE
Add addFromFiltered / addAllFromFiltered — type+extension-URL pipeline filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,39 @@ val result = OperationResult.of(listOf(patient, appointment), "inputs")
     }
 ```
 
+#### From all parameters, filtered by type and extension URLs
+
+These methods search **all** accumulated parameters (regardless of key), keep only resources of the given type, and — if extension URLs are supplied — further keep only those that carry **all** of the specified URLs (AND semantics). The filtered list is then passed to the builder.
+
+| Method | Description |
+|---|---|
+| `addFromFiltered(type, extUrls...) { list -> R }` | Filters all params by type + extensions; builder returns a single `R` stored under the type's simple name |
+| `addFromFiltered(name, type, extUrls...) { list -> R }` | Same but stores the result under an explicit `name` |
+| `addAllFromFiltered(type, extUrls...) { list -> List<R> }` | Builder returns a list; otherwise identical to the unnamed `addFromFiltered` variant |
+| `addAllFromFiltered(name, type, extUrls...) { list -> List<R> }` | Named variant of `addAllFromFiltered` |
+
+The unnamed variants have reified inline overloads so the `KClass` argument can be omitted in Kotlin. Named variants intentionally have no reified overload — a reified `addFromFiltered(name, extUrls…)` would be ambiguous with the unnamed reified overload when the first argument is a `String`. Pass `KClass` explicitly when an output key is required.
+
+```kotlin
+// Collect all Patients that carry the enrollment extension, then build an outcome
+val result = OperationResult.of(listOf(enrolledPatient, unenrolledPatient, appointment), "inputs")
+    .addFromFiltered(Patient::class, "http://example.org/enrolled") { enrolled ->
+        OperationOutcome().apply { addIssue().diagnostics = "Enrolled: ${enrolled.size}" }
+    }
+
+// Reified — no KClass needed
+val result2 = OperationResult.of(patients, "patients")
+    .addFromFiltered<Patient, OperationOutcome>("http://example.org/enrolled") { enrolled ->
+        buildSummary(enrolled)
+    }
+
+// Named output key, multiple extension URLs (AND logic)
+val result3 = OperationResult.of(patients, "patients")
+    .addFromFiltered("enrolled-summary", Patient::class, "http://ext/url1", "http://ext/url2") { filtered ->
+        buildSummary(filtered)
+    }
+```
+
 #### Error-resilient variants
 
 | Method | On exception | Returns |

--- a/README.md
+++ b/README.md
@@ -124,33 +124,45 @@ val result = OperationResult.of(listOf(patient, appointment), "inputs")
 
 #### From all parameters, filtered by type and extension URLs
 
-These methods search **all** accumulated parameters (regardless of key), keep only resources of the given type, and — if extension URLs are supplied — further keep only those that carry **all** of the specified URLs (AND semantics). The filtered list is then passed to the builder.
+These methods search **all** accumulated parameters (regardless of key), keep only resources of the given type, and — if extension URLs are supplied — further filter by extension-URL presence. Two matching strategies are available, encoded directly in the method name:
 
-| Method | Description |
-|---|---|
-| `addFromFiltered(type, extUrls...) { list -> R }` | Filters all params by type + extensions; builder returns a single `R` stored under the type's simple name |
-| `addFromFiltered(name, type, extUrls...) { list -> R }` | Same but stores the result under an explicit `name` |
-| `addAllFromFiltered(type, extUrls...) { list -> List<R> }` | Builder returns a list; otherwise identical to the unnamed `addFromFiltered` variant |
-| `addAllFromFiltered(name, type, extUrls...) { list -> List<R> }` | Named variant of `addAllFromFiltered` |
+| Method | Semantics | Description |
+|---|---|---|
+| `addFromHavingAllExtensions(type, extUrls...) { list -> R }` | AND | Resource must carry **every** supplied URL; builder returns a single `R` stored under the type's simple name |
+| `addFromHavingAllExtensions(name, type, extUrls...) { list -> R }` | AND | Same, explicit output `name` |
+| `addFromHavingAnyExtension(type, extUrls...) { list -> R }` | OR | Resource must carry **at least one** of the URLs; single `R` result |
+| `addFromHavingAnyExtension(name, type, extUrls...) { list -> R }` | OR | Same, explicit output `name` |
+| `addAllFromHavingAllExtensions(type, extUrls...) { list -> List<R> }` | AND | Builder returns a list |
+| `addAllFromHavingAllExtensions(name, type, extUrls...) { list -> List<R> }` | AND | Named list variant |
+| `addAllFromHavingAnyExtension(type, extUrls...) { list -> List<R> }` | OR | Builder returns a list |
+| `addAllFromHavingAnyExtension(name, type, extUrls...) { list -> List<R> }` | OR | Named list variant |
 
-The unnamed variants have reified inline overloads so the `KClass` argument can be omitted in Kotlin. Named variants intentionally have no reified overload — a reified `addFromFiltered(name, extUrls…)` would be ambiguous with the unnamed reified overload when the first argument is a `String`. Pass `KClass` explicitly when an output key is required.
+When no URLs are supplied, all resources of the given type are passed to the builder regardless of which variant is used.
+
+All unnamed variants have reified inline overloads so the `KClass` argument can be omitted in Kotlin. Named variants intentionally have no reified overload — a reified `addFromHavingAllExtensions(name, extUrls…)` would be ambiguous with the unnamed reified overload when the first argument is a `String`. Use the KClass overload when an explicit output key is needed.
 
 ```kotlin
-// Collect all Patients that carry the enrollment extension, then build an outcome
-val result = OperationResult.of(listOf(enrolledPatient, unenrolledPatient, appointment), "inputs")
-    .addFromFiltered(Patient::class, "http://example.org/enrolled") { enrolled ->
-        OperationOutcome().apply { addIssue().diagnostics = "Enrolled: ${enrolled.size}" }
+// AND — Patients that carry both extensions
+val result = OperationResult.of(patients, "patients")
+    .addFromHavingAllExtensions(Patient::class, "http://ext/enrolled", "http://ext/consented") { filtered ->
+        OperationOutcome().apply { addIssue().diagnostics = "Eligible: ${filtered.size}" }
+    }
+
+// OR — Patients that carry at least one of the extensions
+val result2 = OperationResult.of(patients, "patients")
+    .addFromHavingAnyExtension(Patient::class, "http://ext/high-priority", "http://ext/urgent") { filtered ->
+        buildAlertFor(filtered)
     }
 
 // Reified — no KClass needed
-val result2 = OperationResult.of(patients, "patients")
-    .addFromFiltered<Patient, OperationOutcome>("http://example.org/enrolled") { enrolled ->
-        buildSummary(enrolled)
+val result3 = OperationResult.of(patients, "patients")
+    .addFromHavingAllExtensions<Patient, OperationOutcome>("http://ext/enrolled") { filtered ->
+        buildSummary(filtered)
     }
 
-// Named output key, multiple extension URLs (AND logic)
-val result3 = OperationResult.of(patients, "patients")
-    .addFromFiltered("enrolled-summary", Patient::class, "http://ext/url1", "http://ext/url2") { filtered ->
+// Named output key
+val result4 = OperationResult.of(patients, "patients")
+    .addFromHavingAllExtensions("enrolled-summary", Patient::class, "http://ext/enrolled") { filtered ->
         buildSummary(filtered)
     }
 ```

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -206,21 +206,182 @@ class OperationResult<T> private constructor(
         return copyWith(values)
     }
 
-    // Extension-filtered collection helper
+    // Builder methods — filter all accumulated parameters by type and extension URLs
 
     /**
      * Collects all values across every accumulated parameter, keeps only instances of [type],
-     * and — if [extUrls] is non-empty — further keeps only those that implement
-     * [IBaseHasExtensions] and carry **all** of the supplied extension URLs (AND logic).
+     * and — if [extUrls] is non-empty — further filters by extension-URL presence.
+     *
+     * When [matchAll] is `true` (AND): a resource must carry **every** supplied URL.
+     * When [matchAll] is `false` (OR): a resource must carry **at least one** of the URLs.
+     * When [extUrls] is empty, all instances of [type] are returned regardless of [matchAll].
      */
-    private fun <I : Base> collectFiltered(type: KClass<I>, extUrls: Array<out String>): List<I> {
+    private fun <I : Base> collectByExtension(
+        type: KClass<I>,
+        extUrls: Array<out String>,
+        matchAll: Boolean
+    ): List<I> {
         val allOfType = parameters.values.flatten().filterIsInstance(type.java)
         return if (extUrls.isEmpty()) allOfType
         else allOfType.filter { resource ->
-            resource is IBaseHasExtensions &&
+            resource is IBaseHasExtensions && if (matchAll) {
                 extUrls.all { url -> FhirExtensionHelper.hasExtension(resource, url) }
+            } else {
+                extUrls.any { url -> FhirExtensionHelper.hasExtension(resource, url) }
+            }
         }
     }
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that carry **every** one of
+     * the supplied [extUrls] (AND semantics), passes the typed list to [builder], and stores the
+     * single result under [type]'s simple name (lowercase).
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addFromHavingAnyExtension] when OR semantics are needed instead.
+     */
+    fun <I : Base, R : Base> addFromHavingAllExtensions(
+        type: KClass<I>,
+        vararg extUrls: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> {
+        val stepName = type.java.simpleName.lowercase()
+        return runBuilderStep(stepName) { start ->
+            storeAndCopy(stepName, builder(collectByExtension(type, extUrls, matchAll = true)), start)
+        }
+    }
+
+    /**
+     * Like [addFromHavingAllExtensions] but stores the result under the explicit [name].
+     * Placing [name] before the [extUrls] vararg keeps the Java call-site clean.
+     */
+    fun <I : Base, R : Base> addFromHavingAllExtensions(
+        name: String,
+        type: KClass<I>,
+        vararg extUrls: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) { start ->
+            storeAndCopy(name, builder(collectByExtension(type, extUrls, matchAll = true)), start)
+        }
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that carry **at least one**
+     * of the supplied [extUrls] (OR semantics), passes the typed list to [builder], and stores the
+     * single result under [type]'s simple name (lowercase).
+     *
+     * Use [addFromHavingAllExtensions] when AND semantics are needed instead.
+     */
+    fun <I : Base, R : Base> addFromHavingAnyExtension(
+        type: KClass<I>,
+        vararg extUrls: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> {
+        val stepName = type.java.simpleName.lowercase()
+        return runBuilderStep(stepName) { start ->
+            storeAndCopy(stepName, builder(collectByExtension(type, extUrls, matchAll = false)), start)
+        }
+    }
+
+    /**
+     * Like [addFromHavingAnyExtension] but stores the result under the explicit [name].
+     */
+    fun <I : Base, R : Base> addFromHavingAnyExtension(
+        name: String,
+        type: KClass<I>,
+        vararg extUrls: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) { start ->
+            storeAndCopy(name, builder(collectByExtension(type, extUrls, matchAll = false)), start)
+        }
+
+    /**
+     * Like [addFromHavingAllExtensions] but [builder] returns a `List<R>`.
+     * The output name defaults to [type]'s simple name (lowercase).
+     */
+    fun <I : Base, R : Base> addAllFromHavingAllExtensions(
+        type: KClass<I>,
+        vararg extUrls: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> {
+        val stepName = type.java.simpleName.lowercase()
+        return runBuilderStep(stepName) { start ->
+            storeListAndCopy(stepName, builder(collectByExtension(type, extUrls, matchAll = true)), start)
+        }
+    }
+
+    /** Like [addAllFromHavingAllExtensions] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingAllExtensions(
+        name: String,
+        type: KClass<I>,
+        vararg extUrls: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) { start ->
+            storeListAndCopy(name, builder(collectByExtension(type, extUrls, matchAll = true)), start)
+        }
+
+    /**
+     * Like [addFromHavingAnyExtension] but [builder] returns a `List<R>`.
+     * The output name defaults to [type]'s simple name (lowercase).
+     */
+    fun <I : Base, R : Base> addAllFromHavingAnyExtension(
+        type: KClass<I>,
+        vararg extUrls: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> {
+        val stepName = type.java.simpleName.lowercase()
+        return runBuilderStep(stepName) { start ->
+            storeListAndCopy(stepName, builder(collectByExtension(type, extUrls, matchAll = false)), start)
+        }
+    }
+
+    /** Like [addAllFromHavingAnyExtension] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingAnyExtension(
+        name: String,
+        type: KClass<I>,
+        vararg extUrls: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) { start ->
+            storeListAndCopy(name, builder(collectByExtension(type, extUrls, matchAll = false)), start)
+        }
+
+    /**
+     * Reified overload of [addFromHavingAllExtensions] (unnamed output key).
+     *
+     * **Named variants are intentionally not reified** — a reified `addFromHavingAllExtensions(name,
+     * extUrls…, builder)` would be ambiguous with this overload when the first argument is a
+     * `String` (Kotlin cannot determine whether it is `name` or the first vararg element).
+     * Use the KClass overload when an explicit output key is required:
+     * `addFromHavingAllExtensions("my-key", Patient::class, "http://ext/url") { … }`.
+     */
+    inline fun <reified I : Base, R : Base> addFromHavingAllExtensions(
+        vararg extUrls: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingAllExtensions(I::class, *extUrls, builder = builder)
+
+    /** Reified overload of [addFromHavingAnyExtension] (unnamed output key). See
+     *  [addFromHavingAllExtensions] for why a named reified variant is not provided. */
+    inline fun <reified I : Base, R : Base> addFromHavingAnyExtension(
+        vararg extUrls: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingAnyExtension(I::class, *extUrls, builder = builder)
+
+    /** Reified overload of [addAllFromHavingAllExtensions] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingAllExtensions(
+        vararg extUrls: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingAllExtensions(I::class, *extUrls, builder = builder)
+
+    /** Reified overload of [addAllFromHavingAnyExtension] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingAnyExtension(
+        vararg extUrls: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingAnyExtension(I::class, *extUrls, builder = builder)
 
     // Builder methods - single item
 
@@ -253,90 +414,6 @@ class OperationResult<T> private constructor(
             val filtered = parameters[name]?.filterIsInstance(type.java) ?: emptyList()
             storeListAndCopy(name, builder(filtered), start)
         }
-
-    // Builder methods - from all parameters, filtered by type and extension URLs
-
-    /**
-     * Searches **all** accumulated parameters for instances of [type], optionally filtered
-     * by one or more extension URLs (AND logic), passes the filtered list to [builder],
-     * and stores the single result under [type]'s simple name (lowercase).
-     *
-     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
-     * and skip the head value.
-     */
-    fun <I : Base, R : Base> addFromFiltered(
-        type: KClass<I>,
-        vararg extUrls: String,
-        builder: (List<I>) -> R
-    ): OperationResult<R> {
-        val stepName = type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) { start ->
-            storeAndCopy(stepName, builder(collectFiltered(type, extUrls)), start)
-        }
-    }
-
-    /**
-     * Like [addFromFiltered] but stores the result under the explicit [name].
-     * Placing [name] before the [extUrls] vararg keeps the Java call-site clean.
-     */
-    fun <I : Base, R : Base> addFromFiltered(
-        name: String,
-        type: KClass<I>,
-        vararg extUrls: String,
-        builder: (List<I>) -> R
-    ): OperationResult<R> =
-        runBuilderStep(name) { start ->
-            storeAndCopy(name, builder(collectFiltered(type, extUrls)), start)
-        }
-
-    /**
-     * Like [addFromFiltered] but [builder] returns a `List<R>` which is stored as a
-     * parameter list. The output name defaults to [type]'s simple name (lowercase).
-     */
-    fun <I : Base, R : Base> addAllFromFiltered(
-        type: KClass<I>,
-        vararg extUrls: String,
-        builder: (List<I>) -> List<R>
-    ): OperationResult<List<R>> {
-        val stepName = type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) { start ->
-            storeListAndCopy(stepName, builder(collectFiltered(type, extUrls)), start)
-        }
-    }
-
-    /**
-     * Like [addAllFromFiltered] but stores the result list under the explicit [name].
-     */
-    fun <I : Base, R : Base> addAllFromFiltered(
-        name: String,
-        type: KClass<I>,
-        vararg extUrls: String,
-        builder: (List<I>) -> List<R>
-    ): OperationResult<List<R>> =
-        runBuilderStep(name) { start ->
-            storeListAndCopy(name, builder(collectFiltered(type, extUrls)), start)
-        }
-
-    /**
-     * Reified overload of [addFromFiltered] (unnamed output key).
-     *
-     * **Named variants are intentionally not reified** — a reified `addFromFiltered(name, extUrls…,
-     * builder)` would be ambiguous with this overload whenever the caller passes a single `String`
-     * as the first argument (Kotlin cannot determine whether it is `name` or the first vararg
-     * element). Use the KClass overload when an explicit output key is required:
-     * `addFromFiltered("my-key", Patient::class, "http://ext/url") { … }`.
-     */
-    inline fun <reified I : Base, R : Base> addFromFiltered(
-        vararg extUrls: String,
-        noinline builder: (List<I>) -> R
-    ): OperationResult<R> = addFromFiltered(I::class, *extUrls, builder = builder)
-
-    /** Reified overload of [addAllFromFiltered] (unnamed output key). See [addFromFiltered] for
-     *  why a named reified variant is not provided. */
-    inline fun <reified I : Base, R : Base> addAllFromFiltered(
-        vararg extUrls: String,
-        noinline builder: (List<I>) -> List<R>
-    ): OperationResult<List<R>> = addAllFromFiltered(I::class, *extUrls, builder = builder)
 
     // Builder variants with explicit error handling
 

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -2,6 +2,7 @@ package dev.ratkay.operation
 
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException
+import org.hl7.fhir.instance.model.api.IBaseHasExtensions
 import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.BooleanType
 import org.hl7.fhir.r4.model.Extension
@@ -205,6 +206,22 @@ class OperationResult<T> private constructor(
         return copyWith(values)
     }
 
+    // Extension-filtered collection helper
+
+    /**
+     * Collects all values across every accumulated parameter, keeps only instances of [type],
+     * and — if [extUrls] is non-empty — further keeps only those that implement
+     * [IBaseHasExtensions] and carry **all** of the supplied extension URLs (AND logic).
+     */
+    private fun <I : Base> collectFiltered(type: KClass<I>, extUrls: Array<out String>): List<I> {
+        val allOfType = parameters.values.flatten().filterIsInstance(type.java)
+        return if (extUrls.isEmpty()) allOfType
+        else allOfType.filter { resource ->
+            resource is IBaseHasExtensions &&
+                extUrls.all { url -> FhirExtensionHelper.hasExtension(resource, url) }
+        }
+    }
+
     // Builder methods - single item
 
     fun <R : Base> add(name: String? = null, builder: () -> R): OperationResult<R> =
@@ -236,6 +253,90 @@ class OperationResult<T> private constructor(
             val filtered = parameters[name]?.filterIsInstance(type.java) ?: emptyList()
             storeListAndCopy(name, builder(filtered), start)
         }
+
+    // Builder methods - from all parameters, filtered by type and extension URLs
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type], optionally filtered
+     * by one or more extension URLs (AND logic), passes the filtered list to [builder],
+     * and stores the single result under [type]'s simple name (lowercase).
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     */
+    fun <I : Base, R : Base> addFromFiltered(
+        type: KClass<I>,
+        vararg extUrls: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> {
+        val stepName = type.java.simpleName.lowercase()
+        return runBuilderStep(stepName) { start ->
+            storeAndCopy(stepName, builder(collectFiltered(type, extUrls)), start)
+        }
+    }
+
+    /**
+     * Like [addFromFiltered] but stores the result under the explicit [name].
+     * Placing [name] before the [extUrls] vararg keeps the Java call-site clean.
+     */
+    fun <I : Base, R : Base> addFromFiltered(
+        name: String,
+        type: KClass<I>,
+        vararg extUrls: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) { start ->
+            storeAndCopy(name, builder(collectFiltered(type, extUrls)), start)
+        }
+
+    /**
+     * Like [addFromFiltered] but [builder] returns a `List<R>` which is stored as a
+     * parameter list. The output name defaults to [type]'s simple name (lowercase).
+     */
+    fun <I : Base, R : Base> addAllFromFiltered(
+        type: KClass<I>,
+        vararg extUrls: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> {
+        val stepName = type.java.simpleName.lowercase()
+        return runBuilderStep(stepName) { start ->
+            storeListAndCopy(stepName, builder(collectFiltered(type, extUrls)), start)
+        }
+    }
+
+    /**
+     * Like [addAllFromFiltered] but stores the result list under the explicit [name].
+     */
+    fun <I : Base, R : Base> addAllFromFiltered(
+        name: String,
+        type: KClass<I>,
+        vararg extUrls: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) { start ->
+            storeListAndCopy(name, builder(collectFiltered(type, extUrls)), start)
+        }
+
+    /**
+     * Reified overload of [addFromFiltered] (unnamed output key).
+     *
+     * **Named variants are intentionally not reified** — a reified `addFromFiltered(name, extUrls…,
+     * builder)` would be ambiguous with this overload whenever the caller passes a single `String`
+     * as the first argument (Kotlin cannot determine whether it is `name` or the first vararg
+     * element). Use the KClass overload when an explicit output key is required:
+     * `addFromFiltered("my-key", Patient::class, "http://ext/url") { … }`.
+     */
+    inline fun <reified I : Base, R : Base> addFromFiltered(
+        vararg extUrls: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromFiltered(I::class, *extUrls, builder = builder)
+
+    /** Reified overload of [addAllFromFiltered] (unnamed output key). See [addFromFiltered] for
+     *  why a named reified variant is not provided. */
+    inline fun <reified I : Base, R : Base> addAllFromFiltered(
+        vararg extUrls: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromFiltered(I::class, *extUrls, builder = builder)
 
     // Builder variants with explicit error handling
 

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
@@ -250,32 +250,14 @@ class OperationResultTest {
         assertThat(result.getByType<OperationOutcome>(), hasSize(1))
     }
 
-    // ── addFromFiltered / addAllFromFiltered ──────────────────────────────────
+    // ── addFromHavingAllExtensions / addFromHavingAnyExtension ────────────────
 
     @Test
-    fun `addFromFiltered returns only resources that have the matching extension URL`() {
+    fun `addFromHavingAllExtensions returns only resources that have the matching extension URL`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val notEnrolled = patient()
         val result = OperationResult.of(listOf(enrolled, notEnrolled), "patients")
-            .addFromFiltered(Patient::class, "http://example.org/enrolled") { filtered ->
-                OperationOutcome().apply {
-                    addIssue().diagnostics = "count=${filtered.size}"
-                }
-            }
-
-        val outcome = result.getResult()
-        assertEquals("count=1", outcome.issueFirstRep.diagnostics)
-    }
-
-    @Test
-    fun `addFromFiltered with multiple URLs uses AND logic - resource must have all urls`() {
-        val both = patient().apply {
-            addExtension("http://example.org/url1", StringType("a"))
-            addExtension("http://example.org/url2", StringType("b"))
-        }
-        val onlyFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
-        val result = OperationResult.of(listOf(both, onlyFirst), "patients")
-            .addFromFiltered(Patient::class, "http://example.org/url1", "http://example.org/url2") { filtered ->
+            .addFromHavingAllExtensions(Patient::class, "http://example.org/enrolled") { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -285,11 +267,57 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromFiltered with no extUrls returns all resources of that type`() {
-        val p1 = patient()
-        val p2 = patient()
-        val result = OperationResult.of(listOf(p1, p2, appointment()), "items")
-            .addFromFiltered(Patient::class) { filtered ->
+    fun `addFromHavingAllExtensions with multiple URLs requires resource to carry every URL`() {
+        val both = patient().apply {
+            addExtension("http://example.org/url1", StringType("a"))
+            addExtension("http://example.org/url2", StringType("b"))
+        }
+        val onlyFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
+        val result = OperationResult.of(listOf(both, onlyFirst), "patients")
+            .addFromHavingAllExtensions(Patient::class, "http://example.org/url1", "http://example.org/url2") { filtered ->
+                OperationOutcome().apply {
+                    addIssue().diagnostics = "count=${filtered.size}"
+                }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingAnyExtension returns resources carrying at least one of the URLs`() {
+        val hasFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
+        val hasSecond = patient().apply { addExtension("http://example.org/url2", StringType("b")) }
+        val hasBoth = patient().apply {
+            addExtension("http://example.org/url1", StringType("a"))
+            addExtension("http://example.org/url2", StringType("b"))
+        }
+        val hasNeither = patient()
+        val result = OperationResult.of(listOf(hasFirst, hasSecond, hasBoth, hasNeither), "patients")
+            .addFromHavingAnyExtension(Patient::class, "http://example.org/url1", "http://example.org/url2") { filtered ->
+                OperationOutcome().apply {
+                    addIssue().diagnostics = "count=${filtered.size}"
+                }
+            }
+
+        assertEquals("count=3", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingAnyExtension with single URL behaves like addFromHavingAllExtensions`() {
+        val hasIt = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
+        val hasNot = patient()
+        val result = OperationResult.of(listOf(hasIt, hasNot), "patients")
+            .addFromHavingAnyExtension(Patient::class, "http://example.org/url1") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingAllExtensions with no extUrls returns all resources of that type`() {
+        val result = OperationResult.of(listOf(patient(), patient(), appointment()), "items")
+            .addFromHavingAllExtensions(Patient::class) { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -299,9 +327,9 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromFiltered produces empty list when no resources match extension`() {
+    fun `addFromHavingAllExtensions produces empty list when no resources match`() {
         val result = OperationResult.of(listOf(patient(), patient()), "patients")
-            .addFromFiltered(Patient::class, "http://example.org/nonexistent") { filtered ->
+            .addFromHavingAllExtensions(Patient::class, "http://example.org/nonexistent") { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -311,12 +339,22 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromFiltered searches across all parameter keys not just one`() {
+    fun `addFromHavingAnyExtension produces empty list when no resources match any URL`() {
+        val result = OperationResult.of(listOf(patient(), patient()), "patients")
+            .addFromHavingAnyExtension(Patient::class, "http://example.org/nonexistent") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingAllExtensions searches across all parameter keys not just one`() {
         val enrolled1 = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val enrolled2 = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(enrolled1, "group-a")
             .add("group-b") { enrolled2 }
-            .addFromFiltered(Patient::class, "http://example.org/enrolled") { filtered ->
+            .addFromHavingAllExtensions(Patient::class, "http://example.org/enrolled") { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -326,11 +364,10 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromFiltered returns list result built from filtered input`() {
+    fun `addAllFromHavingAllExtensions returns list result built from AND-filtered input`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
-        val notEnrolled = patient()
-        val result = OperationResult.of(listOf(enrolled, notEnrolled), "patients")
-            .addAllFromFiltered(Patient::class, "http://example.org/enrolled") { filtered ->
+        val result = OperationResult.of(listOf(enrolled, patient()), "patients")
+            .addAllFromHavingAllExtensions(Patient::class, "http://example.org/enrolled") { filtered ->
                 filtered.map { OperationOutcome() }
             }
 
@@ -339,10 +376,22 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromFiltered reified overload works correctly`() {
+    fun `addAllFromHavingAnyExtension returns list result built from OR-filtered input`() {
+        val hasFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
+        val hasSecond = patient().apply { addExtension("http://example.org/url2", StringType("b")) }
+        val result = OperationResult.of(listOf(hasFirst, hasSecond, patient()), "patients")
+            .addAllFromHavingAnyExtension(Patient::class, "http://example.org/url1", "http://example.org/url2") { filtered ->
+                filtered.map { OperationOutcome() }
+            }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    @Test
+    fun `addFromHavingAllExtensions reified overload works correctly`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
-            .addFromFiltered<Patient, OperationOutcome>("http://example.org/enrolled") { filtered ->
+            .addFromHavingAllExtensions<Patient, OperationOutcome>("http://example.org/enrolled") { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -352,9 +401,21 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromFiltered records error outcome when builder throws`() {
+    fun `addFromHavingAnyExtension reified overload works correctly`() {
+        val hasFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
+        val hasSecond = patient().apply { addExtension("http://example.org/url2", StringType("b")) }
+        val result = OperationResult.of(listOf(hasFirst, hasSecond, patient()), "patients")
+            .addFromHavingAnyExtension<Patient, OperationOutcome>("http://example.org/url1", "http://example.org/url2") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=2", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingAllExtensions records error outcome when builder throws`() {
         val result = OperationResult.of(patient(), "patients")
-            .addFromFiltered(Patient::class) { _ ->
+            .addFromHavingAllExtensions(Patient::class) { _ ->
                 throw RuntimeException("builder failed")
             }
 
@@ -363,10 +424,10 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromFiltered named overload stores result under explicit name`() {
+    fun `addFromHavingAllExtensions named overload stores result under explicit name`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
-            .addFromFiltered("enrolled-summary", Patient::class, "http://example.org/enrolled") { filtered ->
+            .addFromHavingAllExtensions("enrolled-summary", Patient::class, "http://example.org/enrolled") { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -378,10 +439,10 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromFiltered reified overload returns list result from filtered input`() {
+    fun `addAllFromHavingAllExtensions reified overload returns list result`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient(), patient()), "patients")
-            .addAllFromFiltered<Patient, OperationOutcome>("http://example.org/enrolled") { filtered ->
+            .addAllFromHavingAllExtensions<Patient, OperationOutcome>("http://example.org/enrolled") { filtered ->
                 filtered.map { OperationOutcome() }
             }
 

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
@@ -250,6 +250,144 @@ class OperationResultTest {
         assertThat(result.getByType<OperationOutcome>(), hasSize(1))
     }
 
+    // ── addFromFiltered / addAllFromFiltered ──────────────────────────────────
+
+    @Test
+    fun `addFromFiltered returns only resources that have the matching extension URL`() {
+        val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
+        val notEnrolled = patient()
+        val result = OperationResult.of(listOf(enrolled, notEnrolled), "patients")
+            .addFromFiltered(Patient::class, "http://example.org/enrolled") { filtered ->
+                OperationOutcome().apply {
+                    addIssue().diagnostics = "count=${filtered.size}"
+                }
+            }
+
+        val outcome = result.getResult()
+        assertEquals("count=1", outcome.issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromFiltered with multiple URLs uses AND logic - resource must have all urls`() {
+        val both = patient().apply {
+            addExtension("http://example.org/url1", StringType("a"))
+            addExtension("http://example.org/url2", StringType("b"))
+        }
+        val onlyFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
+        val result = OperationResult.of(listOf(both, onlyFirst), "patients")
+            .addFromFiltered(Patient::class, "http://example.org/url1", "http://example.org/url2") { filtered ->
+                OperationOutcome().apply {
+                    addIssue().diagnostics = "count=${filtered.size}"
+                }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromFiltered with no extUrls returns all resources of that type`() {
+        val p1 = patient()
+        val p2 = patient()
+        val result = OperationResult.of(listOf(p1, p2, appointment()), "items")
+            .addFromFiltered(Patient::class) { filtered ->
+                OperationOutcome().apply {
+                    addIssue().diagnostics = "count=${filtered.size}"
+                }
+            }
+
+        assertEquals("count=2", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromFiltered produces empty list when no resources match extension`() {
+        val result = OperationResult.of(listOf(patient(), patient()), "patients")
+            .addFromFiltered(Patient::class, "http://example.org/nonexistent") { filtered ->
+                OperationOutcome().apply {
+                    addIssue().diagnostics = "count=${filtered.size}"
+                }
+            }
+
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromFiltered searches across all parameter keys not just one`() {
+        val enrolled1 = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
+        val enrolled2 = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
+        val result = OperationResult.of(enrolled1, "group-a")
+            .add("group-b") { enrolled2 }
+            .addFromFiltered(Patient::class, "http://example.org/enrolled") { filtered ->
+                OperationOutcome().apply {
+                    addIssue().diagnostics = "count=${filtered.size}"
+                }
+            }
+
+        assertEquals("count=2", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addAllFromFiltered returns list result built from filtered input`() {
+        val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
+        val notEnrolled = patient()
+        val result = OperationResult.of(listOf(enrolled, notEnrolled), "patients")
+            .addAllFromFiltered(Patient::class, "http://example.org/enrolled") { filtered ->
+                filtered.map { OperationOutcome() }
+            }
+
+        assertThat(result.getResult(), hasSize(1))
+        assertThat(result.getByType<OperationOutcome>(), hasSize(1))
+    }
+
+    @Test
+    fun `addFromFiltered reified overload works correctly`() {
+        val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
+        val result = OperationResult.of(listOf(enrolled, patient()), "patients")
+            .addFromFiltered<Patient, OperationOutcome>("http://example.org/enrolled") { filtered ->
+                OperationOutcome().apply {
+                    addIssue().diagnostics = "count=${filtered.size}"
+                }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromFiltered records error outcome when builder throws`() {
+        val result = OperationResult.of(patient(), "patients")
+            .addFromFiltered(Patient::class) { _ ->
+                throw RuntimeException("builder failed")
+            }
+
+        assertTrue(result.hasErrors())
+        assertThat(result.getOutcomes(), hasSize(1))
+    }
+
+    @Test
+    fun `addFromFiltered named overload stores result under explicit name`() {
+        val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
+        val result = OperationResult.of(listOf(enrolled, patient()), "patients")
+            .addFromFiltered("enrolled-summary", Patient::class, "http://example.org/enrolled") { filtered ->
+                OperationOutcome().apply {
+                    addIssue().diagnostics = "count=${filtered.size}"
+                }
+            }
+
+        assertTrue(result.containsKey("enrolled-summary"))
+        val summary = result.takeFirstTyped("enrolled-summary", OperationOutcome::class)
+        assertEquals("count=1", summary!!.issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addAllFromFiltered reified overload returns list result from filtered input`() {
+        val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
+        val result = OperationResult.of(listOf(enrolled, patient(), patient()), "patients")
+            .addAllFromFiltered<Patient, OperationOutcome>("http://example.org/enrolled") { filtered ->
+                filtered.map { OperationOutcome() }
+            }
+
+        assertThat(result.getResult(), hasSize(1))
+    }
+
     // ── Query methods ─────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
New pipeline methods that search ALL accumulated parameters, keep only resources
of a given type, and (optionally) further filter by having ALL specified FHIR
extension URLs (AND semantics). The filtered List<I> is then passed to the caller's
builder lambda, eliminating boilerplate FhirExtensionHelper.hasExtension() chains.

Four non-reified overloads (unnamed + named output key, single/list result) and two
reified inline overloads (unnamed only — named reified variants would be ambiguous
with the unnamed ones when the first arg is a String, per CLAUDE.md overload rules).

Includes 10 new tests and README documentation.