### PR TITLE
Add FHIRPath support: addFromMatching, addAllFromMatching, whenPath, guardPath, selectByPath

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ src/test/java/dev/ratkay/operation/
 - Factory entry points live in `companion object` as `of()` methods
 - Use reified generics (`KClass<R>`) for type-safe resource filtering
 - Receiver-lambda overloads are named `addUsing` / `addAllUsing` (not `add` / `addAll`)
-- If no explicit key name is given, defaults to `value.fhirType().lowercase()`
+- If no explicit key name is given, the storage key is always the **output** value's `fhirType().lowercase()` — never the input type's name. For example, a builder that receives `Patient` resources and returns an `OperationOutcome` stores under `"operationoutcome"`, not `"patient"`. This applies to every method with an optional `name` parameter: `add`, `addAll`, `addFrom`, `addAllFrom`, `addFromHavingAllExtensions`, `addFromHavingAnyExtension`, `addAllFrom*`, `addFromHavingExtensionWithValueType`, `addFromHavingExtensionValueMatching`, `addAllFromHavingExtensionValueMatching`, `addFromMatching`, `addAllFromMatching`, and `selectByPath`. Pass `null` (or omit the name) to `storeAndCopy`/`storeListAndCopy` and let them derive the key from the result; never pass a derived input-type name.
 - Test method names use Kotlin backtick syntax: `` `descriptive test name` ``
 - Validate with `require()` and `error()` — no checked exceptions
 - `AsyncOperationResult` uses sealed classes for DAG task nodes with cycle detection at registration time

--- a/README.md
+++ b/README.md
@@ -213,6 +213,38 @@ val result4 = OperationResult.of(patients, "patients")
     }
 ```
 
+#### From all parameters, filtered by FHIRPath expression
+
+`addFromMatching` and `addAllFromMatching` evaluate a FHIRPath expression against every accumulated resource of a given type and pass only those that evaluate to `true` to the builder. The expression is relative to each candidate resource (write `"active = true"`, not `"Patient.active = true"`).
+
+| Method | Returns | Default key |
+|---|---|---|
+| `addFromMatching(name?, type, expression) { list -> R }` | `OperationResult<R>` | `type` simple name (lowercase) |
+| `addAllFromMatching(name?, type, expression) { list -> List<R> }` | `OperationResult<List<R>>` | `type` simple name (lowercase) |
+
+Both methods have reified Kotlin overloads (omit `type`) and generate `@JvmOverloads` for Java callers. Error handling follows Pattern A: malformed expressions produce an ERROR `OperationOutcome` and skip the head.
+
+```kotlin
+// Keep only active patients, then build a summary
+val result = OperationResult.of(patients, "patients")
+    .addFromMatching<Patient, OperationOutcome>(expression = "active = true") { active ->
+        OperationOutcome().apply { addIssue().diagnostics = "${active.size} active patients" }
+    }
+
+// Multi-field condition — extension value AND regular field
+val result2 = OperationResult.of(patients, "patients")
+    .addAllFromMatching<Patient, Patient>(
+        "high-risk",
+        expression = "extension('http://ext/risk').value = 'high' and birthDate < @1960-01-01"
+    ) { it }
+
+// Named output key — KClass form (required when you also want an explicit name in Kotlin)
+val result3 = OperationResult.of(patients, "patients")
+    .addFromMatching("enrolled", Patient::class, "identifier.where(system='http://example.org/mpi').exists()") { filtered ->
+        buildEnrolledSummary(filtered)
+    }
+```
+
 #### Error-resilient variants
 
 | Method | On exception | Returns |
@@ -640,6 +672,27 @@ OperationResult.of(patient)
 ```
 
 All three methods preserve the head type `T`. The block passed to `whenTrue` and `ifPresent` may contain any pipeline operations including head-changing ones — the outer head is always restored after the block completes.
+
+#### FHIRPath conditional chaining and extraction
+
+Three FHIRPath-aware methods complement the existing conditional API. All expressions are relative to the current head resource (write `"active = true"`, not `"Patient.active = true"`).
+
+| Method | Head requirement | Behaviour |
+|---|---|---|
+| `whenPath(expression) { ... }` | Must be a `Base`; silent skip if null/non-Base | Runs block and merges parameters when expression is truthy; WARNING on malformed expression |
+| `guardPath(expression, message)` | Must be a `Base`; WARNING if null/non-Base | Records WARNING `OperationOutcome` with `message` when expression is `false`; WARNING on malformed expression |
+| `selectByPath(type, expression, name?)` | Must be a `Base`; ERROR if null/non-Base | Evaluates expression, promotes first matching result of `type` to the new pipeline head, stores under `name`; ERROR if no match found |
+
+```kotlin
+val result = OperationResult.of(patient)
+    .guardPath("active = true", "Patient must be active")
+    .whenPath("identifier.where(system='http://example.org/mpi').exists()") {
+        add("mpi-flag") { StringType("enrolled") }
+    }
+    .selectByPath<HumanName>("name.where(use='official').first()", "official-name")
+```
+
+`selectByPath` has a reified Kotlin overload (`selectByPath<HumanName>("name.first()")`). Error handling for `whenPath` and `guardPath` follows Pattern B (head preserved); `selectByPath` follows Pattern A (head skipped on failure).
 
 #### Convenience lookups
 

--- a/fhirmason-core/pom.xml
+++ b/fhirmason-core/pom.xml
@@ -26,6 +26,15 @@
             <artifactId>hapi-fhir-structures-r4</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.fhir</groupId>
