### PR TITLE
Add conditional chaining methods to OperationResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,28 @@ result.peek { map ->                  // inspect the map without modifying the p
 }
 ```
 
+#### Conditional chaining
+
+| Method | Condition | On exception |
+|--------|-----------|--------------|
+| `whenTrue(condition) { ... }` | Runs block and merges its parameters when `condition` is `true`; returns `OperationResult<T>` unchanged otherwise | WARNING outcome, state preserved |
+| `ifPresent { t -> ... }` | Runs block with the typed head value when it is non-null; skips when head is `null` | WARNING outcome, state preserved |
+| `guardFalse(condition, message)` | When `condition` is `false`, records a WARNING `OperationOutcome` with `IssueType.BUSINESSRULE` and the given `message`; pipeline continues | n/a — no block |
+
+```kotlin
+// Only add an encounter if the patient is active
+OperationResult.of(patient)
+    .guardFalse(patient.active, "Patient is not active — skipping encounter")
+    .whenTrue(patient.hasGeneralPractitioner()) {
+        add("gp") { resolveGp(patient) }
+    }
+    .ifPresent { p ->
+        OperationResult.of(buildEncounter(p), "encounter")
+    }
+```
+
+All three methods preserve the head type `T`. The block passed to `whenTrue` and `ifPresent` may contain any pipeline operations including head-changing ones — the outer head is always restored after the block completes.
+
 #### Convenience lookups
 
 ```kotlin

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -982,6 +982,114 @@ class OperationResult<T> private constructor(
         return this
     }
 
