### PR TITLE
R3: extract private helpers, add Java interop rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,18 @@ src/test/java/dev/ratkay/operation/
 - Validate with `require()` and `error()` — no checked exceptions
 - `AsyncOperationResult` uses sealed classes for DAG task nodes with cycle detection at registration time
 
+## Java Interop Rule
+
+FHIRMason must be fully usable from Java with an unbroken fluent chain. Kotlin extension functions compile to **static** JVM methods and cannot be chained in Java — `result.flatMap(...)` becomes `OperationResultKt.flatMap(result, ...)`, which destroys the API.
+
+**Rule:** Never use Kotlin extension functions for any public API method on `OperationResult<T>` (or any other public API class). All public methods must be declared as class members so that Java callers can use them as instance methods.
+
+Extension functions are only acceptable for:
+- Private/internal helper utilities that Java callers never invoke directly (e.g. top-level `internal fun` helpers in the same package).
+- The existing `getResultList()` top-level extension, which is a special case: it only applies to `OperationResult<List<R>>` and is documented as a Kotlin convenience alias.
+
+When splitting or reorganising source files, keep all public instance methods inside the class body. Only extract **private helpers** (pure functions that accept their inputs as parameters rather than accessing `this`) to separate internal files.
+
 ## Import Rules
 
 - **No wildcard imports** (`import foo.*`) anywhere in source or test files. Import every symbol individually.

--- a/README.md
+++ b/README.md
@@ -1142,10 +1142,13 @@ fhirmason-core/
     ├── main/java/dev/ratkay/operation/
     │   ├── OperationResult.kt              # Synchronous accumulator builder
     │   ├── AsyncOperationResult.kt         # Async/coroutine DAG-based builder
+    │   ├── ParameterMapSerializer.kt       # Dot-delimited key flatten / unflatten logic
     │   ├── ReferenceLinkRule.kt            # Explicit reference linking rule descriptor
+    │   ├── ReferenceLinkHelper.kt          # Reference linking algorithm helpers (internal)
     │   ├── StepMetrics.kt                  # Per-step timing and outcome data
     │   ├── ErrorStrategy.kt                # FAIL_FAST / ACCUMULATE enum
-    │   ├── OperationOutcomeExtensions.kt   # Exception → OperationOutcome helper
+    │   ├── FhirDateTimeConverter.kt        # Java/Kotlin date-time → FHIR type converter
+    │   ├── OperationOutcomeExtensions.kt   # Exception → OperationOutcome helpers
     │   └── FhirExtensionHelper.kt          # Deep extension retrieval utility
     └── test/java/dev/ratkay/operation/
         ├── OperationResultTest.kt

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/FhirExtensionHelper.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/FhirExtensionHelper.kt
@@ -5,6 +5,7 @@ import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.Extension
 import org.hl7.fhir.r4.model.Type
 import java.util.Optional