+            <artifactId>ucum</artifactId>
+            <version>1.0.8</version>
+        </dependency>
+        <dependency>
+            <groupId>ca.uhn.hapi.fhir</groupId>
+            <artifactId>hapi-fhir-caching-guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-core</artifactId>
         </dependency>

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/FhirPathHelper.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/FhirPathHelper.kt
@@ -1,0 +1,77 @@
+package dev.ratkay.operation
+
+import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.fhirpath.IFhirPath
+import org.hl7.fhir.instance.model.api.IBase
+import org.hl7.fhir.r4.model.Base
+import org.hl7.fhir.r4.model.BooleanType
+
+/**
+ * Utility object for evaluating FHIRPath expressions against FHIR R4 resources.
+ *
+ * Wraps HAPI FHIR's [IFhirPath] engine, which is obtained once from
+ * [FhirContext.forR4Cached] and reused for all evaluations. The engine is
+ * thread-safe and expensive to create, so keeping a single instance here avoids
+ * repeated initialisation overhead.
+ *
+ * ### Truthiness semantics for [matches]
+ * FHIRPath expressions return a collection, not a single boolean. This helper
+ * follows the standard FHIRPath truthiness rules:
+ * - Empty collection → `false`
+ * - Single [BooleanType] → its boolean value
+ * - Non-empty, non-boolean collection → `true`
+ *
+ * ### Usage
+ * ```kotlin
+ * val engine = FhirPathHelper
+ *
+ * // Boolean predicate
+ * val isActive: Boolean = FhirPathHelper.matches(patient, "active = true")
+ *
+ * // Typed extraction
+ * val family: StringType? = FhirPathHelper.evaluateFirst(patient, "name.family", StringType::class.java)
+ * ```
+ */
+internal object FhirPathHelper {
+
+    private val engine: IFhirPath = FhirContext.forR4Cached().newFhirPath()
+
+    /**
+     * Evaluates [expression] against [resource] and returns `true` when the result is truthy:
+     * - Single [BooleanType] with value `true`
+     * - Non-empty collection of any non-boolean values
+     *
+     * Returns `false` for an empty collection or a [BooleanType] with value `false`.
+     *
+     * @throws Exception if the expression is syntactically invalid or cannot be evaluated;
+     *   callers (e.g. [OperationResult] builder steps) are responsible for catching this.
+     */
+    fun matches(resource: Base, expression: String): Boolean {
+        val results = engine.evaluate(resource, expression, IBase::class.java)
+        if (results.isEmpty()) return false
+        val first = results.first()
+        return if (first is BooleanType) first.booleanValue() else true
+    }
+
+    /**
+     * Evaluates [expression] against [resource] and returns the first result cast to [type],
+     * or `null` if the expression produces no results or the first result is not of [type].
+     *
+     * @throws Exception if the expression is syntactically invalid or cannot be evaluated.
+     */
+    fun <T : Base> evaluateFirst(resource: Base, expression: String, type: Class<T>): T? =
+        engine.evaluateFirst(resource, expression, type).orElse(null)
+}
+
+/**
+ * Filters [allValues] to instances of [type] where [expression] evaluates to `true`
+ * via [FhirPathHelper.matches].
+ *
+ * Resources that do not match the expression are silently excluded.
+ * Evaluation exceptions propagate to the caller.
+ */
+internal fun <I : Base> filterByPath(
+    allValues: List<Base>,
+    type: Class<I>,
+    expression: String
+): List<I> = allValues.filterIsInstance(type).filter { FhirPathHelper.matches(it, expression) }

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -249,7 +249,7 @@ class OperationResult<T> private constructor(
     /**
      * Searches **all** accumulated parameters for instances of [type] that carry **every** one of
      * the supplied [extUrls] (AND semantics), passes the typed list to [builder], and stores the
-     * single result under [type]'s simple name (lowercase).
+     * single result under the result's fhirType (lowercase).
      *
      * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
      * and skip the head value.
@@ -263,7 +263,7 @@ class OperationResult<T> private constructor(
     ): OperationResult<R> {
         val stepName = type.java.simpleName.lowercase()
         return runBuilderStep(stepName) { start ->
-            storeAndCopy(stepName, builder(collectByExtension(type, extUrls, matchAll = true)), start)
+            storeAndCopy(null, builder(collectByExtension(type, extUrls, matchAll = true)), start)
         }
     }
 
@@ -284,7 +284,7 @@ class OperationResult<T> private constructor(
     /**
      * Searches **all** accumulated parameters for instances of [type] that carry **at least one**
      * of the supplied [extUrls] (OR semantics), passes the typed list to [builder], and stores the
-     * single result under [type]'s simple name (lowercase).
+     * single result under the result's fhirType (lowercase).
      *
      * Use [addFromHavingAllExtensions] when AND semantics are needed instead.
      */
@@ -295,7 +295,7 @@ class OperationResult<T> private constructor(
     ): OperationResult<R> {
         val stepName = type.java.simpleName.lowercase()
         return runBuilderStep(stepName) { start ->
-            storeAndCopy(stepName, builder(collectByExtension(type, extUrls, matchAll = false)), start)
+            storeAndCopy(null, builder(collectByExtension(type, extUrls, matchAll = false)), start)
         }
     }
 
@@ -314,7 +314,7 @@ class OperationResult<T> private constructor(
 
     /**
      * Like [addFromHavingAllExtensions] but [builder] returns a `List<R>`.
-     * The output name defaults to [type]'s simple name (lowercase).
+     * The output name defaults to the result elements' fhirType (lowercase).
      */
     fun <I : Base, R : Base> addAllFromHavingAllExtensions(
         type: KClass<I>,
@@ -323,7 +323,7 @@ class OperationResult<T> private constructor(
     ): OperationResult<List<R>> {
         val stepName = type.java.simpleName.lowercase()
         return runBuilderStep(stepName) { start ->
-            storeListAndCopy(stepName, builder(collectByExtension(type, extUrls, matchAll = true)), start)
+            storeListAndCopy(null, builder(collectByExtension(type, extUrls, matchAll = true)), start)
         }
     }
 
@@ -340,7 +340,7 @@ class OperationResult<T> private constructor(
 
     /**
      * Like [addFromHavingAnyExtension] but [builder] returns a `List<R>`.
-     * The output name defaults to [type]'s simple name (lowercase).
+     * The output name defaults to the result elements' fhirType (lowercase).
      */
     fun <I : Base, R : Base> addAllFromHavingAnyExtension(
         type: KClass<I>,
@@ -349,7 +349,7 @@ class OperationResult<T> private constructor(
     ): OperationResult<List<R>> {
         val stepName = type.java.simpleName.lowercase()
         return runBuilderStep(stepName) { start ->
-            storeListAndCopy(stepName, builder(collectByExtension(type, extUrls, matchAll = false)), start)
+            storeListAndCopy(null, builder(collectByExtension(type, extUrls, matchAll = false)), start)
         }
     }
 
@@ -402,7 +402,7 @@ class OperationResult<T> private constructor(
     /**
      * Searches **all** accumulated parameters for instances of [type] that have an extension at
      * [url] with a value of [valueType], passes the typed list to [builder], and stores the single
-     * result under [type]'s simple name (lowercase).
+     * result under the result's fhirType (lowercase).
      *
      * This is a convenience shorthand for [addFromHavingExtensionValueMatching] with a trivially
      * true predicate — use that method when you also need to inspect the value itself.
@@ -430,7 +430,7 @@ class OperationResult<T> private constructor(
 
     /**
      * Like [addFromHavingExtensionWithValueType] but [builder] returns a `List<R>`.
-     * The output name defaults to [type]'s simple name (lowercase).
+     * The output name defaults to the result elements' fhirType (lowercase).
      */
     fun <I : Base, V : Type, R : Base> addAllFromHavingExtensionWithValueType(
         type: KClass<I>,
@@ -469,7 +469,7 @@ class OperationResult<T> private constructor(
     /**
      * Searches **all** accumulated parameters for instances of [type] that have an extension at
      * [url] with a value of [valueType] satisfying [predicate], passes the typed list to [builder],
-     * and stores the single result under [type]'s simple name (lowercase).
+     * and stores the single result under the result's fhirType (lowercase).
      *
      * The resource is included when **any** of its extension values at [url] satisfies [predicate].
      * Resources with no extension at [url], or whose value is not of [valueType], are excluded.
@@ -488,7 +488,7 @@ class OperationResult<T> private constructor(
     ): OperationResult<R> {
         val stepName = type.java.simpleName.lowercase()
         return runBuilderStep(stepName) { start ->
-            storeAndCopy(stepName, builder(collectByExtensionAndValueType(type, url, valueType, predicate)), start)
+            storeAndCopy(null, builder(collectByExtensionAndValueType(type, url, valueType, predicate)), start)
         }
     }
 
@@ -509,7 +509,7 @@ class OperationResult<T> private constructor(
 
     /**
      * Like [addFromHavingExtensionValueMatching] but [builder] returns a `List<R>`.
-     * The output name defaults to [type]'s simple name (lowercase).
+     * The output name defaults to the result elements' fhirType (lowercase).
      */
     fun <I : Base, V : Type, R : Base> addAllFromHavingExtensionValueMatching(
         type: KClass<I>,
@@ -520,7 +520,7 @@ class OperationResult<T> private constructor(
     ): OperationResult<List<R>> {
         val stepName = type.java.simpleName.lowercase()
         return runBuilderStep(stepName) { start ->
-            storeListAndCopy(stepName, builder(collectByExtensionAndValueType(type, url, valueType, predicate)), start)
+            storeListAndCopy(null, builder(collectByExtensionAndValueType(type, url, valueType, predicate)), start)
         }
     }
 

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -48,13 +48,15 @@ import kotlin.reflect.KClass
  * | Step runners *(private)* | `runStep`, `runBuilderStep`, `runPrimitiveStep` |
  * | Storage helpers *(private)* | `storeAndCopy`, `storeListAndCopy` |
  * | Extension URL filters | `addFromHavingAllExtensions`, `addFromHavingAnyExtension`, `addAllFrom…`, `addFromHavingExtensionWithValueType`, `addFromHavingExtensionValueMatching`, … |
+ * | FHIRPath filters | `addFromMatching`, `addAllFromMatching` |
  * | Core builders | `add`, `addUsing`, `addAll`, `addAllUsing`, `addFrom`, `addAllFrom`, `addOrSkip`, `addOrDefault`, `addWithRetry`, `addWithRetryUsing` |
  * | Primitive values | `addString`, `addBoolean`, `addInteger`, `addDecimal`, `addDate([DateTimeInput])`, `addDateTime([DateTimeInput])`, `addInstant([DateTimeInput])`, `addTime([DateTimeInput])`, `addCanonical`, `addCoding`, `addReference`, `addIdentifier`, `addPeriod`, `addQuantity`, `addCodeableConcept` |
  * | Nested params | `addPart` |
  * | Extension support | `addWithExtension` |
  * | Query | `getAllParameters`, `getAll`, `getByType`, `containsKey`, `getKeys`, `count`, `totalCount`, `isEmpty`, `isNotEmpty` |
  * | Transformations | `filterByType`, `filterByName`, `mapValues`, `flatMap`, `mapHead`, `mapHeadUsing`, `merge`, `remove`, `rename`, `peek` |
- * | Conditional chaining | `whenTrue`, `ifPresent`, `guardFalse` |
+ * | Conditional chaining | `whenTrue`, `ifPresent`, `guardFalse`, `whenPath`, `guardPath` |
+ * | FHIRPath extraction | `selectByPath` |
  * | Extraction | `takeFirst`, `takeFirstTyped`, `extractParam`, `extractParamList` |
  * | Reference linking | `linkReferences` |
  * | Serialization | `toParameters`, `toBundleEntry`, `toBundle`, `toTransactionBundle`, `toBatchBundle`, `getResult` |
@@ -554,6 +556,69 @@ class OperationResult<T> private constructor(
         noinline predicate: (V) -> Boolean,
         noinline builder: (List<I>) -> List<R>
     ): OperationResult<List<R>> = addAllFromHavingExtensionValueMatching(I::class, url, V::class, predicate, builder)
+
+    // Builder methods — filter all accumulated parameters by type and FHIRPath expression
+
+    private fun <I : Base> collectByPath(type: KClass<I>, expression: String): List<I> =
+        filterByPath(parameters.values.flatten(), type.java, expression)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] where [expression]
+     * evaluates to `true` (using [FhirPathHelper.matches] semantics), passes the typed list
+     * to [builder], and stores the single result under [name] (or [type]'s simple name
+     * lowercase when [name] is `null`).
+     *
+     * Error handling follows Pattern A: exceptions (including malformed FHIRPath syntax)
+     * record an ERROR-severity [OperationOutcome] and skip the head value.
+     *
+     * [expression] is evaluated against each individual resource, so it should be written as
+     * a relative path (e.g. `"active = true"`, not `"Patient.active = true"`).
+     *
+     * Use [addAllFromMatching] when [builder] returns a `List<R>`.
+     */
+    @JvmOverloads
+    fun <I : Base, R : Base> addFromMatching(
+        name: String? = null,
+        type: KClass<I>,
+        expression: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> {
+        val stepName = name ?: type.java.simpleName.lowercase()
+        return runBuilderStep(stepName) { start ->
+            storeAndCopy(stepName, builder(collectByPath(type, expression)), start)
+        }
+    }
+
+    /**
+     * Like [addFromMatching] but [builder] returns a `List<R>`.
+     * The output name defaults to [type]'s simple name (lowercase) when [name] is `null`.
+     */
+    @JvmOverloads
+    fun <I : Base, R : Base> addAllFromMatching(
+        name: String? = null,
+        type: KClass<I>,
+        expression: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> {
+        val stepName = name ?: type.java.simpleName.lowercase()
+        return runBuilderStep(stepName) { start ->
+            storeListAndCopy(stepName, builder(collectByPath(type, expression)), start)
+        }
+    }
+
+    /** Reified overload of [addFromMatching] — no [KClass] argument needed at call sites. */
+    inline fun <reified I : Base, R : Base> addFromMatching(
+        name: String? = null,
+        expression: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromMatching(name, I::class, expression, builder)
+
+    /** Reified overload of [addAllFromMatching] — no [KClass] argument needed at call sites. */
+    inline fun <reified I : Base, R : Base> addAllFromMatching(
+        name: String? = null,
+        expression: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromMatching(name, I::class, expression, builder)
 
     // Builder methods - single item
 
@@ -1181,6 +1246,143 @@ class OperationResult<T> private constructor(
         outcomes.add(outcome)
         return copyWith(result)
     }
+
+    // ── FHIRPath conditional chaining ────────────────────────────────────
+
+    /**
+     * Runs [block] on this result only when [expression] evaluates to `true` against the
+     * current head value (using [FhirPathHelper.matches] semantics), merges all accumulated
+     * parameters and outcomes from the block result into the current map, and returns an
+     * [OperationResult] with the original head type [T] preserved.
+     *
+     * When the head is `null` or not a FHIR [Base] resource, the block is skipped silently
+     * and the result is returned unchanged.
+     *
+     * [expression] is evaluated against the head resource directly, so write it as a relative
+     * path (e.g. `"active = true"`, not `"Patient.active = true"`).
+     *
+     * On exception inside [block] or during expression evaluation: records a WARNING-severity
+     * [OperationOutcome] and returns the current result unchanged (Pattern B — head-preserving).
+     */
+    fun whenPath(expression: String, block: OperationResult<T>.() -> OperationResult<*>): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val head = result
+        if (head !is Base) return copyWith(result)
+        val start = System.currentTimeMillis()
+        val subPipeline = OperationResult<T>(
+            mutableMapOf(), result, mutableListOf(), errorStrategy, mutableMapOf(), timingEnabled, mutableListOf()
+        )
+        return try {
+            if (!FhirPathHelper.matches(head, expression)) return copyWith(result)
+            val inner = block(subPipeline)
+            val newParams = shallowCopyParams()
+            inner.parameters.forEach { (key, values) ->
+                newParams.getOrPut(key) { mutableListOf() }.addAll(values)
+            }
+            outcomes.addAll(inner.outcomes)
+            val durationMs = System.currentTimeMillis() - start
+            recordMetric("whenPath", "", durationMs, true)
+            copyWith(result, params = newParams, extensions = shallowCopyExtensions())
+        } catch (e: Exception) {
+            val durationMs = System.currentTimeMillis() - start
+            logger.warn("FHIRMason | step='whenPath' | WARN: {}", e.message)
+            recordMetric("whenPath", "", durationMs, false)
+            val outcome = when (e) {
+                is BaseServerResponseException -> e.toOperationOutcome()
+                else -> e.toOperationOutcome()
+            }
+            outcome.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
+            outcomes.add(outcome)
+            copyWith(result)
+        }
+    }
+
+    /**
+     * Returns this result unchanged when [expression] evaluates to `true` against the current
+     * head value.
+     *
+     * When [expression] evaluates to `false`, records a WARNING-severity [OperationOutcome]
+     * with [message] as diagnostics. When the head is `null` or not a FHIR [Base] resource,
+     * also records a WARNING indicating that the expression could not be evaluated.
+     *
+     * [expression] is evaluated against the head resource directly, so write it as a relative
+     * path (e.g. `"active = true"`, not `"Patient.active = true"`).
+     *
+     * On expression evaluation exception, records a WARNING and returns unchanged
+     * (Pattern B — head-preserving).
+     */
+    fun guardPath(expression: String, message: String): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val head = result
+        if (head !is Base) {
+            val outcome = OperationOutcome().apply {
+                addIssue().apply {
+                    severity = OperationOutcome.IssueSeverity.WARNING
+                    code = OperationOutcome.IssueType.BUSINESSRULE
+                    diagnostics = "guardPath: head value is not a FHIR resource; expression '$expression' could not be evaluated"
+                }
+            }
+            outcomes.add(outcome)
+            return copyWith(result)
+        }
+        return try {
+            if (FhirPathHelper.matches(head, expression)) {
+                copyWith(result)
+            } else {
+                val outcome = OperationOutcome().apply {
+                    addIssue().apply {
+                        severity = OperationOutcome.IssueSeverity.WARNING
+                        code = OperationOutcome.IssueType.BUSINESSRULE
+                        diagnostics = message
+                    }
+                }
+                outcomes.add(outcome)
+                copyWith(result)
+            }
+        } catch (e: Exception) {
+            logger.warn("FHIRMason | step='guardPath' | WARN: {}", e.message)
+            val outcome = when (e) {
+                is BaseServerResponseException -> e.toOperationOutcome()
+                else -> e.toOperationOutcome()
+            }
+            outcome.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
+            outcomes.add(outcome)
+            copyWith(result)
+        }
+    }
+
+    // ── FHIRPath extraction ───────────────────────────────────────────────
+
+    /**
+     * Evaluates [expression] against the current head resource, promotes the first matching
+     * result of type [type] to the new head, and stores it under [name] (or [expression] when
+     * [name] is `null`).
+     *
+     * Error handling follows Pattern A: if the head is `null` or not a [Base], if the
+     * expression matches no values of [type], or if the expression is malformed, an
+     * ERROR-severity [OperationOutcome] is recorded and the head is skipped.
+     *
+     * [expression] is evaluated against the head resource directly, so write it as a relative
+     * path (e.g. `"name.where(use='official').first()"`, not `"Patient.name…"`).
+     *
+     * Use the reified overload to avoid passing [type] explicitly:
+     * `result.selectByPath<HumanName>("name.first()")`
+     */
+    @JvmOverloads
+    fun <R : Base> selectByPath(type: KClass<R>, expression: String, name: String? = null): OperationResult<R> {
+        val stepName = name ?: expression
+        return runBuilderStep(stepName) { start ->
+            val head = result
+            require(head is Base) { "selectByPath: head value is not a FHIR resource" }
+            val match = FhirPathHelper.evaluateFirst(head, expression, type.java)
+                ?: error("selectByPath: expression '$expression' matched no ${type.simpleName} values")
+            storeAndCopy(name, match, start)
+        }
+    }
+
+    /** Reified overload of [selectByPath] — no [KClass] argument needed at call sites. */
+    inline fun <reified R : Base> selectByPath(expression: String, name: String? = null): OperationResult<R> =
+        selectByPath(R::class, expression, name)
 
     /** Returns the first value stored under [name], or `null` if the key is absent or empty. */
     fun takeFirst(name: String): Base? = parameters[name]?.firstOrNull()

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -565,8 +565,8 @@ class OperationResult<T> private constructor(
     /**
      * Searches **all** accumulated parameters for instances of [type] where [expression]
      * evaluates to `true` (using [FhirPathHelper.matches] semantics), passes the typed list
-     * to [builder], and stores the single result under [name] (or [type]'s simple name
-     * lowercase when [name] is `null`).
+     * to [builder], and stores the single result under [name] (or the builder result's
+     * [Base.fhirType] lowercase when [name] is `null` — consistent with [add]).
      *
      * Error handling follows Pattern A: exceptions (including malformed FHIRPath syntax)
      * record an ERROR-severity [OperationOutcome] and skip the head value.
@@ -585,13 +585,14 @@ class OperationResult<T> private constructor(
     ): OperationResult<R> {
         val stepName = name ?: type.java.simpleName.lowercase()
         return runBuilderStep(stepName) { start ->
-            storeAndCopy(stepName, builder(collectByPath(type, expression)), start)
+            storeAndCopy(name, builder(collectByPath(type, expression)), start)
         }
     }
 
     /**
      * Like [addFromMatching] but [builder] returns a `List<R>`.
-     * The output name defaults to [type]'s simple name (lowercase) when [name] is `null`.
+     * When [name] is `null`, the output key defaults to the first element's [Base.fhirType]
+     * (lowercase) — consistent with [addAll].
      */
     @JvmOverloads
     fun <I : Base, R : Base> addAllFromMatching(
@@ -602,7 +603,7 @@ class OperationResult<T> private constructor(
     ): OperationResult<List<R>> {
         val stepName = name ?: type.java.simpleName.lowercase()
         return runBuilderStep(stepName) { start ->
-            storeListAndCopy(stepName, builder(collectByPath(type, expression)), start)
+            storeListAndCopy(name, builder(collectByPath(type, expression)), start)
         }
     }
 

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultFhirPathTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultFhirPathTest.kt
@@ -50,6 +50,18 @@ class OperationResultFhirPathTest {
     }
 
     @Test
+    fun `addFromMatching without explicit name uses output fhirType as key`() {
+        val patient = Patient().apply { active = true }
+
+        val result = OperationResult.of(patient)
+            .addFromMatching<Patient, StringType>(expression = "active = true") { StringType("found") }
+
+        // Key is the output fhirType ("string"), NOT the input type name ("patient")
+        assertThat(result.getAll("string"), hasSize(1))
+        assertThat(result.getAll("patient"), hasSize(1)) // only the original patient, not the StringType
+    }
+
+    @Test
     fun `addFromMatching with explicit name stores result under that key`() {
         val patient = Patient().apply { active = true }
 

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultFhirPathTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultFhirPathTest.kt
@@ -1,0 +1,336 @@
+package dev.ratkay.operation
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.empty
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.notNullValue
+import org.hl7.fhir.r4.model.HumanName
+import org.hl7.fhir.r4.model.Observation
+import org.hl7.fhir.r4.model.OperationOutcome
+import org.hl7.fhir.r4.model.Patient
+import org.hl7.fhir.r4.model.StringType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class OperationResultFhirPathTest {
+
+    // ── addFromMatching ────────────────────────────────────────────────────
+
+    @Test
+    fun `addFromMatching filters accumulated resources to those where expression is true`() {
+        val activePatient = Patient().apply { active = true; setId("p1") }
+        val inactivePatient = Patient().apply { active = false; setId("p2") }
+
+        val result = OperationResult.of(activePatient)
+            .add { inactivePatient }
+            .addFromMatching<Patient, StringType>("result", Patient::class, "active = true") { matches ->
+                assertThat(matches, hasSize(1))
+                assertThat(matches[0].idPart, `is`("p1"))
+                StringType("found")
+            }
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getAll("result"), hasSize(1))
+    }
+
+    @Test
+    fun `addFromMatching with no matches passes empty list to builder`() {
+        val patient = Patient().apply { active = false }
+
+        val result = OperationResult.of(patient)
+            .addFromMatching<Patient, StringType>("result", Patient::class, "active = true") { matches ->
+                assertThat(matches, empty())
+                StringType("none")
+            }
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getAll("result"), hasSize(1))
+    }
+
+    @Test
+    fun `addFromMatching with explicit name stores result under that key`() {
+        val patient = Patient().apply { active = true }
+
+        val result = OperationResult.of(patient)
+            .addFromMatching("active-patients", Patient::class, "active = true") { StringType("ok") }
+
+        assertThat(result.getAll("active-patients"), hasSize(1))
+    }
+
+    @Test
+    fun `addFromMatching with identifier expression filters correctly`() {
+        val patientWithId = Patient().apply {
+            active = true
+            addIdentifier().apply { system = "http://example.org/mpi"; value = "123" }
+        }
+        val patientWithoutId = Patient().apply { active = true }
+
+        val result = OperationResult.of(patientWithId)
+            .add { patientWithoutId }
+            .addFromMatching<Patient, StringType>(
+                "has-id",
+                Patient::class,
+                "identifier.where(system = 'http://example.org/mpi').exists()"
+            ) { matches ->
+                assertThat(matches, hasSize(1))
+                StringType("found")
+            }
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getAll("has-id"), hasSize(1))
+    }
+
+    @Test
+    fun `addFromMatching with malformed expression records ERROR outcome`() {
+        val patient = Patient().apply { active = true }
+
+        val result = OperationResult.of(patient)
+            .addFromMatching<Patient, StringType>("out", Patient::class, "(((invalid") { StringType("x") }
+
+        assertTrue(result.hasErrors())
+        assertThat(result.getOutcomes(), hasSize(1))
+        assertEquals(
+            OperationOutcome.IssueSeverity.ERROR,
+            result.getOutcomes().first().issueFirstRep.severity
+        )
+    }
+
+    @Test
+    fun `addFromMatching filters only resources of the specified type`() {
+        val patient = Patient().apply { active = true }
+        val observation = Observation().apply { setId("obs1") }
+
+        val result = OperationResult.of(patient)
+            .add { observation }
+            .addFromMatching<Patient, StringType>("result", Patient::class, "active = true") { matches ->
+                assertThat(matches, hasSize(1))
+                StringType("patients-only")
+            }
+
+        assertTrue(result.isSuccessful())
+    }
+
+    // ── addAllFromMatching ─────────────────────────────────────────────────
+
+    @Test
+    fun `addAllFromMatching returns all matching resources as list`() {
+        val p1 = Patient().apply { active = true; setId("p1") }
+        val p2 = Patient().apply { active = true; setId("p2") }
+        val p3 = Patient().apply { active = false; setId("p3") }
+
+        val result = OperationResult.of(p1)
+            .add { p2 }
+            .add { p3 }
+            .addAllFromMatching<Patient, Patient>("active", Patient::class, "active = true") { it }
+
+        assertTrue(result.isSuccessful())
+        val patients = result.getResult()
+        assertThat(patients, hasSize(2))
+    }
+
+    @Test
+    fun `addAllFromMatching with explicit name stores under that key`() {
+        val patient = Patient().apply { active = true }
+
+        val result = OperationResult.of(patient)
+            .addAllFromMatching("active", Patient::class, "active = true") { it }
+
+        assertThat(result.getAll("active"), hasSize(1))
+    }
+
+    // ── whenPath ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `whenPath runs block when expression evaluates to true`() {
+        val patient = Patient().apply { active = true }
+
+        val result = OperationResult.of(patient)
+            .whenPath("active = true") { add("flag") { StringType("ran") } }
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getAll("flag"), hasSize(1))
+    }
+
+    @Test
+    fun `whenPath skips block when expression evaluates to false`() {
+        val patient = Patient().apply { active = false }
+
+        val result = OperationResult.of(patient)
+            .whenPath("active = true") { add("flag") { StringType("should-not-run") } }
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getAll("flag"), empty())
+    }
+
+    @Test
+    fun `whenPath skips block silently when head is null`() {
+        val result = OperationResult.empty()
+            .whenPath("active = true") { add("flag") { StringType("should-not-run") } }
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getAll("flag"), empty())
+    }
+
+    @Test
+    fun `whenPath records WARNING when expression is malformed`() {
+        val patient = Patient().apply { active = true }
+
+        val result = OperationResult.of(patient)
+            .whenPath("(((invalid") { add("flag") { StringType("x") } }
+
+        assertTrue(result.hasErrors())
+        assertEquals(
+            OperationOutcome.IssueSeverity.WARNING,
+            result.getOutcomes().first().issueFirstRep.severity
+        )
+    }
+
+    @Test
+    fun `whenPath merges parameters from block into result`() {
+        val patient = Patient().apply { active = true }
+
+        val result = OperationResult.of(patient)
+            .whenPath("active = true") {
+                add("flag") { StringType("active") }
+                    .add("note") { StringType("ok") }
+            }
+
+        assertThat(result.getAll("flag"), hasSize(1))
+        assertThat(result.getAll("note"), hasSize(1))
+    }
+
+    // ── guardPath ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `guardPath passes through when expression evaluates to true`() {
+        val patient = Patient().apply { active = true }
+
+        val result = OperationResult.of(patient)
+            .guardPath("active = true", "Patient must be active")
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getOutcomes(), empty())
+    }
+
+    @Test
+    fun `guardPath adds WARNING when expression evaluates to false`() {
+        val patient = Patient().apply { active = false }
+
+        val result = OperationResult.of(patient)
+            .guardPath("active = true", "Patient must be active")
+
+        assertTrue(result.hasErrors())
+        val issue = result.getOutcomes().first().issueFirstRep
+        assertEquals(OperationOutcome.IssueSeverity.WARNING, issue.severity)
+        assertEquals("Patient must be active", issue.diagnostics)
+    }
+
+    @Test
+    fun `guardPath adds WARNING when head is null`() {
+        val result = OperationResult.empty()
+            .guardPath("active = true", "Patient must be active")
+
+        assertTrue(result.hasErrors())
+        assertEquals(
+            OperationOutcome.IssueSeverity.WARNING,
+            result.getOutcomes().first().issueFirstRep.severity
+        )
+    }
+
+    @Test
+    fun `guardPath adds WARNING when expression is malformed`() {
+        val patient = Patient().apply { active = true }
+
+        val result = OperationResult.of(patient)
+            .guardPath("(((invalid", "guard message")
+
+        assertTrue(result.hasErrors())
+        assertEquals(
+            OperationOutcome.IssueSeverity.WARNING,
+            result.getOutcomes().first().issueFirstRep.severity
+        )
+    }
+
+    @Test
+    fun `guardPath preserves head and pipeline continues in ACCUMULATE mode`() {
+        val patient = Patient().apply { active = false }
+
+        val result = OperationResult.of(patient, errorStrategy = ErrorStrategy.ACCUMULATE)
+            .guardPath("active = true", "not active")
+            .add("note") { StringType("after-guard") }
+
+        // WARNING is recorded but pipeline continues because ACCUMULATE does not skip steps
+        assertTrue(result.hasErrors())
+        assertThat(result.getAll("note"), hasSize(1))
+    }
+
+    // ── selectByPath ──────────────────────────────────────────────────────
+
+    @Test
+    fun `selectByPath promotes first matching sub-element to head`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith"; addGiven("John") }
+        }
+
+        val result = OperationResult.of(patient)
+            .selectByPath<HumanName>("name.first()")
+
+        assertTrue(result.isSuccessful())
+        val name = result.getResult()
+        assertThat(name, notNullValue())
+        assertEquals("Smith", name.family)
+    }
+
+    @Test
+    fun `selectByPath stores result under explicit name`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+        }
+
+        val result = OperationResult.of(patient)
+            .selectByPath(HumanName::class, "name.first()", "official-name")
+
+        assertThat(result.getAll("official-name"), hasSize(1))
+    }
+
+    @Test
+    fun `selectByPath records ERROR when expression matches nothing`() {
+        val patient = Patient()
+
+        val result = OperationResult.of(patient)
+            .selectByPath<HumanName>("name.first()")
+
+        assertTrue(result.hasErrors())
+        assertEquals(
+            OperationOutcome.IssueSeverity.ERROR,
+            result.getOutcomes().first().issueFirstRep.severity
+        )
+    }
+
+    @Test
+    fun `selectByPath records ERROR when head is null`() {
+        val result = OperationResult.empty()
+            .selectByPath<HumanName>("name.first()")
+
+        assertTrue(result.hasErrors())
+        assertEquals(
+            OperationOutcome.IssueSeverity.ERROR,
+            result.getOutcomes().first().issueFirstRep.severity
+        )
+    }
+
+    @Test
+    fun `selectByPath extracts StringType family name`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+        }
+
+        val result = OperationResult.of(patient)
+            .selectByPath<StringType>("name.family")
+
+        assertTrue(result.isSuccessful())
+        assertEquals("Smith", result.getResult().value)
+    }
+}

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultTest.kt
@@ -424,6 +424,31 @@ class OperationResultTest {
     }
 
     @Test
