### PR TITLE
refactor: add errorOutcome helper and simplify warningOutcome expression

### DIFF
--- a/fhirmason-core/src/main/java/dev/ratkay/operation/AsyncOperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/AsyncOperationResult.kt
@@ -152,6 +152,34 @@ class AsyncOperationResult {
         block(values)
     }
 
+    // ── Retry helper ─────────────────────────────────────────────────────────
+
+    /**
+     * Suspending analogue of `OperationResult.executeWithRetry`: calls [block] up to
+     * [maxAttempts] times with exponential backoff via [delay] between attempts.
+     * Returns the first successful result, or throws the last caught exception.
+     */
+    private suspend fun <R> suspendExecuteWithRetry(
+        maxAttempts: Int,
+        initialDelayMs: Long,
+        retryOn: (Exception) -> Boolean,
+        block: suspend () -> R
+    ): R {
+        var lastException: Exception? = null
+        var delayMs = initialDelayMs
+        for (attempt in 1..maxAttempts) {
+            try {
+                return block()
+            } catch (e: Exception) {
+                lastException = e
+                if (!retryOn(e) || attempt == maxAttempts) break
+                delay(delayMs)
+                delayMs *= 2
+            }
+        }
+        throw lastException!!
+    }
+
     // ── Independent task with retry ──────────────────────────────────────────
 
     /**
@@ -186,21 +214,7 @@ class AsyncOperationResult {
         require(initialDelayMs >= 0) { "initialDelayMs must be non-negative" }
         return also {
             registerNode(key, TaskNode.Independent(key) { _ ->
-                var lastException: Exception? = null
-                var delayMs = initialDelayMs
-                var result: List<Base>? = null
-                for (attempt in 1..maxAttempts) {
-                    try {
-                        result = listOf(block())
-                        break
-                    } catch (e: Exception) {
-                        lastException = e
-                        if (!retryOn(e) || attempt == maxAttempts) break
-                        delay(delayMs)
-                        delayMs *= 2
-                    }
-                }
-                result ?: throw lastException!!
+                listOf(suspendExecuteWithRetry(maxAttempts, initialDelayMs, retryOn) { block() })
             })
         }
     }
@@ -426,21 +440,7 @@ class AsyncOperationResult {
         requireNoCycle(key, depList)
         return also {
             registerNode(key, TaskNode.Dependent(key, depList) { depResults ->
-                var lastException: Exception? = null
-                var delayMs = initialDelayMs
-                var result: List<Base>? = null
-                for (attempt in 1..maxAttempts) {
-                    try {
-                        result = listOf(block(depResults))
-                        break
-                    } catch (e: Exception) {
-                        lastException = e
-                        if (!retryOn(e) || attempt == maxAttempts) break
-                        delay(delayMs)
-                        delayMs *= 2
-                    }
-                }
-                result ?: throw lastException!!
+                listOf(suspendExecuteWithRetry(maxAttempts, initialDelayMs, retryOn) { block(depResults) })
             })
         }
     }
@@ -471,21 +471,7 @@ class AsyncOperationResult {
         requireNoCycle(key, depList)
         return also {
             registerNode(key, TaskNode.Dependent(key, depList) { depResults ->
-                var lastException: Exception? = null
-                var delayMs = initialDelayMs
-                var result: List<Base>? = null
-                for (attempt in 1..maxAttempts) {
-                    try {
-                        result = block(depResults)
-                        break
-                    } catch (e: Exception) {
-                        lastException = e
-                        if (!retryOn(e) || attempt == maxAttempts) break
-                        delay(delayMs)
-                        delayMs *= 2
-                    }
-                }
-                result ?: throw lastException!!
+                suspendExecuteWithRetry(maxAttempts, initialDelayMs, retryOn) { block(depResults) }
             })
         }
     }

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/FhirExtensionHelper.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/FhirExtensionHelper.kt
@@ -193,9 +193,7 @@ object FhirExtensionHelper {
         if (!visited.add(System.identityHashCode(node))) return
 
         if (node is IBaseHasExtensions) {
-            node.extension.filterIsInstance<Extension>()
-                .filter { it.url == url }
-                .forEach { results.add(it) }
+            results.addAll(node.extension.filterIsInstance<Extension>().filter { it.url == url })
         }
 
         for (property in node.children()) {

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationOutcomeExtensions.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationOutcomeExtensions.kt
@@ -22,17 +22,29 @@ fun BaseServerResponseException.toOperationOutcome(): OperationOutcome =
     (operationOutcome as? OperationOutcome) ?: (this as Exception).toOperationOutcome()
 
 /**
+ * Dispatches to the correct [toOperationOutcome] overload — preserving the embedded
+ * [OperationOutcome] from [BaseServerResponseException] when present, or creating a
+ * generic ERROR outcome otherwise.
+ *
+ * Both branches look visually identical but call **different** extension function overloads
+ * via Kotlin's static dispatch: the smart-cast in the first branch resolves to
+ * [BaseServerResponseException.toOperationOutcome], while the `else` branch resolves to
+ * [Exception.toOperationOutcome]. This consolidates the dispatch in one place so callers
+ * never need to repeat the `when` pattern inline.
+ */
+internal fun errorOutcome(e: Exception): OperationOutcome = when (e) {
+    is BaseServerResponseException -> e.toOperationOutcome()
+    else -> e.toOperationOutcome()
+}
+
+/**
  * Builds a WARNING-severity [OperationOutcome] from [e], preserving any rich embedded
  * outcome when [e] is a [BaseServerResponseException].
  *
  * Shared by [OperationResult.addOrSkip], [OperationResult.addOrDefault], and the
  * conditional-chaining methods — do not duplicate this logic inline.
  */