+    // ── Conditional chaining ────────────────────────────────────────────
+
+    /**
+     * Runs [block] on this result only when [condition] is true, merges all accumulated
+     * parameters and outcomes from the block result into the current map, and returns an
+     * [OperationResult] with the original head type [T] preserved.
+     *
+     * When [condition] is false the result is returned unchanged.
+     *
+     * On exception inside [block]: records a WARNING-severity [OperationOutcome] and returns
+     * the current result unchanged (Pattern B — head-preserving).
+     */
+    fun whenTrue(condition: Boolean, block: OperationResult<T>.() -> OperationResult<*>): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        if (!condition) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val subPipeline = OperationResult<T>(
+            mutableMapOf(), result, mutableListOf(), errorStrategy, mutableMapOf(), timingEnabled, mutableListOf()
+        )
+        return try {
+            val inner = block(subPipeline)
+            val newParams = shallowCopyParams()
+            inner.parameters.forEach { (key, values) ->
+                newParams.getOrPut(key) { mutableListOf() }.addAll(values)
+            }
+            outcomes.addAll(inner.outcomes)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric("whenTrue", "", durationMs, true)
+            copyWith(result, params = newParams, extensions = shallowCopyExtensions())
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='whenTrue' | WARN: {}", e.message)
+            recordMetric("whenTrue", "", durationMs, false)
+            val outcome = when (e) {
+                is BaseServerResponseException -> e.toOperationOutcome()
+                else -> e.toOperationOutcome()
+            }
+            outcome.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
+            outcomes.add(outcome)
+            copyWith(result)
+        }
+    }
+
+    /**
+     * Runs [block] with the current head value only when it is non-null, merges the block's
+     * accumulated parameters and outcomes, and returns [OperationResult<T>] with the original
+     * head preserved.
+     *
+     * When the head is null the result is returned unchanged.
+     *
+     * On exception inside [block]: records a WARNING-severity [OperationOutcome] and returns
+     * the current result unchanged (Pattern B — head-preserving).
+     */
+    fun ifPresent(block: (T) -> OperationResult<*>): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val current = result ?: return copyWith(result)
+        val start = System.currentTimeMillis()
+        return try {
+            val inner = block(current)
+            val newParams = shallowCopyParams()
+            inner.parameters.forEach { (key, values) ->
+                newParams.getOrPut(key) { mutableListOf() }.addAll(values)
+            }
+            outcomes.addAll(inner.outcomes)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric("ifPresent", "", durationMs, true)
+            copyWith(result, params = newParams, extensions = shallowCopyExtensions())
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='ifPresent' | WARN: {}", e.message)
+            recordMetric("ifPresent", "", durationMs, false)
+            val outcome = when (e) {
+                is BaseServerResponseException -> e.toOperationOutcome()
+                else -> e.toOperationOutcome()
+            }
+            outcome.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
+            outcomes.add(outcome)
+            copyWith(result)
+        }
+    }
+
+    /**
+     * Returns this result unchanged when [condition] is true.
+     *
+     * When [condition] is false, records a WARNING-severity [OperationOutcome] with the
+     * supplied [message] as diagnostics and returns the result unchanged. Does NOT skip
+     * the head or throw.
+     *
+     * Intended for precondition checks inline in a pipeline, e.g.:
+     * ```
+     * result.guardFalse(patient.active, "Patient is not active")
+     *       .add { buildEncounter(patient) }
+     * ```
+     */
+    fun guardFalse(condition: Boolean, message: String): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        if (condition) return copyWith(result)
+        val outcome = OperationOutcome().apply {
+            addIssue().apply {
+                severity = OperationOutcome.IssueSeverity.WARNING
+                code = OperationOutcome.IssueType.BUSINESSRULE
+                diagnostics = message
+            }
+        }
+        outcomes.add(outcome)
+        return copyWith(result)
+    }
+
     /** Returns the first value stored under [name], or `null` if the key is absent or empty. */
     fun takeFirst(name: String): Base? = parameters[name]?.firstOrNull()
 

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultConditionalTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultConditionalTest.kt
@@ -1,0 +1,266 @@
+package dev.ratkay.operation
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.sameInstance
+import org.hl7.fhir.r4.model.Appointment
+import org.hl7.fhir.r4.model.Coverage
+import org.hl7.fhir.r4.model.OperationOutcome
+import org.hl7.fhir.r4.model.Patient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class OperationResultConditionalTest {
+
+    // ── whenTrue ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `whenTrue - runs block and merges parameters when condition is true`() {
+        val appt = appointment()
+        val result = OperationResult.of(patient(), "patient")
+            .whenTrue(true) { add("appt") { appt } }
+
+        assertTrue(result.containsKey("patient"))
+        assertTrue(result.containsKey("appt"))
+        assertThat(result.getAll("appt"), hasSize(1))
+    }
+
+    @Test
+    fun `whenTrue - returns unchanged result when condition is false`() {
+        val result = OperationResult.of(patient(), "patient")
+            .whenTrue(false) { add("appt") { appointment() } }
+
+        assertTrue(result.containsKey("patient"))
+        assertFalse(result.containsKey("appt"))
+    }
+
+    @Test
+    fun `whenTrue - preserves head type T when condition is true`() {
+        val patient = patient()
+        val result: OperationResult<Patient> = OperationResult.of(patient, "patient")
+            .whenTrue(true) { addString("flag", "active") }
+
+        assertSame(patient, result.getResult())
+    }
+
+    @Test
+    fun `whenTrue - preserves head type T when condition is false`() {
+        val patient = patient()
+        val result: OperationResult<Patient> = OperationResult.of(patient, "patient")
+            .whenTrue(false) { addString("flag", "active") }
+
+        assertSame(patient, result.getResult())
+    }
+
+    @Test
+    fun `whenTrue - records WARNING outcome and preserves head when block throws`() {
+        val patient = patient()
+        val result: OperationResult<Patient> = OperationResult.of(patient, "patient")
+            .whenTrue(true) { error("block failed") }
+
+        assertTrue(result.hasErrors())
+        assertThat(result.getOutcomes(), hasSize(1))
+        assertThat(
+            result.getOutcomes().first().issueFirstRep.severity,
+            `is`(OperationOutcome.IssueSeverity.WARNING)
+        )
+        assertSame(patient, result.getResult())
+    }
+
+    @Test
+    fun `whenTrue - merges inner outcomes into outer result`() {
+        val result = OperationResult.of(patient(), "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+            .whenTrue(true) {
+                add("appt") { appointment() }
+                    .add { error("inner error") }
+            }
+
+        assertTrue(result.hasErrors())
+        assertTrue(result.containsKey("appt"))
+    }
+
+    @Test
+    fun `whenTrue - respects shouldSkip in FAIL_FAST mode`() {
+        val result = OperationResult.of(patient(), "patient")
+            .add { error("pipeline already failed") }
+            .whenTrue(true) { add("appt") { appointment() } }
+
+        assertFalse(result.containsKey("appt"))
+    }
+
+    @Test
+    fun `whenTrue - works with head-changing operations inside block`() {
+        val patient = patient()
+        val appt = appointment()
+        val result: OperationResult<Patient> = OperationResult.of(patient, "patient")
+            .whenTrue(true) {
+                // add() inside changes head to Appointment, but whenTrue still returns Patient
+                add("appt") { appt }
+            }
+
+        assertTrue(result.containsKey("appt"))
+        assertSame(patient, result.getResult())
+    }
+
+    // ── ifPresent ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `ifPresent - runs block when head is non-null`() {
+        val result = OperationResult.of(patient(), "patient")
+            .ifPresent { p -> OperationResult.of(p, "resolved-patient") }
+
+        assertTrue(result.containsKey("resolved-patient"))
+    }
+
+    @Test
+    fun `ifPresent - returns unchanged result when head is null`() {
+        val result = OperationResult.empty()
+            .ifPresent { OperationResult.of(appointment(), "appt") }
+
+        assertFalse(result.containsKey("appt"))
+    }
+
+    @Test
+    fun `ifPresent - passes the typed head value to block`() {
+        val patient = patient()
+        var received: Patient? = null
+
+        OperationResult.of(patient, "patient")
+            .ifPresent { p ->
+                received = p
+                OperationResult.of(p, "received")
+            }
+
+        assertSame(patient, received)
+    }
+
+    @Test
+    fun `ifPresent - records WARNING outcome and preserves head when block throws`() {
+        val patient = patient()
+        val result: OperationResult<Patient> = OperationResult.of(patient, "patient")
+            .ifPresent { error("block exploded") }
+
+        assertTrue(result.hasErrors())
+        assertThat(result.getOutcomes(), hasSize(1))
+        assertThat(
+            result.getOutcomes().first().issueFirstRep.severity,
+            `is`(OperationOutcome.IssueSeverity.WARNING)
+        )
+        assertSame(patient, result.getResult())
+    }
+
+    @Test
+    fun `ifPresent - respects shouldSkip in FAIL_FAST mode`() {
+        val result = OperationResult.of(patient(), "patient")
+            .add { error("pipeline already failed") }
+            .ifPresent { OperationResult.of(appointment(), "appt") }
+
+        assertFalse(result.containsKey("appt"))
+    }
+
+    @Test
+    fun `ifPresent - merges parameters from inner result into outer map`() {
+        val coverage = coverage()
+        val result = OperationResult.of(patient(), "patient")
+            .ifPresent { _ ->
+                OperationResult.of(coverage, "coverage")
+                    .addString("status", "active")
+            }
+
+        assertTrue(result.containsKey("coverage"))
+        assertTrue(result.containsKey("status"))
+        assertTrue(result.containsKey("patient"))
+    }
+
+    // ── guardFalse ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `guardFalse - returns unchanged result when condition is true`() {
+        val patient = patient()
+        val result = OperationResult.of(patient, "patient")
+            .guardFalse(true, "should not fire")
+
+        assertFalse(result.hasErrors())
+        assertSame(patient, result.getResult())
+    }
+
+    @Test
+    fun `guardFalse - records WARNING outcome when condition is false`() {
+        val result = OperationResult.of(patient(), "patient")
+            .guardFalse(false, "patient is inactive")
+
+        assertTrue(result.hasErrors())
+        assertThat(result.getOutcomes(), hasSize(1))
+        assertThat(
+            result.getOutcomes().first().issueFirstRep.severity,
+            `is`(OperationOutcome.IssueSeverity.WARNING)
+        )
+        assertEquals("patient is inactive", result.getOutcomes().first().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `guardFalse - does not change the head when condition is false`() {
+        val patient = patient()
+        val result: OperationResult<Patient> = OperationResult.of(patient, "patient")
+            .guardFalse(false, "inactive")
+
+        assertSame(patient, result.getResult())
+    }
+
+    @Test
+    fun `guardFalse - WARNING outcome has BUSINESSRULE issue code`() {
+        val result = OperationResult.of(patient(), "patient")
+            .guardFalse(false, "some business rule violated")
+
+        assertThat(
+            result.getOutcomes().first().issueFirstRep.code,
+            `is`(OperationOutcome.IssueType.BUSINESSRULE)
+        )
+    }
+
+    @Test
+    fun `guardFalse - respects shouldSkip in FAIL_FAST mode`() {
+        val result = OperationResult.of(patient(), "patient")
+            .add { error("pipeline already failed") }
+            .guardFalse(false, "should not add another outcome")
+
+        // Only the original ERROR outcome should be present (shouldSkip returns early)
+        assertThat(result.getOutcomes(), hasSize(1))
+        assertThat(
+            result.getOutcomes().first().issueFirstRep.severity,
+            `is`(OperationOutcome.IssueSeverity.ERROR)
+        )
+    }
+
+    @Test
+    fun `guardFalse - pipeline continues and accumulates resources after guard`() {
+        val appt = appointment()
+        val result = OperationResult.of(patient(), "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+            .guardFalse(false, "inactive")
+            .add("appt") { appt }
+
+        assertTrue(result.containsKey("appt"))
+        assertTrue(result.hasErrors())
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun patient() = Patient().apply {
+        addName().apply {
+            family = "Doe"
+            addGiven("Jane")
+        }
+    }
+
+    private fun appointment() = Appointment().apply {
+        status = Appointment.AppointmentStatus.BOOKED
+    }
+
+    private fun coverage() = Coverage().apply {
+        status = Coverage.CoverageStatus.ACTIVE
+    }
+}


### PR DESCRIPTION
## Summary
Adds three new conditional chaining methods to `OperationResult` that enable inline precondition checks and conditional block execution while preserving the head type and accumulating parameters/outcomes.

## Key Changes
- **`whenTrue(condition) { block }`** — Executes the block and merges its parameters/outcomes only when the condition is true; returns the result unchanged otherwise. Preserves head type `T` even if the block contains head-changing operations.

- **`ifPresent { t -> block }`** — Executes the block with the typed head value when non-null; skips when head is null. Merges block results and preserves head type `T`.

- **`guardFalse(condition, message)`** — Records a WARNING-severity `OperationOutcome` with `IssueType.BUSINESSRULE` when the condition is false; allows the pipeline to continue. Useful for inline validation checks.

## Implementation Details
- All three methods respect the `shouldSkip()` check in FAIL_FAST error strategy mode
- Exception handling in `whenTrue` and `ifPresent` records WARNING outcomes and preserves state (Pattern B)
- Parameters from inner results are shallow-copied and merged into the outer map
- Timing metrics are recorded for `whenTrue` and `ifPresent` when timing is enabled
- Comprehensive test coverage (266 lines) validates all edge cases including exception handling, head preservation, and error strategy interactions
- README documentation added with usage examples