### PR TITLE
Add complex integration tests for OperationResult and AsyncOperationResult

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,4 +130,4 @@ Run the full test suite (`mvn test`) before every commit **and** before every pu
 Keep `README.md` up to date on every branch. When a branch adds or changes a feature, update the relevant section(s) of the README before committing:
 - Add new methods to the appropriate table or code block
 - Add or update usage examples that demonstrate the new behaviour
-- Update the Project Structure section if new source files are added
+- **Update the Project Structure section whenever any file is added, removed, or renamed** — this includes test files (`src/test/…`), not just production source files. The tree in the README must exactly match the files on disk.

--- a/README.md
+++ b/README.md
@@ -1511,6 +1511,8 @@ fhirmason-core/
         ├── OperationResultMapHeadTest.kt
         ├── OperationResultFhirErrorHandlingTest.kt
         ├── OperationResultRetryTest.kt
+        ├── OperationResultFhirPathTest.kt
+        ├── OperationResultComplexTest.kt
         ├── AsyncOperationResultTest.kt
         ├── AsyncOperationResultMetricsTest.kt
         ├── AsyncOperationResultDescribeTest.kt
@@ -1521,6 +1523,7 @@ fhirmason-core/
         ├── AsyncOperationResultDagTimeoutTest.kt
         ├── AsyncOperationResultConditionalTest.kt
         ├── AsyncOperationResultDefaultTest.kt
