### PR TITLE
Add AsyncOperationResult.merge for structural DAG composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -906,6 +906,8 @@ When a task has exactly one dependency, use the typed overloads to skip the manu
 | `addListAfter(key, dep, type) { t -> List<Base> }` | single typed value | `List<Base>` |
 | `addAfterAll(key, dep, type) { list -> Base }` | typed list | `Base` |
 | `addListAfterAll(key, dep, type) { list -> List<Base> }` | typed list | `List<Base>` |
+| `merge { AsyncOperationResult() … }` | — (lambda builds inner DAG) | `this` |
+| `merge(other: AsyncOperationResult)` | — (pre-built inner DAG) | `this` |
 
 ```kotlin
 AsyncOperationResult()
@@ -977,6 +979,50 @@ val result = dag.run()
 ```
 
 On final failure the key is absent from the result and an ERROR `OperationOutcome` is recorded. See the sync builder section for the full parameter table.
+
+### DAG Composition (`merge`)
+
+`merge` combines an independently built sub-DAG into the current DAG. All task nodes from the
+inner `AsyncOperationResult` are absorbed into the outer DAG's node map so they participate
+in the same parallel execution.
+
+After a `merge` call, any task added via `addAfter` or `addListAfter` may reference keys from
+either the original outer DAG or the merged inner DAG:
+
+```kotlin
+// Lambda form — build the inner DAG inline
+val result = AsyncOperationResult()
+    .add("patient") { fetchPatient() }
+    .merge {
+        AsyncOperationResult()
+            .add("coverage") { fetchCoverage() }
+            .addAfter("claim", "coverage", Coverage::class) { cov -> buildClaim(cov) }
+    }
+    .addAfter("summary", "patient", "claim") { deps ->
+        buildSummary(deps["patient"]!!, deps["claim"]!!)
+    }
+    .run()
+```
+
+```kotlin
+// Instance form — useful when the inner DAG is produced by a factory function
+fun billingDag(): AsyncOperationResult = AsyncOperationResult()
+    .add("coverage") { fetchCoverage() }
+    .add("claim")    { fetchClaim() }
+
+val result = AsyncOperationResult()
+    .add("patient") { fetchPatient() }
+    .merge(billingDag())
+    .run()
+```
+
+**Constraints:**
+- Inner nodes may only depend on other inner nodes — cross-DAG inner-to-outer dependencies
+  cannot be expressed (the inner DAG is built independently).
+- Task keys must be unique across both DAGs — a duplicate key throws `IllegalArgumentException`.
+- Empty inner DAGs are silently accepted (no-op).
+- The inner DAG's `timed()` setting is ignored; the outer DAG's timing applies to all tasks
+  after the merge.
 
 ### Constraints
 
@@ -1243,6 +1289,7 @@ fhirmason-core/
         ├── AsyncOperationResultMetricsTest.kt
         ├── AsyncOperationResultDescribeTest.kt
         ├── AsyncOperationResultRetryTest.kt
+        ├── AsyncOperationResultMergeTest.kt
         ├── FhirDateTimeConverterTest.kt
         └── FhirExtensionHelperTest.kt
 

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/AsyncOperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/AsyncOperationResult.kt
@@ -183,6 +183,46 @@ class AsyncOperationResult {
         }
     }
 