+import kotlin.reflect.KClass
 
 /**
  * Utility object for retrieving FHIR extensions from any object that can carry them.
@@ -204,3 +205,51 @@ object FhirExtensionHelper {
         }
     }
 }
+
+// ── Internal helpers used by OperationResult extension-filter methods ────────
+
+/**
+ * Filters [allValues] to instances of [type], then — when [extUrls] is non-empty — further
+ * requires each instance to implement [IBaseHasExtensions] and carry the relevant URLs.
+ *
+ * [matchAll] = `true` (AND): every URL must be present.
+ * [matchAll] = `false` (OR): at least one URL must be present.
+ * When [extUrls] is empty all instances of [type] are returned regardless of [matchAll].
+ */
+internal fun <I : Base> filterByExtension(
+    allValues: List<Base>,
+    type: KClass<I>,
+    extUrls: Array<out String>,
+    matchAll: Boolean
+): List<I> {
+    val allOfType = allValues.filterIsInstance(type.java)
+    return if (extUrls.isEmpty()) allOfType
+    else allOfType.filter { resource ->
+        resource is IBaseHasExtensions && if (matchAll) {
+            extUrls.all { url -> FhirExtensionHelper.hasExtension(resource, url) }
+        } else {
+            extUrls.any { url -> FhirExtensionHelper.hasExtension(resource, url) }
+        }
+    }
+}
+
+/**
+ * Filters [allValues] to instances of [type] that have an extension at [url] with a value
+ * of [valueType] satisfying [predicate].
+ *
+ * Resources that do not implement [IBaseHasExtensions], have no extension at [url], or whose
+ * extension value is not an instance of [valueType] are silently excluded.
+ */
+internal fun <I : Base, V : Type> filterByExtensionAndValueType(
+    allValues: List<Base>,
+    type: KClass<I>,
+    url: String,
+    valueType: KClass<V>,
+    predicate: (V) -> Boolean
+): List<I> =
+    allValues
+        .filterIsInstance(type.java)
+        .filter { resource ->
+            resource is IBaseHasExtensions &&
+                FhirExtensionHelper.getAllValuesAs(resource, url, valueType.java).any(predicate)
+        }

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationOutcomeExtensions.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationOutcomeExtensions.kt
@@ -20,3 +20,19 @@ fun Exception.toOperationOutcome(): OperationOutcome = OperationOutcome().apply 
  */
 fun BaseServerResponseException.toOperationOutcome(): OperationOutcome =
     (operationOutcome as? OperationOutcome) ?: (this as Exception).toOperationOutcome()
+
+/**
+ * Builds a WARNING-severity [OperationOutcome] from [e], preserving any rich embedded
+ * outcome when [e] is a [BaseServerResponseException].
+ *
+ * Shared by [OperationResult.addOrSkip], [OperationResult.addOrDefault], and the
+ * conditional-chaining methods — do not duplicate this logic inline.
+ */
+internal fun warningOutcome(e: Exception): OperationOutcome {
+    val base = when (e) {
+        is BaseServerResponseException -> e.toOperationOutcome()
+        else -> e.toOperationOutcome()
+    }
+    base.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
+    return base
+}

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -2,7 +2,6 @@ package dev.ratkay.operation
 
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException
-import org.hl7.fhir.instance.model.api.IBaseHasExtensions
 import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.BooleanType
 import org.hl7.fhir.r4.model.Extension
@@ -50,6 +49,26 @@ import kotlin.reflect.KClass
  * "head" of the pipeline so that [getResult] returns the correct type without casting.
  * When the last step produced a list, [T] becomes `List<R>` and the result can be
  * retrieved via [getResult] or via the [getResultList] extension.