+        ├── AsyncOperationResultComplexTest.kt
         ├── FhirDateTimeConverterTest.kt
         └── FhirExtensionHelperTest.kt
 

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/AsyncOperationResultComplexTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/AsyncOperationResultComplexTest.kt
@@ -1,0 +1,356 @@
+package dev.ratkay.operation
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.`is`
+import org.hl7.fhir.r4.model.Basic
+import org.hl7.fhir.r4.model.Bundle
+import org.hl7.fhir.r4.model.Claim
+import org.hl7.fhir.r4.model.Coverage
+import org.hl7.fhir.r4.model.Encounter
+import org.hl7.fhir.r4.model.Observation
+import org.hl7.fhir.r4.model.OperationOutcome
+import org.hl7.fhir.r4.model.Patient
+import org.hl7.fhir.r4.model.Practitioner
+import org.hl7.fhir.r4.model.Reference
+import org.hl7.fhir.r4.model.StringType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Complex integration tests for [AsyncOperationResult].
+ *
+ * Each test covers a non-trivial DAG topology or cross-feature interaction
+ * that is not covered by the simple per-group tests in AsyncOperationResultTest.
+ */
+class AsyncOperationResultComplexTest {
+
+    // ── Scenario 1: diamond DAG — A, B → C → D ───────────────────────────────
+
+    @Test
+    fun `diamond DAG A and B run in parallel then C waits for both and D waits for C`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("a") { delay(20); Patient().apply { id = "A" } }
+            .add("b") { delay(20); Practitioner().apply { id = "B" } }
+            .addAfter("c", "a", "b") { deps ->
+                val aId = (deps["a"]!!.first() as Patient).id
+                val bId = (deps["b"]!!.first() as Practitioner).id
+                Basic().apply { id = "$aId+$bId" }
+            }
+            .addAfter("d", "c", Basic::class) { c ->
+                Encounter().apply { id = "D-from-${c.id}" }
+            }
+            .run()
+
+        assertThat(result.getKeys(), containsInAnyOrder("a", "b", "c", "d"))
+
+        val c = result.getAll("c").first() as Basic
+        assertThat(c.id, `is`("A+B"))
+
+        val d = result.getAll("d").first() as Encounter
+        assertThat(d.id, `is`("D-from-A+B"))
+
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `diamond DAG A and B execute concurrently — total wall time is less than A plus B`() = runBlocking {
+        val start = System.currentTimeMillis()
+
+        AsyncOperationResult()
+            .add("a") { delay(80); Patient() }
+            .add("b") { delay(80); Practitioner() }
+            .addAfter("c", "a", "b") { Basic() }
+            .run()
+
+        val elapsed = System.currentTimeMillis() - start
+        // If A and B ran sequentially we'd need ~160 ms; concurrently ~80 ms.
+        // Allow generous headroom for CI variance but rule out sequential execution.
+        assertTrue(elapsed < 150, "Expected concurrent execution but elapsed was ${elapsed}ms")
+    }
+
+    // ── Scenario 2: wide fan-in — 5 independent tasks → 1 collector ──────────
+
+    @Test
+    fun `five independent tasks all feed into a single collector task`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("t1") { Patient().apply { id = "1" } }
+            .add("t2") { Patient().apply { id = "2" } }
+            .add("t3") { Patient().apply { id = "3" } }
+            .add("t4") { Patient().apply { id = "4" } }
+            .add("t5") { Patient().apply { id = "5" } }
+            .addAfter("collector", "t1", "t2", "t3", "t4", "t5") { deps ->
+                val ids = (1..5).map { i -> (deps["t$i"]!!.first() as Patient).id }
+                Basic().apply { id = ids.joinToString(",") }
+            }
+            .run()
+
+        assertThat(result.totalCount(), `is`(6))
+        val collector = result.getAll("collector").first() as Basic
+        assertThat(collector.id, `is`("1,2,3,4,5"))
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `five independent tasks run concurrently — wall time is less than sum of all`() = runBlocking {
+        val start = System.currentTimeMillis()
+
+        AsyncOperationResult()
+            .add("t1") { delay(60); Patient() }
+            .add("t2") { delay(60); Patient() }
+            .add("t3") { delay(60); Patient() }
+            .add("t4") { delay(60); Patient() }
+            .add("t5") { delay(60); Patient() }
+            .addAfter("collector", "t1", "t2", "t3", "t4", "t5") { Basic() }
+            .run()
+
+        val elapsed = System.currentTimeMillis() - start
+        // Sequential would be 300 ms; concurrent should be ~60 ms.
+        assertTrue(elapsed < 220, "Expected concurrent execution but elapsed was ${elapsed}ms")
+    }
+
+    // ── Scenario 3: five-level linear cascade A → B → C → D → E ─────────────
+
+    @Test
+    fun `five-level linear chain passes data through correctly at every level`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("a") { Patient().apply { id = "A" } }
+            .addAfter("b", "a", Patient::class) { a ->
+                Patient().apply { id = "${a.id}-B" }
+            }
+            .addAfter("c", "b", Patient::class) { b ->
+                Patient().apply { id = "${b.id}-C" }
+            }
+            .addAfter("d", "c", Patient::class) { c ->
+                Patient().apply { id = "${c.id}-D" }
+            }
+            .addAfter("e", "d", Patient::class) { d ->
+                StringType("${d.id}-E")
+            }
+            .run()
+
+        assertThat(result.getKeys(), containsInAnyOrder("a", "b", "c", "d", "e"))
+
+        val e = result.getAll("e").first() as StringType
+        assertThat(e.value, `is`("A-B-C-D-E"))
+        assertFalse(result.hasErrors())
+    }
+
+    // ── Scenario 4: failure at tier 2 cascades to tiers 3 and 4 ─────────────
+
+    @Test
+    fun `failure at tier-2 skips all downstream dependents while independent task succeeds`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("a") { Patient().apply { id = "ok" } }   // tier 1, independent, succeeds
+            .add("b") { error("tier-2 boom") }             // tier 1, independent, fails
+            .addAfter("c", "b") { Basic() }                // depends on b — must be skipped
+            .addAfter("d", "c") { Basic() }                // depends on c — must be skipped
+            .run()
+
+        // Independent task not in the failure chain succeeds
+        assertTrue(result.containsKey("a"))
+
+        // Failed task and all dependents are absent
+        assertFalse(result.containsKey("b"))
+        assertFalse(result.containsKey("c"))
+        assertFalse(result.containsKey("d"))
+
+        // All three (b, c, d) appear in failedTasks
+        assertThat(result.getFailedTasks().keys, containsInAnyOrder("b", "c", "d"))
+        assertTrue(result.hasErrors())
+    }
+
+    // ── Scenario 5: partial failure — one branch fails, sibling branch succeeds
+
+    @Test
+    fun `partial failure — failing branch does not affect independent sibling branch`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("a") { error("a fails") }                                       // fails
+            .add("b") { Patient().apply { id = "B" } }                           // succeeds
+            .addAfter("c", "a", Patient::class) { Patient().apply { id = "C" } } // skipped (a failed)
+            .addAfter("d", "b", Patient::class) { p ->
+                Encounter().apply { id = "D-${p.id}" }
+            }                                                                      // succeeds (b ok)
+            .run()
+
+        // Successful branch
+        assertTrue(result.containsKey("b"))
+        assertTrue(result.containsKey("d"))
+        val d = result.getAll("d").first() as Encounter
+        assertThat(d.id, `is`("D-B"))
+
+        // Failed branch
+        assertFalse(result.containsKey("a"))
+        assertFalse(result.containsKey("c"))
+        assertThat(result.getFailedTasks().keys, containsInAnyOrder("a", "c"))
+    }
+
+    // ── Scenario 6: DAG merge with cross-DAG dependency ──────────────────────
+
+    @Test
+    fun `outer task and inner merged task used together in a post-merge dependent task`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .merge {
+                AsyncOperationResult()
+                    .add("coverage") { Coverage().apply { id = "c1" } }
+            }
+            .addAfter("claim", "patient", "coverage") { deps ->
+                val patId = (deps["patient"]!!.first() as Patient).id
+                val covId = (deps["coverage"]!!.first() as Coverage).id
+                Claim().apply { id = "$patId+$covId" }
+            }
+            .run()
+
+        assertThat(result.getKeys(), containsInAnyOrder("patient", "coverage", "claim"))
+
+        val claim = result.getAll("claim").first() as Claim
+        assertThat(claim.id, `is`("p1+c1"))
+        assertFalse(result.hasErrors())
+    }
+
+    // ── Scenario 7: retry in DAG — retried task feeds a dependent ────────────
+
+    @Test
+    fun `retried async task eventually succeeds and its dependent task receives the correct value`() = runBlocking {
+        var attempts = 0
+
+        val result = AsyncOperationResult()
+            .addWithRetry("patient", maxAttempts = 3, initialDelayMs = 0) {
+                attempts++
+                if (attempts < 3) error("transient failure attempt $attempts")
+                Patient().apply { id = "retried-p1" }
+            }
+            .addAfter("encounter", "patient", Patient::class) { p ->
+                Encounter().apply { id = "enc-${p.id}" }
+            }
+            .run()
+
+        assertEquals(3, attempts)
+        assertTrue(result.containsKey("patient"))
+        assertTrue(result.containsKey("encounter"))
+
+        val enc = result.getAll("encounter").first() as Encounter
+        assertThat(enc.id, `is`("enc-retried-p1"))
+        assertFalse(result.hasErrors())
+    }
+
+    // ── Scenario 8: type-safe addAfter chained three levels deep ─────────────
+
+    @Test
+    fun `type-safe addAfter chained three levels receives correctly typed resource at each level`() = runBlocking {
+        var patientReceived: Patient? = null
+        var encounterReceived: Encounter? = null
+        var observationReceived: Observation? = null
+
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "P" } }
+            .addAfter("encounter", "patient", Patient::class) { p ->
+                patientReceived = p
+                Encounter().apply { id = "E-from-${p.id}" }
+            }
+            .addAfter("observation", "encounter", Encounter::class) { e ->
+                encounterReceived = e
+                Observation().apply { id = "O-from-${e.id}" }
+            }
+            .addAfter("outcome", "observation", Observation::class) { obs ->
+                observationReceived = obs
+                OperationOutcome().apply {
+                    addIssue().diagnostics = "processed-${obs.id}"
+                }
+            }
+            .run()
+
+        // Each level received the correctly typed resource
+        assertEquals("P", patientReceived!!.id)
+        assertEquals("E-from-P", encounterReceived!!.id)
+        assertEquals("O-from-E-from-P", observationReceived!!.id)
+
+        // Final outcome diagnostics confirm the chain
+        val oo = result.getAll("outcome").first() as OperationOutcome
+        assertThat(oo.issueFirstRep.diagnostics, `is`("processed-O-from-E-from-P"))
+
+        assertFalse(result.hasErrors())
+    }
+
+    // ── Scenario 9: post-processing async result with OperationResult pipeline ─
+
+    @Test
+    fun `async DAG result is post-processed with sync OperationResult pipeline to produce a Bundle`() = runBlocking {
+        val asyncResult = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1"; active = true } }
+            .addList("observations") {
+                listOf(
+                    Observation().apply { id = "obs1"; status = Observation.ObservationStatus.FINAL },
+                    Observation().apply { id = "obs2"; status = Observation.ObservationStatus.FINAL }
+                )
+            }
+            .run()
+
+        // Post-process: link observation subjects to patient, then bundle everything
+        val encounterRule = ReferenceLinkRule(
+            sourceType = Observation::class,
+            targetType = Patient::class,
+            setter = { obs, p -> obs.subject = Reference("Patient/${p.idPart}") }
+        )
+
+        val bundle = asyncResult
+            .linkReferences(encounterRule)
+            .toBundle(Bundle.BundleType.COLLECTION)
+
+        // Bundle contains all three resources
+        assertThat(bundle.entry, hasSize(3))
+
+        // Observations have their subject wired to the patient
+        val observations = bundle.entry
+            .map { it.resource }
+            .filterIsInstance<Observation>()
+        assertThat(observations, hasSize(2))
+        observations.forEach { obs ->
+            assertEquals("Patient/p1", obs.subject.reference)
+        }
+    }
+
+    // ── Scenario 10: metrics — three parallel tasks, total ≈ max(individual) ─
+
+    @Test
+    fun `timed DAG with three parallel tasks reports per-task metrics and total near max not sum`() {
+        val dag = AsyncOperationResult()
+            .timed()
+            .add("t1") { Thread.sleep(60); Patient().apply { id = "1" } }
+            .add("t2") { Thread.sleep(60); Patient().apply { id = "2" } }
+            .add("t3") { Thread.sleep(60); Patient().apply { id = "3" } }
+
+        dag.runBlocking()
+
+        val metrics = dag.getMetrics()
+        assertEquals(3, metrics.size)
+        assertTrue(metrics.containsKey("t1"))
+        assertTrue(metrics.containsKey("t2"))
+        assertTrue(metrics.containsKey("t3"))
+
+        // All tasks succeeded
+        assertTrue(metrics["t1"]!!.success)
+        assertTrue(metrics["t2"]!!.success)
+        assertTrue(metrics["t3"]!!.success)
+
+        // Each individual task took at least the sleep duration
+        assertTrue(metrics["t1"]!!.durationMs >= 50)
+        assertTrue(metrics["t2"]!!.durationMs >= 50)
+        assertTrue(metrics["t3"]!!.durationMs >= 50)
+
+        // Total wall-clock duration should be well under the sum (3 × 60 ms = 180 ms)
+        // because tasks run in parallel. Allow generous headroom for CI.
+        assertTrue(dag.getTotalDuration() < 220, "Expected parallel execution but total was ${dag.getTotalDuration()}ms")
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    @Suppress("unused")
+    private fun patient(id: String) = Patient().apply { setId(id) }
+}