-internal fun warningOutcome(e: Exception): OperationOutcome {
-    val base = when (e) {
-        is BaseServerResponseException -> e.toOperationOutcome()
-        else -> e.toOperationOutcome()
+internal fun warningOutcome(e: Exception): OperationOutcome =
+    errorOutcome(e).also { outcome ->
+        outcome.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
     }
-    base.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
-    return base
-}

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -165,13 +165,15 @@ class OperationResult<T> private constructor(
         block: () -> OperationResult<R>
     ): OperationResult<R> {
         if (shouldSkip()) return onSkip()
-        var caughtException: Exception? = null
-        val (stepResult, duration) = measureTimedValue {
-            try { block() } catch (e: Exception) { caughtException = e; null }
-        }
+        val (result, duration) = measureTimedValue { runCatching { block() } }
         val durationMs = duration.inWholeMilliseconds
-        return if (caughtException != null) onError(caughtException!!, durationMs)
-               else stepResult!!
+        return result.fold(
+            onSuccess = { it },
+            onFailure = { t ->
+                if (t !is Exception) throw t
+                onError(t, durationMs)
+            }
+        )
     }
 
     private fun <R> runBuilderStep(name: String?, block: () -> OperationResult<R>): OperationResult<R> =
@@ -179,12 +181,7 @@ class OperationResult<T> private constructor(
             onSkip = { skippedResult() },
             onError = { e, durationMs ->
                 recordMetric(name ?: "unknown", "", durationMs, false)
-                outcomes.add(
-                    when (e) {
-                        is BaseServerResponseException -> e.toOperationOutcome()
-                        else -> e.toOperationOutcome()
-                    }
-                )
+                outcomes.add(errorOutcome(e))
                 skippedResult()
             },
             block = block
@@ -206,12 +203,7 @@ class OperationResult<T> private constructor(
             onError = { e, durationMs ->
                 logger.warn("FHIRMason | step='{}' | WARN: {}", name, e.message)
                 recordMetric(name, "", durationMs, false)
-                val outcome = when (e) {
-                    is BaseServerResponseException -> e.toOperationOutcome()
-                    else -> e.toOperationOutcome()
-                }
-                outcome.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
-                outcomes.add(outcome)
+                outcomes.add(warningOutcome(e))
                 copyWith(result)
             },
             block = {

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -1,6 +1,5 @@
 package dev.ratkay.operation
 
-import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException
 import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.BooleanType
@@ -1188,30 +1187,26 @@ class OperationResult<T> private constructor(
         val subPipeline = OperationResult<T>(
             mutableMapOf(), result, mutableListOf(), errorStrategy, mutableMapOf(), timingEnabled, mutableListOf()
         )
-        var caughtException: Exception? = null
-        val (inner, duration) = measureTimedValue {
-            try { block(subPipeline) } catch (e: Exception) { caughtException = e; null }
-        }
+        val (innerResult, duration) = measureTimedValue { runCatching { block(subPipeline) } }
         val durationMs = duration.inWholeMilliseconds
-        return if (caughtException != null) {
-            logger.warn("FHIRMason | step='whenTrue' | WARN: {}", caughtException!!.message)
-            recordMetric("whenTrue", "", durationMs, false)
-            val outcome = when (val ex = caughtException!!) {
-                is BaseServerResponseException -> ex.toOperationOutcome()
-                else -> ex.toOperationOutcome()
+        return innerResult.fold(
+            onSuccess = { inner ->
+                val newParams = shallowCopyParams()
+                inner.parameters.forEach { (key, values) ->
+                    newParams.getOrPut(key) { mutableListOf() }.addAll(values)
+                }
+                outcomes.addAll(inner.outcomes)
+                recordMetric("whenTrue", "", durationMs, true)
+                copyWith(result, params = newParams, extensions = shallowCopyExtensions())
+            },
+            onFailure = { t ->
+                if (t !is Exception) throw t
+                logger.warn("FHIRMason | step='whenTrue' | WARN: {}", t.message)
+                recordMetric("whenTrue", "", durationMs, false)
+                outcomes.add(warningOutcome(t))
+                copyWith(result)
             }
-            outcome.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
-            outcomes.add(outcome)
-            copyWith(result)
-        } else {
-            val newParams = shallowCopyParams()
-            inner!!.parameters.forEach { (key, values) ->
-                newParams.getOrPut(key) { mutableListOf() }.addAll(values)
-            }
-            outcomes.addAll(inner.outcomes)
-            recordMetric("whenTrue", "", durationMs, true)
-            copyWith(result, params = newParams, extensions = shallowCopyExtensions())
-        }
+        )
     }
 
     /**
@@ -1227,30 +1222,26 @@ class OperationResult<T> private constructor(
     fun ifPresent(block: (T) -> OperationResult<*>): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val current = result ?: return copyWith(result)
-        var caughtException: Exception? = null
-        val (inner, duration) = measureTimedValue {
-            try { block(current) } catch (e: Exception) { caughtException = e; null }
-        }
+        val (innerResult, duration) = measureTimedValue { runCatching { block(current) } }
         val durationMs = duration.inWholeMilliseconds
-        return if (caughtException != null) {
-            logger.warn("FHIRMason | step='ifPresent' | WARN: {}", caughtException!!.message)
-            recordMetric("ifPresent", "", durationMs, false)
-            val outcome = when (val ex = caughtException!!) {
-                is BaseServerResponseException -> ex.toOperationOutcome()
-                else -> ex.toOperationOutcome()
+        return innerResult.fold(
+            onSuccess = { inner ->
+                val newParams = shallowCopyParams()
+                inner.parameters.forEach { (key, values) ->
+                    newParams.getOrPut(key) { mutableListOf() }.addAll(values)
+                }
+                outcomes.addAll(inner.outcomes)
+                recordMetric("ifPresent", "", durationMs, true)
+                copyWith(result, params = newParams, extensions = shallowCopyExtensions())
+            },
+            onFailure = { t ->
+                if (t !is Exception) throw t
+                logger.warn("FHIRMason | step='ifPresent' | WARN: {}", t.message)
+                recordMetric("ifPresent", "", durationMs, false)
+                outcomes.add(warningOutcome(t))
+                copyWith(result)
             }
-            outcome.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
-            outcomes.add(outcome)
-            copyWith(result)
-        } else {
-            val newParams = shallowCopyParams()
-            inner!!.parameters.forEach { (key, values) ->
-                newParams.getOrPut(key) { mutableListOf() }.addAll(values)
-            }
-            outcomes.addAll(inner.outcomes)
-            recordMetric("ifPresent", "", durationMs, true)
-            copyWith(result, params = newParams, extensions = shallowCopyExtensions())
-        }
+        )
     }
 
     /**
@@ -1304,37 +1295,35 @@ class OperationResult<T> private constructor(
         val subPipeline = OperationResult<T>(
             mutableMapOf(), result, mutableListOf(), errorStrategy, mutableMapOf(), timingEnabled, mutableListOf()
         )
-        var caughtException: Exception? = null
-        val (inner, duration) = measureTimedValue {
-            try {
+        val (innerResult, duration) = measureTimedValue {
+            runCatching {
                 if (!FhirPathHelper.matches(head, expression)) null
                 else block(subPipeline)
-            } catch (e: Exception) { caughtException = e; null }
+            }
         }
         val durationMs = duration.inWholeMilliseconds
-        return when {
-            caughtException != null -> {
-                logger.warn("FHIRMason | step='whenPath' | WARN: {}", caughtException!!.message)
-                recordMetric("whenPath", "", durationMs, false)
-                val outcome = when (val ex = caughtException!!) {
-                    is BaseServerResponseException -> ex.toOperationOutcome()
-                    else -> ex.toOperationOutcome()
+        return innerResult.fold(
+            onSuccess = { inner ->
+                if (inner != null) {
+                    val newParams = shallowCopyParams()
+                    inner.parameters.forEach { (key, values) ->
+                        newParams.getOrPut(key) { mutableListOf() }.addAll(values)
+                    }
+                    outcomes.addAll(inner.outcomes)
+                    recordMetric("whenPath", "", durationMs, true)
+                    copyWith(result, params = newParams, extensions = shallowCopyExtensions())
+                } else {
+                    copyWith(result)  // expression evaluated to false
                 }
-                outcome.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
-                outcomes.add(outcome)
+            },
+            onFailure = { t ->
+                if (t !is Exception) throw t
+                logger.warn("FHIRMason | step='whenPath' | WARN: {}", t.message)
+                recordMetric("whenPath", "", durationMs, false)
+                outcomes.add(warningOutcome(t))
                 copyWith(result)
             }
-            inner != null -> {
-                val newParams = shallowCopyParams()
-                inner.parameters.forEach { (key, values) ->
-                    newParams.getOrPut(key) { mutableListOf() }.addAll(values)
-                }
-                outcomes.addAll(inner.outcomes)
-                recordMetric("whenPath", "", durationMs, true)
-                copyWith(result, params = newParams, extensions = shallowCopyExtensions())
-            }
-            else -> copyWith(result)  // expression evaluated to false
-        }
+        )
     }
 
     /**
@@ -1381,12 +1370,7 @@ class OperationResult<T> private constructor(
             }
         } catch (e: Exception) {
             logger.warn("FHIRMason | step='guardPath' | WARN: {}", e.message)
-            val outcome = when (e) {
-                is BaseServerResponseException -> e.toOperationOutcome()
-                else -> e.toOperationOutcome()
-            }
-            outcome.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
-            outcomes.add(outcome)
+            outcomes.add(warningOutcome(e))
             copyWith(result)
         }
     }

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -1078,9 +1078,7 @@ class OperationResult<T> private constructor(
 
     fun <R : Base> mapValues(transform: (Base) -> R): OperationResult<R> {
         val transformed = parameters.mapValues { (_, values) ->
-            val newList = mutableListOf<Base>()
-            values.forEach { newList.add(transform(it)) }
-            newList
+            values.map(transform).toMutableList<Base>()
         }.toMutableMap()
         return copyWith<R>(null, params = transformed)
     }
@@ -1153,10 +1151,7 @@ class OperationResult<T> private constructor(
      */
     fun rename(oldName: String, newName: String): OperationResult<T> {
         val newParams = shallowCopyParams()
-        val values = newParams.remove(oldName)
-        if (values != null) {
-            newParams.getOrPut(newName) { mutableListOf() }.addAll(values)
-        }
+        newParams.remove(oldName)?.let { newParams.getOrPut(newName) { mutableListOf() }.addAll(it) }
         return copyWith(result, params = newParams, extensions = shallowCopyExtensions())
     }
 
@@ -1574,15 +1569,9 @@ class OperationResult<T> private constructor(
     // Private helpers
 
     private fun addToParameters(values: List<Base>, name: String?) {
-        if (name != null) {
-            values.forEach { value ->
-                parameters.getOrPut(name) { mutableListOf() }.add(value)
-            }
-        } else {
-            values.forEach { value ->
-                val key = value.fhirType().lowercase()
-                parameters.getOrPut(key) { mutableListOf() }.add(value)
-            }
+        values.forEach { value ->
+            val key = name ?: value.fhirType().lowercase()
+            parameters.getOrPut(key) { mutableListOf() }.add(value)
         }
     }
 

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -688,47 +688,49 @@ class OperationResult<T> private constructor(
 
     @JvmOverloads
     fun <R : Base> addOrSkip(name: String? = null, builder: () -> R): OperationResult<T> {
-        var caughtException: Exception? = null
-        val (value, duration) = measureTimedValue {
-            try { builder() } catch (e: Exception) { caughtException = e; null }
-        }
+        val (builderResult, duration) = measureTimedValue { runCatching { builder() } }
         val durationMs = duration.inWholeMilliseconds
-        return if (caughtException != null) {
-            val key = name ?: "unknown"
-            logger.warn("FHIRMason | step='{}' | WARN: {}", key, caughtException!!.message)
-            recordMetric(key, "", durationMs, false)
-            outcomes.add(warningOutcome(caughtException!!))
-            copyWith(result)
-        } else {
-            val key = name ?: value!!.fhirType().lowercase()
-            parameters.getOrPut(key) { mutableListOf() }.add(value!!)
-            recordMetric(key, value.fhirType(), durationMs, true)
-            logStep(key, value.fhirType(), durationMs)
-            copyWith(result)
-        }
+        return builderResult.fold(
+            onSuccess = { value ->
+                val key = name ?: value.fhirType().lowercase()
+                parameters.getOrPut(key) { mutableListOf() }.add(value)
+                recordMetric(key, value.fhirType(), durationMs, true)
+                logStep(key, value.fhirType(), durationMs)
+                copyWith(result)
+            },
+            onFailure = { t ->
+                if (t !is Exception) throw t
+                val key = name ?: "unknown"
+                logger.warn("FHIRMason | step='{}' | WARN: {}", key, t.message)
+                recordMetric(key, "", durationMs, false)
+                outcomes.add(warningOutcome(t))
+                copyWith(result)
+            }
+        )
     }
 
     @JvmOverloads
     fun <R : Base> addOrDefault(name: String? = null, default: R, builder: () -> R): OperationResult<R> {
-        var caughtException: Exception? = null
-        val (value, duration) = measureTimedValue {
-            try { builder() } catch (e: Exception) { caughtException = e; null }
-        }
+        val (builderResult, duration) = measureTimedValue { runCatching { builder() } }
         val durationMs = duration.inWholeMilliseconds
-        return if (caughtException != null) {
-            val key = name ?: default.fhirType().lowercase()
-            logger.warn("FHIRMason | step='{}' | WARN: {}", key, caughtException!!.message)
-            recordMetric(key, "", durationMs, false)
-            outcomes.add(warningOutcome(caughtException!!))
-            parameters.getOrPut(key) { mutableListOf() }.add(default)
-            copyWith(default)
-        } else {
-            val key = name ?: value!!.fhirType().lowercase()
-            parameters.getOrPut(key) { mutableListOf() }.add(value!!)
-            recordMetric(key, value.fhirType(), durationMs, true)
-            logStep(key, value.fhirType(), durationMs)
-            copyWith(value!!)
-        }
+        return builderResult.fold(
+            onSuccess = { value ->
+                val key = name ?: value.fhirType().lowercase()
+                parameters.getOrPut(key) { mutableListOf() }.add(value)
+                recordMetric(key, value.fhirType(), durationMs, true)
+                logStep(key, value.fhirType(), durationMs)
+                copyWith(value)
+            },
+            onFailure = { t ->
+                if (t !is Exception) throw t
+                val key = name ?: default.fhirType().lowercase()
+                logger.warn("FHIRMason | step='{}' | WARN: {}", key, t.message)
+                recordMetric(key, "", durationMs, false)
+                outcomes.add(warningOutcome(t))
+                parameters.getOrPut(key) { mutableListOf() }.add(default)
+                copyWith(default)
+            }
+        )
     }
 
     // ── Builder variant with retry ────────────────────────────────────────────

--- a/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
+++ b/fhirmason-core/src/main/java/dev/ratkay/operation/OperationResult.kt
@@ -736,6 +736,40 @@ class OperationResult<T> private constructor(
     // ── Builder variant with retry ────────────────────────────────────────────
 
     /**
+     * Executes [block] up to [maxAttempts] times with exponential backoff between retries.
+     * Returns the first successful result, or throws the last caught exception when all
+     * attempts are exhausted or [retryOn] returns `false`.
+     *
+     * Thread interruption during a sleep re-interrupts the thread and triggers an immediate throw.
+     */
+    private fun <R> executeWithRetry(
+        maxAttempts: Int,
+        initialDelayMs: Long,
+        retryOn: (Exception) -> Boolean,
+        block: () -> R
+    ): R {
+        var lastException: Exception? = null
+        var delayMs = initialDelayMs
+        for (attempt in 1..maxAttempts) {
+            try {
+                return block()
+            } catch (e: Exception) {
+                lastException = e
+                if (!retryOn(e) || attempt == maxAttempts) break
+                try {
+                    Thread.sleep(delayMs)
+                } catch (i: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    lastException = i
+                    break
+                }
+                delayMs *= 2
+            }
+        }
+        throw lastException!!
+    }
+
+    /**
      * Calls [builder] up to [maxAttempts] times, retrying on transient failures with
      * exponential backoff between attempts.
      *
@@ -770,30 +804,10 @@ class OperationResult<T> private constructor(
         require(maxAttempts >= 1) { "maxAttempts must be at least 1" }
         require(initialDelayMs >= 0) { "initialDelayMs must be non-negative" }
         return runBuilderStep(name) {
-            var lastException: Exception? = null
-            var delayMs = initialDelayMs
-            var successValue: R? = null
-            val duration = measureTime {
-                for (attempt in 1..maxAttempts) {
-                    try {
-                        successValue = builder()
-                        break
-                    } catch (e: Exception) {
-                        lastException = e
-                        if (!retryOn(e) || attempt == maxAttempts) break
-                        try {
-                            Thread.sleep(delayMs)
-                        } catch (interrupted: InterruptedException) {
-                            Thread.currentThread().interrupt()
-                            lastException = interrupted
-                            break
-                        }
-                        delayMs *= 2
-                    }
-                }
+            val (value, duration) = measureTimedValue {
+                executeWithRetry(maxAttempts, initialDelayMs, retryOn) { builder() }
             }
-            if (successValue != null) storeAndCopy(name, successValue!!, duration.inWholeMilliseconds)
-            else throw lastException!!
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
         }
     }
 
@@ -821,30 +835,10 @@ class OperationResult<T> private constructor(
             // IllegalStateException here — caught by runBuilderStep's outer try/catch
             // (Pattern A, one attempt), not inside the retry loop.
             val head = getResult()
-            var lastException: Exception? = null
-            var delayMs = initialDelayMs
-            var successValue: R? = null
-            val duration = measureTime {
-                for (attempt in 1..maxAttempts) {
-                    try {
-                        successValue = builder(head)
-                        break
-                    } catch (e: Exception) {
-                        lastException = e
-                        if (!retryOn(e) || attempt == maxAttempts) break
-                        try {
-                            Thread.sleep(delayMs)
-                        } catch (interrupted: InterruptedException) {
-                            Thread.currentThread().interrupt()
-                            lastException = interrupted
-                            break
-                        }
-                        delayMs *= 2
-                    }
-                }
+            val (value, duration) = measureTimedValue {
+                executeWithRetry(maxAttempts, initialDelayMs, retryOn) { builder(head) }
             }
-            if (successValue != null) storeAndCopy(name, successValue!!, duration.inWholeMilliseconds)
-            else throw lastException!!
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
         }
     }
 


### PR DESCRIPTION
- Add internal errorOutcome(e) to encapsulate the static-dispatch when-expression
  that selects between BaseServerResponseException.toOperationOutcome() and
  Exception.toOperationOutcome() — consolidating this pattern in one place
- Refactor warningOutcome to a single-expression function using errorOutcome + also