+ *
+ * ### Section map (for navigation)
+ * | Section | Methods |
+ * |---------|---------|
+ * | Error state | `hasErrors`, `isSuccessful`, `getOutcomes`, `getFailedTasks`, `toOperationOutcome`, `throwIfErrors` |
+ * | Metrics & timing | `timed`, `getMetrics` |
+ * | Step runners *(private)* | `runStep`, `runBuilderStep`, `runPrimitiveStep` |
+ * | Storage helpers *(private)* | `storeAndCopy`, `storeListAndCopy` |
+ * | Extension URL filters | `addFromHavingAllExtensions`, `addFromHavingAnyExtension`, `addAllFrom…`, `addFromHavingExtensionWithValueType`, `addFromHavingExtensionValueMatching`, … |
+ * | Core builders | `add`, `addUsing`, `addAll`, `addAllUsing`, `addFrom`, `addAllFrom`, `addOrSkip`, `addOrDefault` |
+ * | Primitive values | `addString`, `addBoolean`, `addInteger`, `addDecimal`, `addDate`, `addDateTime`, `addInstant`, `addTime`, `addCanonical`, `addCoding`, `addReference`, `addIdentifier`, `addPeriod`, `addQuantity`, `addCodeableConcept` |
+ * | Nested params | `addPart` |
+ * | Extension support | `addWithExtension` |
+ * | Query | `getAllParameters`, `getAll`, `getByType`, `containsKey`, `getKeys`, `count`, `totalCount`, `isEmpty`, `isNotEmpty` |
+ * | Transformations | `filterByType`, `filterByName`, `mapValues`, `flatMap`, `mapHead`, `mapHeadUsing`, `merge`, `remove`, `rename`, `peek` |
+ * | Conditional chaining | `whenTrue`, `ifPresent`, `guardFalse` |
+ * | Extraction | `takeFirst`, `takeFirstTyped`, `extractParam`, `extractParamList` |
+ * | Reference linking | `linkReferences` |
+ * | Serialization | `toParameters`, `toBundleEntry`, `toBundle`, `toTransactionBundle`, `toBatchBundle`, `getResult` |
+ * | Factory *(companion)* | `of`, `fromParameters`, `fromParametersTyped`, `fromBundle`, `empty` |
  */
 class OperationResult<T> private constructor(
     private val parameters: MutableMap<String, MutableList<Base>>,
@@ -229,51 +248,11 @@ class OperationResult<T> private constructor(
 
     // Builder methods — filter all accumulated parameters by type and extension URLs
 
-    /**
-     * Collects all values across every accumulated parameter, keeps only instances of [type],
-     * and — if [extUrls] is non-empty — further filters by extension-URL presence.
-     *
-     * When [matchAll] is `true` (AND): a resource must carry **every** supplied URL.
-     * When [matchAll] is `false` (OR): a resource must carry **at least one** of the URLs.
-     * When [extUrls] is empty, all instances of [type] are returned regardless of [matchAll].
-     */
-    private fun <I : Base> collectByExtension(
-        type: KClass<I>,
-        extUrls: Array<out String>,
-        matchAll: Boolean
-    ): List<I> {
-        val allOfType = parameters.values.flatten().filterIsInstance(type.java)
-        return if (extUrls.isEmpty()) allOfType
-        else allOfType.filter { resource ->
-            resource is IBaseHasExtensions && if (matchAll) {
-                extUrls.all { url -> FhirExtensionHelper.hasExtension(resource, url) }
-            } else {
-                extUrls.any { url -> FhirExtensionHelper.hasExtension(resource, url) }
-            }
-        }
-    }
+    private fun <I : Base> collectByExtension(type: KClass<I>, extUrls: Array<out String>, matchAll: Boolean): List<I> =
+        filterByExtension(parameters.values.flatten(), type, extUrls, matchAll)
 
-    /**
-     * Searches **all** accumulated parameters for instances of [type] that have an [Extension] at
-     * [url] whose value is an instance of [valueType] and satisfies [predicate].
-     *
-     * Resources that do not implement [IBaseHasExtensions], have no extension at [url], or whose
-     * extension value is not an instance of [valueType] are silently excluded.
-     * When the extension appears multiple times at [url], the resource passes if **any** value
-     * satisfies [predicate].
-     */
-    private fun <I : Base, V : Type> collectByExtensionAndValueType(
-        type: KClass<I>,
-        url: String,
-        valueType: KClass<V>,
-        predicate: (V) -> Boolean
-    ): List<I> =
-        parameters.values.flatten()
-            .filterIsInstance(type.java)
-            .filter { resource ->
-                resource is IBaseHasExtensions &&
-                    FhirExtensionHelper.getAllValuesAs(resource, url, valueType.java).any(predicate)
-            }
+    private fun <I : Base, V : Type> collectByExtensionAndValueType(type: KClass<I>, url: String, valueType: KClass<V>, predicate: (V) -> Boolean): List<I> =
+        filterByExtensionAndValueType(parameters.values.flatten(), type, url, valueType, predicate)
 
     /**
      * Searches **all** accumulated parameters for instances of [type] that carry **every** one of
@@ -1199,20 +1178,8 @@ class OperationResult<T> private constructor(
      * @throws IllegalArgumentException if more than one target resource exists for any rule.
      */
     fun linkReferences(vararg rules: ReferenceLinkRule<*, *>): OperationResult<T> {
-        val copiedParams = deepCopyParameters()
-        val allResources = copiedParams.values.flatten().filterIsInstance<Resource>()
-        rules.forEach { rule ->
-            val sources = allResources.filter { rule.sourceType.java.isInstance(it) }
-            val targets = allResources.filter { rule.targetType.java.isInstance(it) }
-            require(targets.size <= 1) {
-                "Ambiguous reference target: ${targets.size} resources of type " +
-                "'${rule.targetType.simpleName}' found; exactly one is required per rule"
-            }
-            val target = targets.singleOrNull() ?: return@forEach
-            sources.forEach { source ->
-                if (source !== target) rule.applyTo(source, target)
-            }
-        }
+        val copiedParams = deepCopyParameters(parameters)
+        applyReferenceLinkRules(copiedParams, rules)
         return copyWith(result, params = copiedParams)
     }
 
@@ -1236,36 +1203,8 @@ class OperationResult<T> private constructor(
      * accumulated resources remain unchanged.
      */
     fun linkReferences(): OperationResult<T> {
-        val copiedParams = deepCopyParameters()
-        val allResources = copiedParams.values.flatten().filterIsInstance<Resource>()
-
-        val resourceIndex: Map<String, List<Resource>> = allResources
-            .filter { it.hasId() }
-            .groupBy { it.fhirType().lowercase() }
-
-        allResources.forEach { source ->
-            source.children().forEach { property ->
-                val typeCode = property.typeCode ?: return@forEach
-                if (!typeCode.startsWith("Reference(")) return@forEach
-                if (property.hasValues()) return@forEach
-
-                val allowedTypes = typeCode
-                    .removePrefix("Reference(")
-                    .removeSuffix(")")
-                    .split("|")
-                    .map { it.trim().lowercase() }
-
-                val candidates: List<Resource> = allowedTypes.flatMap { type ->
-                    resourceIndex[type]?.filter { it !== source } ?: emptyList()
-                }
-
-                if (candidates.size == 1) {
-                    val target = candidates.single()
-                    val ref = Reference("${target.fhirType()}/${target.idPart}")
-                    runCatching { source.setProperty(property.name, ref) }
-                }
-            }
-        }
+        val copiedParams = deepCopyParameters(parameters)
+        autoLinkReferences(copiedParams)
         return copyWith(result, params = copiedParams)
     }
 
@@ -1337,26 +1276,6 @@ class OperationResult<T> private constructor(
     fun getResult(): T = result ?: throw IllegalStateException("No result set")
 
     // Private helpers
-
-    /**
-     * Returns a deep copy of [parameters] so that [linkReferences] can mutate the copies
-     * without affecting the original accumulated resources.
-     *
-     * HAPI FHIR's [Base.copy] performs a recursive clone of each element.
-     */
-    private fun deepCopyParameters(): MutableMap<String, MutableList<Base>> =
-        parameters.mapValues { (_, values) ->
-            values.map { base -> if (base is Resource) base.copy() else base }.toMutableList()
-        }.toMutableMap()
-
-    private fun warningOutcome(e: Exception): OperationOutcome {
-        val base = when (e) {
-            is BaseServerResponseException -> e.toOperationOutcome()
-            else -> e.toOperationOutcome()
-        }
-        base.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
-        return base
-    }
 
     private fun addToParameters(values: List<Base>, name: String?) {
         if (name != null) {

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/ReferenceLinkHelper.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/ReferenceLinkHelper.kt
@@ -1,0 +1,97 @@
+package dev.ratkay.operation
+
+import org.hl7.fhir.r4.model.Base
+import org.hl7.fhir.r4.model.Reference
+import org.hl7.fhir.r4.model.Resource
+
+/**
+ * Internal helpers for [OperationResult.linkReferences].
+ *
+ * All functions operate on a **copy** of the parameter map produced by [deepCopyParameters];
+ * they never mutate the original [OperationResult] state.
+ */
+
+/**
+ * Returns a deep copy of [parameters] so that reference-linking can mutate the copies
+ * without affecting the original accumulated resources.
+ *
+ * HAPI FHIR's [Base.copy] performs a recursive clone of each element.
+ */
+internal fun deepCopyParameters(parameters: Map<String, MutableList<Base>>): MutableMap<String, MutableList<Base>> =
+    parameters.mapValues { (_, values) ->
+        values.map { base -> if (base is Resource) base.copy() else base }.toMutableList()
+    }.toMutableMap()
+
+/**
+ * Applies explicit [rules] to all resources in [copiedParams].
+ *
+ * For each rule there must be **at most one** target resource; if multiple are found an
+ * [IllegalArgumentException] is thrown because the wiring would be ambiguous. Every source
+ * resource has its reference set to the single target. Self-pairs (source === target) are
+ * skipped.
+ */
+internal fun applyReferenceLinkRules(
+    copiedParams: MutableMap<String, MutableList<Base>>,
+    rules: Array<out ReferenceLinkRule<*, *>>
+) {
+    val allResources = copiedParams.values.flatten().filterIsInstance<Resource>()
+    rules.forEach { rule ->
+        val sources = allResources.filter { rule.sourceType.java.isInstance(it) }
+        val targets = allResources.filter { rule.targetType.java.isInstance(it) }
+        require(targets.size <= 1) {
+            "Ambiguous reference target: ${targets.size} resources of type " +
+                "'${rule.targetType.simpleName}' found; exactly one is required per rule"
+        }
+        val target = targets.singleOrNull() ?: return@forEach
+        sources.forEach { source ->
+            if (source !== target) rule.applyTo(source, target)
+        }
+    }
+}
+
+/**
+ * Automatically wires FHIR references in [copiedParams] by introspecting each resource's
+ * HAPI child properties.
+ *
+ * Algorithm:
+ * 1. Build an index of ID-bearing resources keyed by `fhirType().lowercase()`.
+ * 2. For every accumulated resource, iterate its [Base.children] properties.
+ * 3. For each unset property whose typeCode starts with `"Reference("`, parse the allowed
+ *    target types from the typeCode (e.g. `"Reference(Patient|Group)"`).
+ * 4. If exactly one matching resource exists in the index for one of those types, assign a
+ *    `Reference("ResourceType/id")` via [Base.setProperty].
+ *
+ * Only unset reference properties are touched; already-populated references are left unchanged.
+ * Ambiguous cases (multiple candidates for the same property) are silently skipped.
+ */
+internal fun autoLinkReferences(copiedParams: MutableMap<String, MutableList<Base>>) {
+    val allResources = copiedParams.values.flatten().filterIsInstance<Resource>()
+
+    val resourceIndex: Map<String, List<Resource>> = allResources
+        .filter { it.hasId() }
+        .groupBy { it.fhirType().lowercase() }
+
+    allResources.forEach { source ->
+        source.children().forEach { property ->
+            val typeCode = property.typeCode ?: return@forEach
+            if (!typeCode.startsWith("Reference(")) return@forEach
+            if (property.hasValues()) return@forEach
+
+            val allowedTypes = typeCode
+                .removePrefix("Reference(")
+                .removeSuffix(")")
+                .split("|")
+                .map { it.trim().lowercase() }
+
+            val candidates: List<Resource> = allowedTypes.flatMap { type ->
+                resourceIndex[type]?.filter { it !== source } ?: emptyList()
+            }
+
+            if (candidates.size == 1) {
+                val target = candidates.single()
+                val ref = Reference("${target.fhirType()}/${target.idPart}")
+                runCatching { source.setProperty(property.name, ref) }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- CLAUDE.md: document that extension functions on public API classes break Java callers' fluent chains; all public methods must be class members
- ReferenceLinkHelper.kt (new): deepCopyParameters, applyReferenceLinkRules, autoLinkReferences — extracted from linkReferences() method bodies
- FhirExtensionHelper.kt: add internal filterByExtension and filterByExtensionAndValueType top-level helpers
- OperationOutcomeExtensions.kt: add internal warningOutcome helper
- OperationResult.kt: delegate to extracted helpers, add class-level section map KDoc for navigation; remove IBaseHasExtensions import

OperationResult.kt reduced from 1526 → 1445 lines. All 454 tests pass.