### PR TITLE
Add extension URL + value type / predicate filters to OperationResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,51 @@ val result4 = OperationResult.of(patients, "patients")
     }
 ```
 
+#### From all parameters, filtered by extension URL + value type or value predicate
+
+These methods extend the URL-presence filters above by also inspecting the **value** of the matched extension. Two sub-families are available:
+
+| Method | Filters by | Description |
+|---|---|---|
+| `addFromHavingExtensionWithValueType(type, url, valueType) { list -> R }` | URL + value type | Resource must have an extension at `url` with a value of `valueType`; single `R` result |
+| `addFromHavingExtensionWithValueType(name, type, url, valueType) { list -> R }` | URL + value type | Same, explicit output `name` |
+| `addAllFromHavingExtensionWithValueType(type, url, valueType) { list -> List<R> }` | URL + value type | Builder returns a list |
+| `addAllFromHavingExtensionWithValueType(name, type, url, valueType) { list -> List<R> }` | URL + value type | Named list variant |
+| `addFromHavingExtensionValueMatching(type, url, valueType, predicate) { list -> R }` | URL + typed predicate | Resource must have an extension at `url` with a value of `valueType` satisfying `predicate`; single `R` result |
+| `addFromHavingExtensionValueMatching(name, type, url, valueType, predicate) { list -> R }` | URL + typed predicate | Same, explicit output `name` |
+| `addAllFromHavingExtensionValueMatching(type, url, valueType, predicate) { list -> List<R> }` | URL + typed predicate | Builder returns a list |
+| `addAllFromHavingExtensionValueMatching(name, type, url, valueType, predicate) { list -> List<R> }` | URL + typed predicate | Named list variant |
+
+When the extension appears more than once at a URL, the resource is included if **any** of its values satisfies the condition. All unnamed variants have reified inline overloads. Named variants intentionally have no reified overload for the same reason as above.
+
+`addFromHavingExtensionWithValueType` is a convenience shorthand for `addFromHavingExtensionValueMatching` with a trivially true predicate — prefer the latter when you need to inspect the value itself.
+
+```kotlin
+// Type check — Patients whose "enrolled" extension carries a StringType value
+val result = OperationResult.of(patients, "patients")
+    .addFromHavingExtensionWithValueType(Patient::class, "http://ext/enrolled", StringType::class) { filtered ->
+        buildSummary(filtered)
+    }
+
+// Reified type check
+val result2 = OperationResult.of(patients, "patients")
+    .addFromHavingExtensionWithValueType<Patient, StringType, OperationOutcome>("http://ext/enrolled") { filtered ->
+        buildSummary(filtered)
+    }
+
+// Value predicate — only Patients enrolled (StringType "true")
+val result3 = OperationResult.of(patients, "patients")
+    .addFromHavingExtensionValueMatching(Patient::class, "http://ext/enrolled", StringType::class, { it.value == "true" }) { filtered ->
+        buildEnrolledSummary(filtered)
+    }
+
+// Reified predicate
+val result4 = OperationResult.of(patients, "patients")
+    .addFromHavingExtensionValueMatching<Patient, BooleanType, OperationOutcome>("http://ext/active", { it.booleanValue() }) { filtered ->
+        buildActiveSummary(filtered)
+    }
+```
+
 #### Error-resilient variants
 
 | Method | On exception | Returns |

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -233,6 +233,28 @@ class OperationResult<T> private constructor(
     }
 
     /**
+     * Searches **all** accumulated parameters for instances of [type] that have an [Extension] at
+     * [url] whose value is an instance of [valueType] and satisfies [predicate].
+     *
+     * Resources that do not implement [IBaseHasExtensions], have no extension at [url], or whose
+     * extension value is not an instance of [valueType] are silently excluded.
+     * When the extension appears multiple times at [url], the resource passes if **any** value
+     * satisfies [predicate].
+     */
+    private fun <I : Base, V : Type> collectByExtensionAndValueType(
+        type: KClass<I>,
+        url: String,
+        valueType: KClass<V>,
+        predicate: (V) -> Boolean
+    ): List<I> =
+        parameters.values.flatten()
+            .filterIsInstance(type.java)
+            .filter { resource ->
+                resource is IBaseHasExtensions &&
+                    FhirExtensionHelper.getAllValuesAs(resource, url, valueType.java).any(predicate)
+            }
+
+    /**
      * Searches **all** accumulated parameters for instances of [type] that carry **every** one of
      * the supplied [extUrls] (AND semantics), passes the typed list to [builder], and stores the
      * single result under [type]'s simple name (lowercase).
@@ -382,6 +404,166 @@ class OperationResult<T> private constructor(
         vararg extUrls: String,
         noinline builder: (List<I>) -> List<R>
     ): OperationResult<List<R>> = addAllFromHavingAnyExtension(I::class, *extUrls, builder = builder)
+
+    // ── Extension URL + value-type / value-predicate filters ─────────────────
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have an extension at
+     * [url] with a value of [valueType], passes the typed list to [builder], and stores the single
+     * result under [type]'s simple name (lowercase).
+     *
+     * This is a convenience shorthand for [addFromHavingExtensionValueMatching] with a trivially
+     * true predicate — use that method when you also need to inspect the value itself.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     */
+    fun <I : Base, V : Type, R : Base> addFromHavingExtensionWithValueType(
+        type: KClass<I>,
+        url: String,
+        valueType: KClass<V>,
+        builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingExtensionValueMatching(type, url, valueType, { true }, builder)
+
+    /**
+     * Like [addFromHavingExtensionWithValueType] but stores the result under the explicit [name].
+     */
+    fun <I : Base, V : Type, R : Base> addFromHavingExtensionWithValueType(
+        name: String,
+        type: KClass<I>,
+        url: String,
+        valueType: KClass<V>,
+        builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingExtensionValueMatching(name, type, url, valueType, { true }, builder)
+
+    /**
+     * Like [addFromHavingExtensionWithValueType] but [builder] returns a `List<R>`.
+     * The output name defaults to [type]'s simple name (lowercase).
+     */
+    fun <I : Base, V : Type, R : Base> addAllFromHavingExtensionWithValueType(
+        type: KClass<I>,
+        url: String,
+        valueType: KClass<V>,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingExtensionValueMatching(type, url, valueType, { true }, builder)
+
+    /** Like [addAllFromHavingExtensionWithValueType] but stores the result list under the explicit [name]. */
+    fun <I : Base, V : Type, R : Base> addAllFromHavingExtensionWithValueType(
+        name: String,
+        type: KClass<I>,
+        url: String,
+        valueType: KClass<V>,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingExtensionValueMatching(name, type, url, valueType, { true }, builder)
+
+    /**
+     * Reified overload of [addFromHavingExtensionWithValueType] (unnamed output key).
+     *
+     * **Named variants are intentionally not reified** — a reified overload whose first argument
+     * is a `String` would be ambiguous with this one. Use the KClass overload when an explicit
+     * output key is required.
+     */
+    inline fun <reified I : Base, reified V : Type, R : Base> addFromHavingExtensionWithValueType(
+        url: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingExtensionWithValueType(I::class, url, V::class, builder)
+
+    /** Reified overload of [addAllFromHavingExtensionWithValueType] (unnamed output key). */
+    inline fun <reified I : Base, reified V : Type, R : Base> addAllFromHavingExtensionWithValueType(
+        url: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingExtensionWithValueType(I::class, url, V::class, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have an extension at
+     * [url] with a value of [valueType] satisfying [predicate], passes the typed list to [builder],
+     * and stores the single result under [type]'s simple name (lowercase).
+     *
+     * The resource is included when **any** of its extension values at [url] satisfies [predicate].
+     * Resources with no extension at [url], or whose value is not of [valueType], are excluded.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addFromHavingExtensionWithValueType] when only a type check (no value inspection) is needed.
+     */
+    fun <I : Base, V : Type, R : Base> addFromHavingExtensionValueMatching(
+        type: KClass<I>,
+        url: String,
+        valueType: KClass<V>,
+        predicate: (V) -> Boolean,
+        builder: (List<I>) -> R
+    ): OperationResult<R> {
+        val stepName = type.java.simpleName.lowercase()
+        return runBuilderStep(stepName) { start ->
+            storeAndCopy(stepName, builder(collectByExtensionAndValueType(type, url, valueType, predicate)), start)
+        }
+    }
+
+    /**
+     * Like [addFromHavingExtensionValueMatching] but stores the result under the explicit [name].
+     */
+    fun <I : Base, V : Type, R : Base> addFromHavingExtensionValueMatching(
+        name: String,
+        type: KClass<I>,
+        url: String,
+        valueType: KClass<V>,
+        predicate: (V) -> Boolean,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) { start ->
+            storeAndCopy(name, builder(collectByExtensionAndValueType(type, url, valueType, predicate)), start)
+        }
+
+    /**
+     * Like [addFromHavingExtensionValueMatching] but [builder] returns a `List<R>`.
+     * The output name defaults to [type]'s simple name (lowercase).
+     */
+    fun <I : Base, V : Type, R : Base> addAllFromHavingExtensionValueMatching(
+        type: KClass<I>,
+        url: String,
+        valueType: KClass<V>,
+        predicate: (V) -> Boolean,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> {
+        val stepName = type.java.simpleName.lowercase()
+        return runBuilderStep(stepName) { start ->
+            storeListAndCopy(stepName, builder(collectByExtensionAndValueType(type, url, valueType, predicate)), start)
+        }
+    }
+
+    /** Like [addAllFromHavingExtensionValueMatching] but stores the result list under the explicit [name]. */
+    fun <I : Base, V : Type, R : Base> addAllFromHavingExtensionValueMatching(
+        name: String,
+        type: KClass<I>,
+        url: String,
+        valueType: KClass<V>,
+        predicate: (V) -> Boolean,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) { start ->
+            storeListAndCopy(name, builder(collectByExtensionAndValueType(type, url, valueType, predicate)), start)
+        }
+
+    /**
+     * Reified overload of [addFromHavingExtensionValueMatching] (unnamed output key).
+     *
+     * **Named variants are intentionally not reified** — a reified overload whose first argument
+     * is a `String` would be ambiguous with this one. Use the KClass overload when an explicit
+     * output key is required.
+     */
+    inline fun <reified I : Base, reified V : Type, R : Base> addFromHavingExtensionValueMatching(
+        url: String,
+        noinline predicate: (V) -> Boolean,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingExtensionValueMatching(I::class, url, V::class, predicate, builder)
+
+    /** Reified overload of [addAllFromHavingExtensionValueMatching] (unnamed output key). */
+    inline fun <reified I : Base, reified V : Type, R : Base> addAllFromHavingExtensionValueMatching(
+        url: String,
+        noinline predicate: (V) -> Boolean,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingExtensionValueMatching(I::class, url, V::class, predicate, builder)
 
     // Builder methods - single item
 

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
@@ -449,6 +449,146 @@ class OperationResultTest {
         assertThat(result.getResult(), hasSize(1))
     }
 
+    // ── Extension URL + value-type / value-predicate filters ─────────────────
+
+    @Test
+    fun `addFromHavingExtensionWithValueType returns resources where extension at URL has matching value type`() {
+        val withString = patient().apply { addExtension("http://example.org/flag", StringType("active")) }
+        val withBoolean = patient().apply { addExtension("http://example.org/flag", BooleanType(true)) }
+        val noExtension = patient()
+        val result = OperationResult.of(listOf(withString, withBoolean, noExtension), "patients")
+            .addFromHavingExtensionWithValueType(Patient::class, "http://example.org/flag", StringType::class) { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingExtensionWithValueType returns empty list when no resources have that value type at URL`() {
+        val withBoolean = patient().apply { addExtension("http://example.org/flag", BooleanType(false)) }
+        val result = OperationResult.of(listOf(withBoolean, patient()), "patients")
+            .addFromHavingExtensionWithValueType(Patient::class, "http://example.org/flag", StringType::class) { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingExtensionWithValueType named variant stores result under explicit name`() {
+        val withString = patient().apply { addExtension("http://example.org/flag", StringType("active")) }
+        val result = OperationResult.of(listOf(withString, patient()), "patients")
+            .addFromHavingExtensionWithValueType("flag-summary", Patient::class, "http://example.org/flag", StringType::class) { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.containsKey("flag-summary"))
+        val summary = result.takeFirstTyped("flag-summary", OperationOutcome::class)
+        assertEquals("count=1", summary!!.issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addAllFromHavingExtensionWithValueType returns list result`() {
+        val withString1 = patient().apply { addExtension("http://example.org/flag", StringType("a")) }
+        val withString2 = patient().apply { addExtension("http://example.org/flag", StringType("b")) }
+        val withBoolean = patient().apply { addExtension("http://example.org/flag", BooleanType(true)) }
+        val result = OperationResult.of(listOf(withString1, withString2, withBoolean), "patients")
+            .addAllFromHavingExtensionWithValueType(Patient::class, "http://example.org/flag", StringType::class) { filtered ->
+                filtered.map { OperationOutcome() }
+            }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    @Test
+    fun `addFromHavingExtensionWithValueType reified overload works correctly`() {
+        val withString = patient().apply { addExtension("http://example.org/flag", StringType("x")) }
+        val result = OperationResult.of(listOf(withString, patient()), "patients")
+            .addFromHavingExtensionWithValueType<Patient, StringType, OperationOutcome>("http://example.org/flag") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingExtensionValueMatching returns resources where extension value satisfies predicate`() {
+        val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
+        val notEnrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("false")) }
+        val noExt = patient()
+        val result = OperationResult.of(listOf(enrolled, notEnrolled, noExt), "patients")
+            .addFromHavingExtensionValueMatching(Patient::class, "http://example.org/enrolled", StringType::class, { it.value == "true" }) { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingExtensionValueMatching returns empty list when predicate never satisfied`() {
+        val patient1 = patient().apply { addExtension("http://example.org/enrolled", StringType("false")) }
+        val result = OperationResult.of(listOf(patient1, patient()), "patients")
+            .addFromHavingExtensionValueMatching(Patient::class, "http://example.org/enrolled", StringType::class, { it.value == "true" }) { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingExtensionValueMatching named variant stores result under explicit name`() {
+        val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
+        val result = OperationResult.of(listOf(enrolled, patient()), "patients")
+            .addFromHavingExtensionValueMatching("enrolled-patients", Patient::class, "http://example.org/enrolled", StringType::class, { it.value == "true" }) { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.containsKey("enrolled-patients"))
+        val summary = result.takeFirstTyped("enrolled-patients", OperationOutcome::class)
+        assertEquals("count=1", summary!!.issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addAllFromHavingExtensionValueMatching returns list result`() {
+        val high = patient().apply { addExtension("http://example.org/priority", IntegerType(10)) }
+        val low = patient().apply { addExtension("http://example.org/priority", IntegerType(1)) }
+        val none = patient()
+        val result = OperationResult.of(listOf(high, low, none), "patients")
+            .addAllFromHavingExtensionValueMatching(Patient::class, "http://example.org/priority", IntegerType::class, { it.value > 5 }) { filtered ->
+                filtered.map { OperationOutcome() }
+            }
+
+        assertThat(result.getResult(), hasSize(1))
+    }
+
+    @Test
+    fun `addFromHavingExtensionValueMatching reified overload works correctly`() {
+        val enrolled = patient().apply { addExtension("http://example.org/enrolled", BooleanType(true)) }
+        val notEnrolled = patient().apply { addExtension("http://example.org/enrolled", BooleanType(false)) }
+        val result = OperationResult.of(listOf(enrolled, notEnrolled), "patients")
+            .addFromHavingExtensionValueMatching<Patient, BooleanType, OperationOutcome>("http://example.org/enrolled", { it.booleanValue() }) { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingExtensionValueMatching with multiple extensions at same URL — any satisfying match passes`() {
+        val multiExt = patient().apply {
+            addExtension("http://example.org/role", StringType("admin"))
+            addExtension("http://example.org/role", StringType("user"))
+        }
+        val userOnly = patient().apply { addExtension("http://example.org/role", StringType("user")) }
+        val result = OperationResult.of(listOf(multiExt, userOnly, patient()), "patients")
+            .addFromHavingExtensionValueMatching(Patient::class, "http://example.org/role", StringType::class, { it.value == "admin" }) { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
     // ── Query methods ─────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Introduces two new filter families that go beyond URL-presence checking
and also inspect the extension value:

- addFromHavingExtensionWithValueType — filters resources by URL + FHIR
  value type (e.g. StringType, BooleanType, Coding). Convenience wrapper
  around the predicate variant with a trivially-true predicate.

- addFromHavingExtensionValueMatching — filters resources by URL + a
  typed predicate over the extension value. Useful for exact-value or
  range checks (e.g. enrolled == "true", priority > 5).

Both families follow the same shape as the existing extension-URL filters:
unnamed/named × single/list builder × KClass + reified overloads (12 new
public methods total). All follow Pattern A exception handling via
runBuilderStep. A single private helper
collectByExtensionAndValueType backs both families, delegating value
extraction to FhirExtensionHelper.getAllValuesAs.

11 new tests added; README updated with method tables and usage examples.