--- a/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultComplexTest.kt
+++ b/fhirmason-core/src/test/java/dev/ratkay/operation/OperationResultComplexTest.kt
@@ -1,0 +1,451 @@
+package dev.ratkay.operation
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.instanceOf
+import org.hl7.fhir.r4.model.BooleanType
+import org.hl7.fhir.r4.model.Bundle
+import org.hl7.fhir.r4.model.Coverage
+import org.hl7.fhir.r4.model.Encounter
+import org.hl7.fhir.r4.model.Observation
+import org.hl7.fhir.r4.model.OperationOutcome
+import org.hl7.fhir.r4.model.Patient
+import org.hl7.fhir.r4.model.Reference
+import org.hl7.fhir.r4.model.StringType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Complex integration tests for [OperationResult].
+ *
+ * Each test exercises multiple API methods together in non-trivial combinations
+ * designed to reveal emergent behaviour that simple per-method tests cannot catch.
+ */
+class OperationResultComplexTest {
+
+    // ── Scenario 1: extension filter → list mapping → serialise → round-trip ─
+
+    @Test
+    fun `enrolled patients are filtered, observations created, bundle serialised and round-tripped correctly`() {
+        val p1 = patient("p1").apply { addExtension("http://example.org/enrolled", BooleanType(true)) }
+        val p2 = patient("p2").apply { addExtension("http://example.org/enrolled", BooleanType(true)) }
+        val p3 = patient("p3") // not enrolled — must be excluded
+
+        val result = OperationResult.of(listOf(p1, p2, p3), "patients")
+            .addAllFromHavingExtensionValueMatching(
+                Patient::class,
+                "http://example.org/enrolled",
+                BooleanType::class,
+                { it.booleanValue() }
+            ) { enrolled ->
+                enrolled.map { p ->
+                    Observation().apply {
+                        id = "obs-${p.idPart}"
+                        status = Observation.ObservationStatus.FINAL
+                    }
+                }
+            }
+
+        // Sanity-check before serialisation
+        assertEquals(3, result.count("patients"))
+        assertEquals(2, result.count("observation"))
+        assertTrue(result.isSuccessful())
+
+        // Serialise → deserialise
+        val bundle = result.toBundle(Bundle.BundleType.COLLECTION)
+        val restored = OperationResult.fromBundle(bundle)
+
+        assertEquals(3, restored.count("patient"))
+        assertEquals(2, restored.count("observation"))
+        assertTrue(restored.isSuccessful())
+        assertThat(restored.getByType<Observation>(), hasSize(2))
+    }
+
+    // ── Scenario 2: error accumulation across 6 steps ────────────────────────
+
+    @Test
+    fun `ACCUMULATE strategy collects all errors while successful steps still produce values`() {
+        val result = OperationResult.of(patient("p1"), "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+            .add("step1") { Observation().apply { id = "obs1" } }
+            .add("step2") { error("step2 failed") }
+            .add("step3") { Encounter().apply { id = "enc1" } }
+            .add("step4") { error("step4 failed") }
+            .add("step5") { Coverage().apply { id = "cov1" } }
+            .add("step6") { Observation().apply { id = "obs2" } }
+
+        // Successful steps are present
+        assertTrue(result.containsKey("step1"))
+        assertTrue(result.containsKey("step3"))
+        assertTrue(result.containsKey("step5"))
+        assertTrue(result.containsKey("step6"))
+
+        // Failed steps produce no value
+        assertFalse(result.containsKey("step2"))
+        assertFalse(result.containsKey("step4"))
+
+        // Exactly two ERROR outcomes accumulated
+        assertEquals(2, result.getOutcomes().size)
+        assertTrue(result.hasErrors())
+        assertFalse(result.isSuccessful())
+        result.getOutcomes().forEach { outcome ->
+            assertEquals(OperationOutcome.IssueSeverity.ERROR, outcome.issueFirstRep.severity)
+        }
+    }
+
+    // ── Scenario 3: FAIL_FAST halts chain at first error ─────────────────────
+
+    @Test
+    fun `FAIL_FAST stops pipeline at first error and subsequent lambdas are never executed`() {
+        var step3Executed = false
+        var step4Executed = false
+        var step5Executed = false
+
+        val result = OperationResult.of(patient("p1"), "patient") // FAIL_FAST by default
+            .add("step1") { Observation().apply { id = "obs1" } }
+            .add("step2") { error("step2 failed") }
+            .add("step3") { step3Executed = true; Encounter() }
+            .add("step4") { step4Executed = true; Coverage() }
+            .add("step5") { step5Executed = true; Observation() }
+
+        // Step before failure is present; all after are absent
+        assertTrue(result.containsKey("step1"))
+        assertFalse(result.containsKey("step3"))
+        assertFalse(result.containsKey("step4"))
+        assertFalse(result.containsKey("step5"))
+
+        // Lambdas after the failure were never called
+        assertFalse(step3Executed)
+        assertFalse(step4Executed)
+        assertFalse(step5Executed)
+
+        // Exactly one ERROR outcome
+        assertEquals(1, result.getOutcomes().size)
+    }
+
+    // ── Scenario 4: nested flatMap chaining across three resource types ────────
+
+    @Test
+    fun `flatMap chained twice accumulates parameters from all three pipeline levels`() {
+        val result = OperationResult.of(patient("p1"), "patient")
+            .flatMap { _ ->
+                OperationResult.of(encounter("e1"), "encounter")
+                    .addString("encounter-status", "finished")
+                    .flatMap { _ ->
+                        OperationResult.of(observation("obs1"), "observation")
+                            .addString("observation-status", "final")
+                    }
+            }
+
+        // All parameters from every level are present
+        assertTrue(result.containsKey("patient"))
+        assertTrue(result.containsKey("encounter"))
+        assertTrue(result.containsKey("encounter-status"))
+        assertTrue(result.containsKey("observation"))
+        assertTrue(result.containsKey("observation-status"))
+        assertEquals(5, result.totalCount())
+
+        // Head is the Observation (innermost result)
+        assertThat(result.getResult(), instanceOf(Observation::class.java))
+        assertFalse(result.hasErrors())
+    }
+
+    // ── Scenario 5: whenTrue nesting + guardFalse across two patient states ──
+
+    @Test
+    fun `nested whenTrue adds parameters only when both conditions are met`() {
+        val activeNamedPatient = patient("p1").apply {
+            active = true
+            addName().apply { addGiven("John"); family = "Doe" }
+        }
+
+        val result = OperationResult.of(activeNamedPatient, "patient")
+            .whenTrue(activeNamedPatient.active) {
+                addString("status", "active")
+                    .whenTrue(activeNamedPatient.hasName()) {
+                        addString("has-name", "true")
+                    }
+            }
+            .guardFalse(activeNamedPatient.active, "patient is inactive")
+
+        assertFalse(result.hasErrors())
+        assertTrue(result.containsKey("status"))
+        assertTrue(result.containsKey("has-name"))
+    }
+
+    @Test
+    fun `guardFalse records WARNING and pipeline continues in ACCUMULATE after conditional skip`() {
+        val inactivePatient = patient("p2").apply { active = false }
+
+        val result = OperationResult.of(inactivePatient, "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+            .whenTrue(inactivePatient.active) {
+                addString("status", "active") // must not run
+            }
+            .guardFalse(inactivePatient.active, "patient is inactive")
+            .add("encounter") { encounter("e1") }
+
+        // whenTrue block did not run
+        assertFalse(result.containsKey("status"))
+
+        // guardFalse added a WARNING
+        assertEquals(1, result.getOutcomes().size)
+        assertEquals(OperationOutcome.IssueSeverity.WARNING, result.getOutcomes().first().issueFirstRep.severity)
+
+        // Pipeline continues after guardFalse in ACCUMULATE mode
+        assertTrue(result.containsKey("encounter"))
+    }
+
+    // ── Scenario 6: whenPath driven by a real FHIRPath identifier expression ─
+
+    @Test
+    fun `whenPath runs block for patient with matching identifier system and skips for other`() {
+        val matchingPatient = Patient().apply {
+            setId("p1")
+            addIdentifier().apply {
+                system = "http://example.org"
+                value = "123"
+            }
+        }
+        val nonMatchingPatient = Patient().apply {
+            setId("p2")
+            addIdentifier().apply {
+                system = "http://other.org"
+                value = "456"
+            }
+        }
+
+        val matchResult = OperationResult.of(matchingPatient, "patient")
+            .whenPath("identifier.where(system = 'http://example.org').exists()") {
+                add("encounter") { encounter("enc-match") }
+            }
+
+        val skipResult = OperationResult.of(nonMatchingPatient, "patient")
+            .whenPath("identifier.where(system = 'http://example.org').exists()") {
+                add("encounter") { encounter("enc-skip") }
+            }
+
+        // Block ran for the matching patient
+        assertTrue(matchResult.containsKey("encounter"))
+        assertFalse(matchResult.hasErrors())
+
+        // Block was skipped for the non-matching patient
+        assertFalse(skipResult.containsKey("encounter"))
+        assertFalse(skipResult.hasErrors())
+    }
+
+    // ── Scenario 7: addPart nesting — nested parameters round-trip via toParameters ─
+
+    @Test
+    fun `addPart produces nested parameter structure that survives toParameters round-trip`() {
+        val result = OperationResult.of(patient("p1"), "patient")
+            .addString("status", "active")
+            .addPart("summary") {
+                addString("enrolled", "true")
+                    .addString("score", "42")
+            }
+
+        // The top-level result is successful and has outer parameters
+        assertTrue(result.isSuccessful())
+        assertTrue(result.containsKey("patient"))
+        assertTrue(result.containsKey("status"))
+
+        // Serialise to Parameters
+        val params = result.toParameters()
+        assertNotNull(params)
+
+        // The nested "summary" part is present as a top-level parameter
+        val summaryParams = params.parameter.filter { it.name == "summary" }
+        assertThat(summaryParams, hasSize(1))
+
+        // It carries its children as parts
+        val summaryParam = summaryParams.first()
+        assertFalse(summaryParam.hasValue())
+        assertFalse(summaryParam.hasResource())
+        assertThat(summaryParam.part, hasSize(2))
+
+        val partNames = summaryParam.part.map { it.name }
+        assertTrue(partNames.contains("enrolled"))
+        assertTrue(partNames.contains("score"))
+    }
+
+    // ── Scenario 8: addWithRetryUsing reads pipeline head, fails then succeeds ─
+
+    @Test
+    fun `addWithRetryUsing succeeds on third attempt using pipeline head without leaving an error outcome`() {
+        var attempts = 0
+        val basePatient = patient("p1")
+
+        val result = OperationResult.of(basePatient, "patient")
+            .addWithRetryUsing("encounter", maxAttempts = 3, initialDelayMs = 0) { p: Patient ->
+                attempts++
+                if (attempts < 3) error("transient failure attempt $attempts for ${p.idPart}")
+                encounter("enc-${p.idPart}")
+            }
+
+        assertEquals(3, attempts)
+        assertTrue(result.containsKey("encounter"))
+        assertFalse(result.hasErrors())
+
+        val enc = result.getAll("encounter").first() as Encounter
+        assertEquals("enc-p1", enc.idPart)
+    }
+
+    // ── Scenario 9: merge two independent results preserves both maps & outcomes ─
+
+    @Test
+    fun `merging two results with distinct keys combines parameter maps and accumulates outcomes`() {
+        // Both pipelines have a warning (Pattern B step failure)
+        val a = OperationResult.of(patient("p1"), "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+            .addOrSkip<Observation>("obs") { error("optional obs failed") }
+
+        val b = OperationResult.of(encounter("e1"), "encounter", errorStrategy = ErrorStrategy.ACCUMULATE)
+            .addString("status", "finished")
+
+        val merged = a.merge(b)
+
+        // All keys from both results are present
+        assertTrue(merged.containsKey("patient"))
+        assertTrue(merged.containsKey("encounter"))
+        assertTrue(merged.containsKey("status"))
+
+        // totalCount = patient(1) + encounter(1) + status(1) = 3
+        assertEquals(3, merged.totalCount())
+
+        // Outcomes from both sides are preserved
+        assertEquals(1, merged.getOutcomes().size)
+        assertEquals(OperationOutcome.IssueSeverity.WARNING, merged.getOutcomes().first().issueFirstRep.severity)
+    }
+
+    // ── Scenario 10: rename + remove + filterByName sequence ─────────────────
+
+    @Test
+    fun `rename then remove then filterByName leaves only the renamed entry in the map`() {
+        val result = OperationResult.of(patient("p1"), "a")
+            .add("b") { encounter("e1") }
+            .add("c") { observation("obs1") }
+            .add("d") { Coverage() }
+            .rename("a", "alpha")
+            .remove("b")
+            .filterByName("alpha")
+
+        // Only "alpha" survives
+        assertTrue(result.containsKey("alpha"))
+        assertFalse(result.containsKey("a"))
+        assertFalse(result.containsKey("b"))
+        assertFalse(result.containsKey("c"))
+        assertFalse(result.containsKey("d"))
+        assertEquals(1, result.totalCount())
+    }
+
+    @Test
+    fun `rename of a non-existent key is a no-op and leaves the map unchanged`() {
+        val result = OperationResult.of(patient("p1"), "patient")
+            .add("encounter") { encounter("e1") }
+            .rename("nonexistent", "something")
+
+        // Map unchanged
+        assertTrue(result.containsKey("patient"))
+        assertTrue(result.containsKey("encounter"))
+        assertFalse(result.containsKey("something"))
+        assertEquals(2, result.totalCount())
+    }
+
+    // ── Scenario 11: extension-value predicate followed by FHIRPath filter ───
+
+    @Test
+    fun `extension predicate filter combined with FHIRPath filter produces correct intersection`() {
+        val activeEnrolled = Patient().apply {
+            setId("p1")
+            active = true
+            addExtension("http://example.org/enrolled", BooleanType(true))
+        }
+        val inactiveEnrolled = Patient().apply {
+            setId("p2")
+            active = false
+            addExtension("http://example.org/enrolled", BooleanType(true))
+        }
+        val activeNotEnrolled = Patient().apply {
+            setId("p3")
+            active = true
+            // no enrolled extension
+        }
+
+        // First filter: enrolled patients only → produces List<Patient> as head
+        val afterExtFilter = OperationResult.of(listOf(activeEnrolled, inactiveEnrolled, activeNotEnrolled), "patients")
+            .addAllFromHavingExtensionValueMatching(
+                Patient::class,
+                "http://example.org/enrolled",
+                BooleanType::class,
+                { it.booleanValue() }
+            ) { enrolled ->
+                // Store enrolled patients back so FHIRPath filter can find them
+                enrolled
+            }
+
+        // afterExtFilter has 2 patients under "patient" key (from fhirType)
+        assertEquals(2, afterExtFilter.count("patient"))
+
+        // Second filter: from those enrolled, keep only active ones.
+        // filterByName("patient") drops the original "patients" key so the FHIRPath step
+        // only sees the 2 enrolled patients, not all 3 originals.
+        val finalResult = afterExtFilter
+            .filterByName("patient")
+            .addAllFromMatching<Patient, Patient>("active-enrolled", Patient::class, "active = true") { it }
+
+        assertEquals(1, finalResult.count("active-enrolled"))
+        assertFalse(finalResult.hasErrors())
+
+        val surviving = finalResult.getAll("active-enrolled").first() as Patient
+        assertEquals("p1", surviving.idPart)
+    }
+
+    // ── Scenario 12: linkReferences two rules — one resolves, one cannot ──────
+
+    @Test
+    fun `two explicit linkReferences rules — one resolves successfully, other has no target to link`() {
+        val p = patient("p1")
+        val enc = encounter("e1")
+        // No observation in the pipeline — the observation rule has no target
+
+        val encounterRule = ReferenceLinkRule(
+            sourceType = Encounter::class,
+            targetType = Patient::class,
+            setter = { e, pat -> e.subject = Reference("Patient/${pat.idPart}") }
+        )
+        val observationRule = ReferenceLinkRule(
+            sourceType = Observation::class,
+            targetType = Patient::class,
+            setter = { obs, pat -> obs.subject = Reference("Patient/${pat.idPart}") }
+        )
+
+        val linked = OperationResult.of(p, "patient")
+            .add { enc }
+            .linkReferences(encounterRule, observationRule)
+
+        // No exception — missing target is silently skipped
+        assertFalse(linked.hasErrors())
+
+        // The encounter rule resolved: subject is set
+        val linkedEnc = linked.getByType<Encounter>().single()
+        assertEquals("Patient/p1", linkedEnc.subject.reference)
+
+        // Original encounter was not mutated
+        assertFalse(enc.hasSubject())
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun patient(id: String) = Patient().apply { setId(id) }
+
+    private fun encounter(id: String) = Encounter().apply {
+        setId(id)
+        status = Encounter.EncounterStatus.FINISHED
+    }
+
+    private fun observation(id: String) = Observation().apply {
+        setId(id)
+        status = Observation.ObservationStatus.FINAL
+    }
+}


### PR DESCRIPTION
Covers non-trivial DAG topologies, error cascades, multi-step pipeline
combinations, and cross-feature interactions not captured by the existing
per-method unit tests.

OperationResultComplexTest (14 tests):
- Extension filter → observation mapping → Bundle serialisation round-trip
- ACCUMULATE and FAIL_FAST error strategy chains across 6 steps
- Nested flatMap across three resource types
- Nested whenTrue + guardFalse conditions
- whenPath with identifier FHIRPath expression
- addPart nested parameter structure surviving toParameters round-trip
- addWithRetryUsing succeeding on third attempt
- merge preserving parameter maps and outcomes from both sides
- rename → remove → filterByName sequence
- Extension predicate filter combined with FHIRPath active filter
- linkReferences with two rules where one has no matching target

AsyncOperationResultComplexTest (10 tests):
- Diamond DAG (A,B → C → D) with correct data propagation
- Diamond DAG concurrent execution timing
- Five-task fan-in collector
- Five-task fan-in concurrent timing
- Five-level linear cascade with per-level data passing
- Failure cascade skipping all downstream dependents
- Partial failure leaving independent sibling branch intact
- Cross-DAG merge feeding a post-merge dependent task
- Retry task feeding a downstream dependent
- Three-level type-safe addAfter chain
- Async DAG post-processed with sync OperationResult pipeline
- Timed parallel tasks reporting per-task metrics