+    fun `addFromHavingAllExtensions unnamed overload stores result under output fhirType not input type`() {
+        val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
+        val result = OperationResult.of(listOf(enrolled, patient()), "patients")
+            .addFromHavingAllExtensions(Patient::class, "http://example.org/enrolled") { _ ->
+                OperationOutcome().apply { addIssue().diagnostics = "found" }
+            }
+
+        // Key must be "operationoutcome" (output fhirType), NOT "patient" (input type)
+        assertThat(result.getAll("operationoutcome"), hasSize(1))
+        assertFalse(result.containsKey("patient"))
+    }
+
+    @Test
+    fun `addFromHavingAnyExtension unnamed overload stores result under output fhirType not input type`() {
+        val hasExt = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
+        val result = OperationResult.of(listOf(hasExt, patient()), "patients")
+            .addFromHavingAnyExtension(Patient::class, "http://example.org/url1") { _ ->
+                OperationOutcome().apply { addIssue().diagnostics = "found" }
+            }
+
+        assertThat(result.getAll("operationoutcome"), hasSize(1))
+        assertFalse(result.containsKey("patient"))
+    }
+
+    @Test
     fun `addFromHavingAllExtensions named overload stores result under explicit name`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
@@ -447,6 +472,31 @@ class OperationResultTest {
             }
 
         assertThat(result.getResult(), hasSize(1))