+    // ── DAG composition ──────────────────────────────────────────────────────
+
+    /**
+     * Merges all task nodes from [other] into this DAG and returns `this`.
+     *
+     * The two DAGs must be completely independent: nodes in [other] may only depend on
+     * other nodes registered in [other], not on nodes already registered in this DAG.
+     * After the merge, any task added via [addAfter] or [addListAfter] may reference
+     * keys from either the original outer DAG or the merged inner DAG:
+     * ```kotlin
+     * AsyncOperationResult()
+     *     .add("patient") { fetchPatient() }
+     *     .merge {
+     *         AsyncOperationResult()
+     *             .add("coverage") { fetchCoverage() }
+     *             .addAfter("claim", "coverage", Coverage::class) { cov -> buildClaim(cov) }
+     *     }
+     *     .addAfter("summary", "patient", "claim") { deps -> combine(deps) }
+     *     .run()
+     * ```
+     *
+     * Duplicate keys between DAGs cause [IllegalArgumentException] — task keys are
+     * identities, not values; two tasks cannot share the same name in a single DAG.
+     * The [other] instance's [timed] setting is ignored; the outer DAG's applies uniformly
+     * to all tasks after the merge.
+     *
+     * @throws IllegalArgumentException if any key from [other] is already registered in this DAG
+     */
+    fun merge(other: AsyncOperationResult): AsyncOperationResult = also {
+        other.nodes.values.forEach { node -> registerNode(node.key, node) }
+    }
+
+    /**
+     * Calls [block] to build an inner [AsyncOperationResult] and merges all of its task nodes
+     * into this DAG. Returns `this`. See [merge] for the full contract.
+     *
+     * @throws IllegalArgumentException if any key produced by [block] is already registered in this DAG
+     */
+    fun merge(block: () -> AsyncOperationResult): AsyncOperationResult = merge(block())
+
     // ── DAG inspection ───────────────────────────────────────────────────────
 
     /**

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/AsyncOperationResultMergeTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/AsyncOperationResultMergeTest.kt
@@ -1,0 +1,344 @@
+package dev.ratkay.operation
+
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.`is`
+import org.hl7.fhir.r4.model.Appointment
+import org.hl7.fhir.r4.model.Claim
+import org.hl7.fhir.r4.model.Coverage
+import org.hl7.fhir.r4.model.Encounter
+import org.hl7.fhir.r4.model.Patient
+import org.hl7.fhir.r4.model.Practitioner
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AsyncOperationResultMergeTest {
+
+    // ── Group 1: Basic merge behaviour ───────────────────────────────────────
+
+    @Test
+    fun `merge - inner nodes appear in result`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("outer") { Patient().apply { id = "p1" } }
+            .merge {
+                AsyncOperationResult()
+                    .add("inner") { Coverage().apply { id = "c1" } }
+            }
+            .run()
+
+        assertThat(result.containsKey("outer"), `is`(true))
+        assertThat(result.containsKey("inner"), `is`(true))
+    }
+
+    @Test
+    fun `merge - inner nodes execute and produce correct values`() = runBlocking {
+        val result = AsyncOperationResult()
+            .merge {
+                AsyncOperationResult()
+                    .add("coverage") { Coverage().apply { id = "cov1" } }
+            }
+            .run()
+
+        assertThat(result.count("coverage"), `is`(1))
+        assertThat((result.getAll("coverage").first() as Coverage).id, `is`("cov1"))
+    }
+
+    @Test
+    fun `merge - addAfter after merge can reference merged inner key`() = runBlocking {
+        val result = AsyncOperationResult()
+            .merge {
+                AsyncOperationResult()
+                    .add("patient") { Patient().apply { id = "p1" } }
+            }
+            .addAfter("encounter", "patient", Patient::class) { patient ->
+                Encounter().apply { id = "enc-${patient.id}" }
+            }
+            .run()
+
+        val encounter = result.getAll("encounter").first() as Encounter
+        assertThat(encounter.id, `is`("enc-p1"))
+    }
+
+    @Test
+    fun `merge - outer and inner keys coexist and all produce results`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("outerA") { Patient().apply { id = "a" } }
+            .add("outerB") { Coverage().apply { id = "b" } }
+            .merge {
+                AsyncOperationResult()
+                    .add("innerX") { Appointment().apply { id = "x" } }
+                    .add("innerY") { Practitioner().apply { id = "y" } }
+            }
+            .run()
+
+        assertThat(result.getKeys(), containsInAnyOrder("outerA", "outerB", "innerX", "innerY"))
+        assertThat(result.totalCount(), `is`(4))
+    }
+
+    // ── Group 2: Inner DAG's internal dependencies survive merge ─────────────
+
+    @Test
+    fun `merge - inner dependent node resolves correctly after merge`() = runBlocking {
+        val result = AsyncOperationResult()
+            .merge {
+                AsyncOperationResult()
+                    .add("base") { Patient().apply { id = "base" } }
+                    .addAfter("derived", "base", Patient::class) { p ->
+                        Coverage().apply { id = "derived-from-${p.id}" }
+                    }
+            }
+            .run()
+
+        val derived = result.getAll("derived").first() as Coverage
+        assertThat(derived.id, `is`("derived-from-base"))
+    }
+
+    @Test
+    fun `merge - inner three-tier chain resolves in order after merge`() = runBlocking {
+        val result = AsyncOperationResult()
+            .merge {
+                AsyncOperationResult()
+                    .add("a") { Patient().apply { id = "A" } }
+                    .addAfter("b", "a", Patient::class) { a ->
+                        Patient().apply { id = "${a.id}-B" }
+                    }
+                    .addAfter("c", "b", Patient::class) { b ->
+                        Patient().apply { id = "${b.id}-C" }
+                    }
+            }
+            .run()
+
+        assertThat((result.getAll("c").first() as Patient).id, `is`("A-B-C"))
+    }
+
+    // ── Group 3: Composing outer + inner ─────────────────────────────────────
+
+    @Test
+    fun `merge - addAfter after merge can depend on both outer and inner keys`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("outerPatient") { Patient().apply { id = "p1" } }
+            .merge {
+                AsyncOperationResult()
+                    .add("innerCoverage") { Coverage().apply { id = "c1" } }
+            }
+            .addAfter("claim", "outerPatient", "innerCoverage") { deps ->
+                val patient = deps["outerPatient"]!!.first() as Patient
+                val coverage = deps["innerCoverage"]!!.first() as Coverage
+                Claim().apply { id = "${patient.id}+${coverage.id}" }
+            }
+            .run()
+
+        val claim = result.getAll("claim").first() as Claim
+        assertThat(claim.id, `is`("p1+c1"))
+    }
+
+    // ── Group 4: Error handling ───────────────────────────────────────────────
+
+    @Test
+    fun `merge - inner task failure is captured as failed task`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("outer") { Patient() }
+            .merge {
+                AsyncOperationResult()
+                    .add("failing") { error("inner boom") }
+            }
+            .run()
+
+        assertThat(result.containsKey("outer"), `is`(true))
+        assertFalse(result.containsKey("failing"))
+        assertTrue(result.hasErrors())
+        assertTrue(result.getFailedTasks().containsKey("failing"))
+    }
+
+    @Test
+    fun `merge - inner failure does not affect independent outer tasks`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("outer") { Patient().apply { id = "ok" } }
+            .merge {
+                AsyncOperationResult()
+                    .add("failing") { error("boom") }
+            }
+            .run()
+
+        assertThat(result.containsKey("outer"), `is`(true))
+        assertThat(result.getFailedTasks().size, `is`(1))
+    }
+
+    // ── Group 5: Duplicate key validation ────────────────────────────────────
+
+    @Test
+    fun `merge - duplicate key between outer and inner throws IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult()
+                .add("patient") { Patient() }
+                .merge {
+                    AsyncOperationResult()
+                        .add("patient") { Coverage() }
+                }
+        }
+    }
+
+    @Test
+    fun `merge - duplicate key across two sequential merges throws IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult()
+                .merge {
+                    AsyncOperationResult().add("patient") { Patient() }
+                }
+                .merge {
+                    AsyncOperationResult().add("patient") { Coverage() }
+                }
+        }
+    }
+
+    // ── Group 6: Edge cases ───────────────────────────────────────────────────
+
+    @Test
+    fun `merge - empty inner DAG is a no-op`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .merge { AsyncOperationResult() }
+            .run()
+
+        assertThat(result.containsKey("patient"), `is`(true))
+        assertThat(result.totalCount(), `is`(1))
+    }
+
+    @Test
+    fun `merge - empty outer merged with non-empty inner works`() = runBlocking {
+        val result = AsyncOperationResult()
+            .merge {
+                AsyncOperationResult()
+                    .add("only") { Patient().apply { id = "sole" } }
+            }
+            .run()
+
+        assertThat(result.containsKey("only"), `is`(true))
+        assertThat((result.getAll("only").first() as Patient).id, `is`("sole"))
+    }
+
+    @Test
+    fun `merge - multiple sequential merges accumulate all nodes`() = runBlocking {
+        val result = AsyncOperationResult()
+            .merge { AsyncOperationResult().add("a") { Patient() } }
+            .merge { AsyncOperationResult().add("b") { Coverage() } }
+            .merge { AsyncOperationResult().add("c") { Appointment() } }
+            .run()
+
+        assertThat(result.getKeys(), containsInAnyOrder("a", "b", "c"))
+        assertThat(result.totalCount(), `is`(3))
+    }
+
+    @Test
+    fun `merge - addAfter chain after merge referencing inner key resolves correctly`() = runBlocking {
+        val result = AsyncOperationResult()
+            .merge {
+                AsyncOperationResult()
+                    .add("patient") { Patient().apply { id = "p1" } }
+            }
+            .addAfter("coverage", "patient", Patient::class) { p ->
+                Coverage().apply { id = "cov-${p.id}" }
+            }
+            .addAfter("claim", "coverage", Coverage::class) { c ->
+                Claim().apply { id = "claim-${c.id}" }
+            }
+            .run()
+
+        val claim = result.getAll("claim").first() as Claim
+        assertThat(claim.id, `is`("claim-cov-p1"))
+    }
+
+    // ── Group 7: Instance overload ────────────────────────────────────────────
+
+    @Test
+    fun `merge instance overload - pre-built inner DAG merges correctly`() = runBlocking {
+        val innerDag = AsyncOperationResult()
+            .add("coverage") { Coverage().apply { id = "c1" } }
+
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .merge(innerDag)
+            .run()
+
+        assertThat(result.getKeys(), containsInAnyOrder("patient", "coverage"))
+    }
+
+    @Test
+    fun `merge instance overload - duplicate key throws IllegalArgumentException`() {
+        val innerDag = AsyncOperationResult().add("patient") { Coverage() }
+
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult()
+                .add("patient") { Patient() }
+                .merge(innerDag)
+        }
+    }
+
+    // ── Group 8: describe() integration ──────────────────────────────────────
+
+    @Test
+    fun `merge - describe shows merged nodes in correct tiers`() {
+        val output = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .merge {
+                AsyncOperationResult()
+                    .add("coverage") { Coverage() }
+                    .addAfter("claim", "coverage") { _ -> Claim() }
+            }
+            .describe()
+
+        assertThat(output, containsString("patient"))
+        assertThat(output, containsString("coverage"))
+        assertThat(output, containsString("claim"))
+        assertThat(output, containsString("depends on [coverage]"))
+    }
+
+    @Test
+    fun `merge - describe reflects cross-DAG dependency added after merge`() {
+        val output = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .merge {
+                AsyncOperationResult().add("coverage") { Coverage() }
+            }
+            .addAfter("claim", "patient", "coverage") { _ -> Claim() }
+            .describe()
+
+        assertThat(output, containsString("claim"))
+        assertThat(output, containsString("depends on [patient, coverage]"))
+    }
+
+    // ── Group 9: Timing / metrics ─────────────────────────────────────────────
+
+    @Test
+    fun `merge - timed outer DAG captures metrics for merged inner tasks`() {
+        val dag = AsyncOperationResult()
+            .timed()
+            .merge {
+                AsyncOperationResult()
+                    .add("innerPatient") { Patient() }
+            }
+
+        dag.runBlocking()
+
+        assertTrue(dag.getMetrics().containsKey("innerPatient"))
+        assertTrue(dag.getMetrics()["innerPatient"]!!.success)
+    }
+
+    @Test
+    fun `merge - inner DAG timed setting does not enable metrics on outer`() {
+        val dag = AsyncOperationResult()
+            .merge {
+                AsyncOperationResult()
+                    .timed()
+                    .add("innerTask") { Patient() }
+            }
+
+        dag.runBlocking()
+
+        assertTrue(dag.getMetrics().isEmpty())
+    }
+}


### PR DESCRIPTION
Introduces two overloads that absorb all task nodes from an independently
built inner AsyncOperationResult into the outer DAG's node map, so both
sets of tasks participate in the same parallel execution:

  fun merge(other: AsyncOperationResult): AsyncOperationResult
  fun merge(block: () -> AsyncOperationResult): AsyncOperationResult

The lambda form delegates to the instance form. Inner DAGs must be
self-contained (their nodes may only depend on other inner nodes).
After merge, any subsequent addAfter/addListAfter call may reference
keys from either DAG. Duplicate keys between DAGs throw
IllegalArgumentException at registration time. The inner instance's
timed() setting is ignored; the outer DAG's applies uniformly.

No changes to run(), describe(), or any existing method — all operate
on this.nodes and see the merged result transparently.

Adds 21 tests in AsyncOperationResultMergeTest covering: basic merge,
inner dependency chains, cross-DAG addAfter, error propagation,
duplicate-key validation, edge cases (empty DAG, multiple merges,
deep addAfter chains), instance overload, describe() integration, and
timing/metrics behaviour.