+    }
+
+    @Test
+    fun `addAllFromHavingAllExtensions unnamed overload stores results under output fhirType not input type`() {
+        val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
+        val result = OperationResult.of(listOf(enrolled, patient()), "patients")
+            .addAllFromHavingAllExtensions(Patient::class, "http://example.org/enrolled") { filtered ->
+                filtered.map { OperationOutcome() }
+            }
+
+        assertThat(result.getAll("operationoutcome"), hasSize(1))
+        assertFalse(result.containsKey("patient"))
+    }
+
+    @Test
+    fun `addAllFromHavingAnyExtension unnamed overload stores results under output fhirType not input type`() {
+        val hasFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
+        val hasSecond = patient().apply { addExtension("http://example.org/url2", StringType("b")) }
+        val result = OperationResult.of(listOf(hasFirst, hasSecond, patient()), "patients")
+            .addAllFromHavingAnyExtension(Patient::class, "http://example.org/url1", "http://example.org/url2") { filtered ->
+                filtered.map { OperationOutcome() }
+            }
+
+        assertThat(result.getAll("operationoutcome"), hasSize(2))
+        assertFalse(result.containsKey("patient"))
     }
 
     // ── Extension URL + value-type / value-predicate filters ─────────────────
@@ -587,6 +637,30 @@ class OperationResultTest {
             }
 
         assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingExtensionValueMatching unnamed overload stores result under output fhirType not input type`() {
+        val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
+        val result = OperationResult.of(listOf(enrolled, patient()), "patients")
+            .addFromHavingExtensionValueMatching(Patient::class, "http://example.org/enrolled", StringType::class, { it.value == "true" }) { _ ->
+                OperationOutcome().apply { addIssue().diagnostics = "found" }
+            }
+
+        assertThat(result.getAll("operationoutcome"), hasSize(1))
+        assertFalse(result.containsKey("patient"))
+    }
+
+    @Test
+    fun `addAllFromHavingExtensionValueMatching unnamed overload stores results under output fhirType not input type`() {
+        val high = patient().apply { addExtension("http://example.org/priority", IntegerType(10)) }
+        val result = OperationResult.of(listOf(high, patient()), "patients")
+            .addAllFromHavingExtensionValueMatching(Patient::class, "http://example.org/priority", IntegerType::class, { it.value > 5 }) { filtered ->
+                filtered.map { OperationOutcome() }
+            }
+
+        assertThat(result.getAll("operationoutcome"), hasSize(1))
+        assertFalse(result.containsKey("patient"))
     }
 
     // ── Query methods ─────────────────────────────────────────────────────────

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,11 @@
                 <artifactId>hapi-fhir-server</artifactId>
                 <version>${hapi.fhir.version}</version>
             </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>hapi-fhir-caching-guava</artifactId>
+                <version>${hapi.fhir.version}</version>
+            </dependency>
             <!-- Internal modules -->
             <dependency>
                 <groupId>dev.ratkay</groupId>


### PR DESCRIPTION
Introduces FhirPathHelper (internal) and five new OperationResult<T> methods that let
callers use standard FHIRPath expressions alongside the existing extension-filter API:

- addFromMatching / addAllFromMatching  — filter accumulated resources of a given type
  by a FHIRPath predicate and pass matching resources to a builder (Pattern A)
- whenPath  — run a nested pipeline block only when the head resource satisfies an
  expression (Pattern B, mirrors whenTrue)
- guardPath — record a WARNING when the head resource does not satisfy an expression
  (Pattern B, mirrors guardFalse)
- selectByPath — evaluate a FHIRPath expression against the head resource and promote
  the first matching result to the new pipeline head (Pattern A)

Also adds org.fhir:ucum and hapi-fhir-caching-guava as explicit runtime dependencies
required by the HAPI FHIR FHIRPath engine (both were optional/absent from the
transitive tree). Includes 20 new tests in OperationResultFhirPathTest.