### PR TITLE
Add DSTU3 AsyncOperationResult and port all async tests from R4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,19 @@ Run the full test suite (`mvn test`) before every commit **and** before every pu
 - Fix every failure, even if it appears unrelated to your changes, before committing or pushing.
 - A commit that introduces or leaves a failing test is a policy violation regardless of intent.
 
+## DSTU3 Porting Policy
+
+FHIRMason supports both FHIR R4 (the primary version) and FHIR DSTU3.
+
+**R4 has priority.** All new features are designed and implemented for R4 first.
+
+**New features must be ported to DSTU3 unless impossible.** After a feature is complete and tested in R4, port it to the DSTU3 module with equivalent source and test files. A feature may be skipped for DSTU3 only if it relies on R4-exclusive FHIR constructs (e.g., a resource type or element that does not exist in DSTU3). Document any such exception in the PR or commit message.
+
+Port checklist:
+- Mirror the DSTU3 source file (change package, swap `org.hl7.fhir.r4.model.*` → `org.hl7.fhir.dstu3.model.*`, adjust any DSTU3-specific API differences)
+- Mirror all R4 test files for the feature in the DSTU3 test directory, adapting resource types and imports
+- Ensure all DSTU3 tests pass before committing
+
 ## README Maintenance
 
 Keep `README.md` up to date on every branch. When a branch adds or changes a feature, update the relevant section(s) of the README before committing:

--- a/README.md
+++ b/README.md
@@ -1509,7 +1509,7 @@ suspend fun buildOutput(): Parameters {
 |---|---|---|
 | `fhirmason-api` | `fhirmason-api` | Shared building blocks: `IOperationResult<T>`, `ErrorStrategy`, `StepMetrics`, `DateTimeInput` |
 | `fhirmason-r4` | `fhirmason-r4` | R4 pipeline builders (`OperationResult`, `AsyncOperationResult`) |
-| `fhirmason-dstu3` | `fhirmason-dstu3` | DSTU3 pipeline builder (`OperationResult`) |
+| `fhirmason-dstu3` | `fhirmason-dstu3` | DSTU3 pipeline builders (`OperationResult`, `AsyncOperationResult`) |
 | `fhirmason-spring` | `fhirmason-spring` | Spring Boot auto-configuration and base provider class |
 
 ---
@@ -1574,6 +1574,7 @@ fhirmason-dstu3/
 └── src/
     ├── main/java/dev/ratkay/operation/dstu3/
     │   ├── OperationResult.kt              # Synchronous accumulator builder (DSTU3)
+    │   ├── AsyncOperationResult.kt         # Async/coroutine DAG-based builder (DSTU3)
     │   ├── ParameterMapSerializer.kt       # Dot-delimited key flatten / unflatten logic
     │   ├── ReferenceLinkRule.kt            # Explicit reference linking rule descriptor
     │   ├── ReferenceLinkHelper.kt          # Reference linking algorithm helpers (internal)
@@ -1592,6 +1593,18 @@ fhirmason-dstu3/
         ├── OperationResultRetryTest.kt
         ├── OperationResultFhirPathTest.kt
         ├── OperationResultComplexTest.kt
+        ├── AsyncOperationResultTest.kt
+        ├── AsyncOperationResultMetricsTest.kt
+        ├── AsyncOperationResultDescribeTest.kt
+        ├── AsyncOperationResultRetryTest.kt
+        ├── AsyncOperationResultDependentRetryTest.kt
+        ├── AsyncOperationResultMergeTest.kt
+        ├── AsyncOperationResultTimeoutTest.kt
+        ├── AsyncOperationResultDagTimeoutTest.kt
+        ├── AsyncOperationResultConditionalTest.kt
+        ├── AsyncOperationResultDefaultTest.kt
+        ├── AsyncOperationResultComplexTest.kt
+        ├── AsyncOperationResultTypedDepOverloadsTest.kt
         ├── FhirDateTimeConverterTest.kt
         └── FhirExtensionHelperTest.kt
 

--- a/fhirmason-dstu3/pom.xml
+++ b/fhirmason-dstu3/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>hapi-fhir-caching-guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/AsyncOperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/AsyncOperationResult.kt
@@ -1,0 +1,618 @@
+package dev.ratkay.operation.dstu3
+
+import dev.ratkay.operation.ErrorStrategy
+import dev.ratkay.operation.StepMetrics
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.hl7.fhir.dstu3.model.Base
+import org.hl7.fhir.dstu3.model.OperationOutcome
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.KClass
+import kotlin.time.measureTime
+import kotlin.time.measureTimedValue
+
+class AsyncOperationResult {
+
+    private val logger = LoggerFactory.getLogger(AsyncOperationResult::class.java)
+
+    private var timingEnabled: Boolean = false
+    private var dagTimeoutMs: Long? = null
+
+    private val taskMetrics = ConcurrentHashMap<String, StepMetrics>()
+    private var totalDurationMs: Long = 0L
+
+    private sealed class TaskNode {
+        abstract val key: String
+        abstract val deps: List<String>
+        abstract val block: suspend (Map<String, List<Base>>) -> List<Base>
+
+        class Independent(
+            override val key: String,
+            override val block: suspend (Map<String, List<Base>>) -> List<Base>
+        ) : TaskNode() {
+            override val deps: List<String> = emptyList()
+        }
+
+        class Dependent(
+            override val key: String,
+            override val deps: List<String>,
+            override val block: suspend (Map<String, List<Base>>) -> List<Base>
+        ) : TaskNode()
+    }
+
+    private val nodes: LinkedHashMap<String, TaskNode> = LinkedHashMap()
+
+    /** Enables per-task metrics collection. [getMetrics] returns empty when not called. */
+    fun timed(): AsyncOperationResult = also { timingEnabled = true }
+
+    /**
+     * Sets a maximum wall-clock time for the entire DAG execution.
+     *
+     * If [run] does not complete within [durationMs] milliseconds, it returns an
+     * [OperationResult] containing a single `TIMEOUT`-coded [OperationOutcome] and no task
+     * results. [getTotalDuration] will return `0` on timeout because the duration assignment
+     * inside the DAG execution is interrupted before it can run.
+     *
+     * [runBlocking] inherits this timeout automatically.
+     *
+     * @param durationMs maximum allowed wall-clock time in milliseconds; must be > 0
+     */
+    fun timeout(durationMs: Long): AsyncOperationResult = also {
+        require(durationMs > 0) { "durationMs must be positive" }
+        dagTimeoutMs = durationMs
+    }
+
+    /** Returns a snapshot of [StepMetrics] collected per task after [run] or [runBlocking]. */
+    fun getMetrics(): Map<String, StepMetrics> = taskMetrics.toMap()
+
+    /** Returns total wall-clock DAG execution time in milliseconds. Zero before [run] completes. */
+    fun getTotalDuration(): Long = totalDurationMs
+
+    private fun registerNode(key: String, node: TaskNode) {
+        require(!nodes.containsKey(key)) { "Duplicate task key: '$key'" }
+        nodes[key] = node
+    }
+
+    fun add(key: String, block: suspend () -> Base): AsyncOperationResult = also {
+        registerNode(key, TaskNode.Independent(key) { listOf(block()) })
+    }
+
+    fun addList(key: String, block: suspend () -> List<Base>): AsyncOperationResult = also {
+        registerNode(key, TaskNode.Independent(key) { block() })
+    }
+
+    fun addAfter(
+        key: String,
+        vararg deps: String,
+        block: suspend (Map<String, List<Base>>) -> Base
+    ): AsyncOperationResult = also {
+        val depList = deps.toList()
+        requireKeysExist(depList)
+        requireNoCycle(key, depList)
+        registerNode(key, TaskNode.Dependent(key, depList) { map -> listOf(block(map)) })
+    }
+
+    fun addListAfter(
+        key: String,
+        vararg deps: String,
+        block: suspend (Map<String, List<Base>>) -> List<Base>
+    ): AsyncOperationResult = also {
+        val depList = deps.toList()
+        requireKeysExist(depList)
+        requireNoCycle(key, depList)
+        registerNode(key, TaskNode.Dependent(key, depList, block))
+    }
+
+    // Type-safe single-dependency convenience methods
+
+    fun <T : Base> addAfter(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        block: suspend (T) -> Base
+    ): AsyncOperationResult = addAfter(key, dep) { deps ->
+        val value = deps[dep]!!.filterIsInstance(type.java).first()
+        block(value)
+    }
+
+    fun <T : Base> addListAfter(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        block: suspend (T) -> List<Base>
+    ): AsyncOperationResult = addListAfter(key, dep) { deps ->
+        val value = deps[dep]!!.filterIsInstance(type.java).first()
+        block(value)
+    }
+
+    // Type-safe list-injection convenience methods
+
+    fun <T : Base> addAfterAll(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        block: suspend (List<T>) -> Base
+    ): AsyncOperationResult = addAfter(key, dep) { deps ->
+        val values = deps[dep]!!.filterIsInstance(type.java)
+        block(values)
+    }
+
+    fun <T : Base> addListAfterAll(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        block: suspend (List<T>) -> List<Base>
+    ): AsyncOperationResult = addListAfter(key, dep) { deps ->
+        val values = deps[dep]!!.filterIsInstance(type.java)
+        block(values)
+    }
+
+    // ── Retry helper ─────────────────────────────────────────────────────────
+
+    private suspend fun <R> suspendExecuteWithRetry(
+        maxAttempts: Int,
+        initialDelayMs: Long,
+        retryOn: (Exception) -> Boolean,
+        block: suspend () -> R
+    ): R {
+        var lastException: Exception? = null
+        var delayMs = initialDelayMs
+        for (attempt in 1..maxAttempts) {
+            try {
+                return block()
+            } catch (e: Exception) {
+                lastException = e
+                if (!retryOn(e) || attempt == maxAttempts) break
+                delay(delayMs)
+                delayMs *= 2
+            }
+        }
+        throw lastException!!
+    }
+
+    // ── Independent task with retry ──────────────────────────────────────────
+
+    @JvmOverloads
+    fun <R : Base> addWithRetry(
+        key: String,
+        maxAttempts: Int = 3,
+        initialDelayMs: Long = 500,
+        retryOn: (Exception) -> Boolean = { true },
+        block: suspend () -> R
+    ): AsyncOperationResult {
+        require(maxAttempts >= 1) { "maxAttempts must be at least 1" }
+        require(initialDelayMs >= 0) { "initialDelayMs must be non-negative" }
+        return also {
+            registerNode(key, TaskNode.Independent(key) { _ ->
+                listOf(suspendExecuteWithRetry(maxAttempts, initialDelayMs, retryOn) { block() })
+            })
+        }
+    }
+
+    // ── Independent task with timeout ────────────────────────────────────────
+
+    fun addWithTimeout(key: String, timeoutMs: Long, block: suspend () -> Base): AsyncOperationResult = also {
+        require(timeoutMs > 0) { "timeoutMs must be positive" }
+        registerNode(key, TaskNode.Independent(key) {
+            withTimeout(timeoutMs) { listOf(block()) }
+        })
+    }
+
+    fun addListWithTimeout(key: String, timeoutMs: Long, block: suspend () -> List<Base>): AsyncOperationResult = also {
+        require(timeoutMs > 0) { "timeoutMs must be positive" }
+        registerNode(key, TaskNode.Independent(key) {
+            withTimeout(timeoutMs) { block() }
+        })
+    }
+
+    // ── Dependent task with timeout ───────────────────────────────────────────
+
+    fun addAfterWithTimeout(
+        key: String,
+        vararg deps: String,
+        timeoutMs: Long,
+        block: suspend (Map<String, List<Base>>) -> Base
+    ): AsyncOperationResult = also {
+        require(timeoutMs > 0) { "timeoutMs must be positive" }
+        val depList = deps.toList()
+        requireKeysExist(depList)
+        requireNoCycle(key, depList)
+        registerNode(key, TaskNode.Dependent(key, depList) { depResults ->
+            withTimeout(timeoutMs) { listOf(block(depResults)) }
+        })
+    }
+
+    fun addListAfterWithTimeout(
+        key: String,
+        vararg deps: String,
+        timeoutMs: Long,
+        block: suspend (Map<String, List<Base>>) -> List<Base>
+    ): AsyncOperationResult = also {
+        require(timeoutMs > 0) { "timeoutMs must be positive" }
+        val depList = deps.toList()
+        requireKeysExist(depList)
+        requireNoCycle(key, depList)
+        registerNode(key, TaskNode.Dependent(key, depList) { depResults ->
+            withTimeout(timeoutMs) { block(depResults) }
+        })
+    }
+
+    // ── Type-safe single-dependency overloads for timeout ────────────────────
+
+    fun <T : Base> addAfterWithTimeout(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        timeoutMs: Long,
+        block: suspend (T) -> Base
+    ): AsyncOperationResult = addAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
+        val value = deps[dep]!!.filterIsInstance(type.java).first()
+        block(value)
+    }
+
+    fun <T : Base> addListAfterWithTimeout(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        timeoutMs: Long,
+        block: suspend (T) -> List<Base>
+    ): AsyncOperationResult = addListAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
+        val value = deps[dep]!!.filterIsInstance(type.java).first()
+        block(value)
+    }
+
+    fun <T : Base> addAfterAllWithTimeout(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        timeoutMs: Long,
+        block: suspend (List<T>) -> Base
+    ): AsyncOperationResult = addAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
+        val values = deps[dep]!!.filterIsInstance(type.java)
+        block(values)
+    }
+
+    fun <T : Base> addListAfterAllWithTimeout(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        timeoutMs: Long,
+        block: suspend (List<T>) -> List<Base>
+    ): AsyncOperationResult = addListAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
+        val values = deps[dep]!!.filterIsInstance(type.java)
+        block(values)
+    }
+
+    // ── Dependent task with retry ─────────────────────────────────────────────
+
+    fun addAfterWithRetry(
+        key: String,
+        vararg deps: String,
+        maxAttempts: Int = 3,
+        initialDelayMs: Long = 500,
+        retryOn: (Exception) -> Boolean = { true },
+        block: suspend (Map<String, List<Base>>) -> Base
+    ): AsyncOperationResult {
+        require(maxAttempts >= 1) { "maxAttempts must be at least 1" }
+        require(initialDelayMs >= 0) { "initialDelayMs must be non-negative" }
+        val depList = deps.toList()
+        requireKeysExist(depList)
+        requireNoCycle(key, depList)
+        return also {
+            registerNode(key, TaskNode.Dependent(key, depList) { depResults ->
+                listOf(suspendExecuteWithRetry(maxAttempts, initialDelayMs, retryOn) { block(depResults) })
+            })
+        }
+    }
+
+    fun addListAfterWithRetry(
+        key: String,
+        vararg deps: String,
+        maxAttempts: Int = 3,
+        initialDelayMs: Long = 500,
+        retryOn: (Exception) -> Boolean = { true },
+        block: suspend (Map<String, List<Base>>) -> List<Base>
+    ): AsyncOperationResult {
+        require(maxAttempts >= 1) { "maxAttempts must be at least 1" }
+        require(initialDelayMs >= 0) { "initialDelayMs must be non-negative" }
+        val depList = deps.toList()
+        requireKeysExist(depList)
+        requireNoCycle(key, depList)
+        return also {
+            registerNode(key, TaskNode.Dependent(key, depList) { depResults ->
+                suspendExecuteWithRetry(maxAttempts, initialDelayMs, retryOn) { block(depResults) }
+            })
+        }
+    }
+
+    // ── Type-safe single-dependency overloads for retry ──────────────────────
+
+    fun <T : Base> addAfterWithRetry(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        maxAttempts: Int = 3,
+        initialDelayMs: Long = 500,
+        retryOn: (Exception) -> Boolean = { true },
+        block: suspend (T) -> Base
+    ): AsyncOperationResult = addAfterWithRetry(
+        key, dep,
+        maxAttempts = maxAttempts,
+        initialDelayMs = initialDelayMs,
+        retryOn = retryOn
+    ) { deps ->
+        val value = deps[dep]!!.filterIsInstance(type.java).first()
+        block(value)
+    }
+
+    fun <T : Base> addListAfterWithRetry(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        maxAttempts: Int = 3,
+        initialDelayMs: Long = 500,
+        retryOn: (Exception) -> Boolean = { true },
+        block: suspend (T) -> List<Base>
+    ): AsyncOperationResult = addListAfterWithRetry(
+        key, dep,
+        maxAttempts = maxAttempts,
+        initialDelayMs = initialDelayMs,
+        retryOn = retryOn
+    ) { deps ->
+        val value = deps[dep]!!.filterIsInstance(type.java).first()
+        block(value)
+    }
+
+    fun <T : Base> addAfterAllWithRetry(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        maxAttempts: Int = 3,
+        initialDelayMs: Long = 500,
+        retryOn: (Exception) -> Boolean = { true },
+        block: suspend (List<T>) -> Base
+    ): AsyncOperationResult = addAfterWithRetry(
+        key, dep,
+        maxAttempts = maxAttempts,
+        initialDelayMs = initialDelayMs,
+        retryOn = retryOn
+    ) { deps ->
+        val values = deps[dep]!!.filterIsInstance(type.java)
+        block(values)
+    }
+
+    fun <T : Base> addListAfterAllWithRetry(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        maxAttempts: Int = 3,
+        initialDelayMs: Long = 500,
+        retryOn: (Exception) -> Boolean = { true },
+        block: suspend (List<T>) -> List<Base>
+    ): AsyncOperationResult = addListAfterWithRetry(
+        key, dep,
+        maxAttempts = maxAttempts,
+        initialDelayMs = initialDelayMs,
+        retryOn = retryOn
+    ) { deps ->
+        val values = deps[dep]!!.filterIsInstance(type.java)
+        block(values)
+    }
+
+    // ── Independent task with fallback value ─────────────────────────────────
+
+    fun <R : Base> addWithDefault(key: String, default: R, block: suspend () -> R): AsyncOperationResult = also {
+        registerNode(key, TaskNode.Independent(key) {
+            try {
+                listOf(block())
+            } catch (e: BaseServerResponseException) {
+                logger.warn("FHIRMason.async | task='{}' | using default: {}", key, e.message)
+                listOf(default)
+            } catch (e: Exception) {
+                logger.warn("FHIRMason.async | task='{}' | using default: {}", key, e.message)
+                listOf(default)
+            }
+        })
+    }
+
+    fun <R : Base> addListWithDefault(key: String, default: List<R>, block: suspend () -> List<R>): AsyncOperationResult = also {
+        registerNode(key, TaskNode.Independent(key) {
+            try {
+                block()
+            } catch (e: BaseServerResponseException) {
+                logger.warn("FHIRMason.async | task='{}' | using default list: {}", key, e.message)
+                default
+            } catch (e: Exception) {
+                logger.warn("FHIRMason.async | task='{}' | using default list: {}", key, e.message)
+                default
+            }
+        })
+    }
+
+    // ── Conditional task registration ────────────────────────────────────────
+
+    fun addIf(condition: Boolean, key: String, block: suspend () -> Base): AsyncOperationResult =
+        if (condition) add(key, block) else this
+
+    fun addListIf(condition: Boolean, key: String, block: suspend () -> List<Base>): AsyncOperationResult =
+        if (condition) addList(key, block) else this
+
+    // ── DAG composition ──────────────────────────────────────────────────────
+
+    fun merge(other: AsyncOperationResult): AsyncOperationResult = also {
+        other.nodes.values.forEach { node -> registerNode(node.key, node) }
+    }
+
+    fun merge(block: () -> AsyncOperationResult): AsyncOperationResult = merge(block())
+
+    // ── DAG inspection ───────────────────────────────────────────────────────
+
+    fun describe(): String {
+        if (nodes.isEmpty()) return "AsyncOperationResult DAG: (empty)"
+
+        val tierOf = mutableMapOf<String, Int>()
+        fun computeTier(key: String): Int = tierOf.getOrPut(key) {
+            val node = nodes[key]!!
+            if (node.deps.isEmpty()) 1
+            else 1 + node.deps.maxOf { computeTier(it) }
+        }
+        nodes.keys.forEach { computeTier(it) }
+
+        val byTier: Map<Int, List<TaskNode>> = nodes.values
+            .groupBy { tierOf[it.key]!! }
+            .toSortedMap()
+
+        val sb = StringBuilder("AsyncOperationResult DAG:\n")
+        byTier.forEach { (tier, tasks) ->
+            val keysStr = tasks.joinToString(", ") { it.key }
+            val allDeps = tasks.flatMap { it.deps }.distinct()
+            sb.append("  Tier $tier (parallel): [$keysStr]")
+            if (allDeps.isNotEmpty()) {
+                sb.append(" → depends on [${allDeps.joinToString(", ")}]")
+            }
+            sb.append("\n")
+        }
+        return sb.toString().trimEnd()
+    }
+
+    suspend fun run(): OperationResult<Base> {
+        val t = dagTimeoutMs
+        return if (t != null) {
+            try {
+                withTimeout(t) { runInternal() }
+            } catch (e: TimeoutCancellationException) {
+                OperationResult.fromMap(emptyMap(), listOf(dagTimeoutOutcome(t)), emptyMap())
+            }
+        } else {
+            runInternal()
+        }
+    }
+
+    private suspend fun runInternal(): OperationResult<Base> = coroutineScope {
+        val resolved = mutableMapOf<String, Deferred<List<Base>?>>()
+        val failedTasks = ConcurrentHashMap<String, OperationOutcome>()
+
+        fun launchNode(node: TaskNode): Deferred<List<Base>?> =
+            resolved.getOrPut(node.key) {
+                async {
+                    logger.debug("FHIRMason.async | task='{}' | status=STARTED", node.key)
+
+                    val depResults = mutableMapOf<String, List<Base>>()
+                    var failedDep: String? = null
+                    for (depKey in node.deps) {
+                        val depResult = launchNode(nodes[depKey]!!).await()
+                        if (depResult == null) { failedDep = depKey; break }
+                        depResults[depKey] = depResult
+                    }
+
+                    var taskResult: List<Base>? = null
+                    val taskDuration = measureTime {
+                        taskResult = if (failedDep != null) {
+                            failedTasks[node.key] = dependencyFailureOutcome(node.key, failedDep)
+                            null
+                        } else {
+                            try {
+                                node.block(depResults)
+                            } catch (e: BaseServerResponseException) {
+                                failedTasks[node.key] = e.toOperationOutcome()
+                                null
+                            } catch (e: Exception) {
+                                failedTasks[node.key] = e.toOperationOutcome()
+                                null
+                            }
+                        }
+                    }
+
+                    val durationMs = taskDuration.inWholeMilliseconds
+                    val success = taskResult != null
+                    val resourceType = taskResult?.firstOrNull()?.fhirType() ?: ""
+
+                    if (success) {
+                        logger.debug(
+                            "FHIRMason.async | task='{}' | status=COMPLETED | duration={}ms",
+                            node.key, durationMs
+                        )
+                    } else {
+                        logger.debug(
+                            "FHIRMason.async | task='{}' | status=FAILED | duration={}ms",
+                            node.key, durationMs
+                        )
+                    }
+
+                    if (timingEnabled) {
+                        taskMetrics[node.key] = StepMetrics(node.key, resourceType, durationMs, success)
+                    }
+
+                    taskResult
+                }
+            }
+
+        val accumulator = mutableMapOf<String, MutableList<Base>>()
+        val dagDuration = measureTime {
+            nodes.values.forEach { launchNode(it) }
+            resolved.forEach { (key, deferred) ->
+                val taskResult = deferred.await()
+                if (taskResult != null) {
+                    accumulator.getOrPut(key) { mutableListOf() }.addAll(taskResult)
+                }
+            }
+        }
+
+        totalDurationMs = dagDuration.inWholeMilliseconds
+        logger.debug(
+            "FHIRMason.async | dag=COMPLETED | totalDuration={}ms | tasks={}",
+            totalDurationMs, nodes.size
+        )
+
+        val outcomes = failedTasks.values.toList()
+        OperationResult.fromMap(accumulator, outcomes, failedTasks)
+    }
+
+    fun runBlocking(): OperationResult<Base> = runBlocking { run() }
+
+    private fun dagTimeoutOutcome(durationMs: Long): OperationOutcome = OperationOutcome().apply {
+        addIssue().apply {
+            severity = OperationOutcome.IssueSeverity.ERROR
+            code = OperationOutcome.IssueType.TIMEOUT
+            diagnostics = "DAG execution exceeded timeout of ${durationMs}ms"
+        }
+    }
+
+    private fun dependencyFailureOutcome(taskKey: String, failedDep: String): OperationOutcome =
+        OperationOutcome().apply {
+            addIssue().apply {
+                severity = OperationOutcome.IssueSeverity.ERROR
+                code = OperationOutcome.IssueType.PROCESSING
+                diagnostics = "Task '$taskKey' skipped: dependency '$failedDep' failed"
+            }
+        }
+
+    private fun requireKeysExist(deps: List<String>) {
+        deps.forEach { dep ->
+            require(nodes.containsKey(dep)) {
+                "Dependency '$dep' has not been registered. Register tasks in dependency order."
+            }
+        }
+    }
+
+    private fun requireNoCycle(newKey: String, deps: List<String>) {
+        fun reachable(from: String, target: String, visited: MutableSet<String>): Boolean {
+            if (from == target) return true
+            if (!visited.add(from)) return false
+            val node = nodes[from] ?: return false
+            return node.deps.any { reachable(it, target, visited) }
+        }
+        deps.forEach { dep ->
+            require(!reachable(dep, newKey, mutableSetOf())) {
+                "Adding '$newKey' with dependency '$dep' would create a cycle."
+            }
+        }
+    }
+}

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultComplexTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultComplexTest.kt
@@ -1,0 +1,333 @@
+package dev.ratkay.operation.dstu3
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.`is`
+import org.hl7.fhir.dstu3.model.Basic
+import org.hl7.fhir.dstu3.model.Bundle
+import org.hl7.fhir.dstu3.model.Claim
+import org.hl7.fhir.dstu3.model.Coverage
+import org.hl7.fhir.dstu3.model.Encounter
+import org.hl7.fhir.dstu3.model.Observation
+import org.hl7.fhir.dstu3.model.OperationOutcome
+import org.hl7.fhir.dstu3.model.Patient
+import org.hl7.fhir.dstu3.model.Practitioner
+import org.hl7.fhir.dstu3.model.Reference
+import org.hl7.fhir.dstu3.model.StringType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AsyncOperationResultComplexTest {
+
+    // ── Scenario 1: diamond DAG — A, B → C → D ───────────────────────────────
+
+    @Test
+    fun `diamond DAG A and B run in parallel then C waits for both and D waits for C`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("a") { delay(20); Patient().apply { id = "A" } }
+            .add("b") { delay(20); Practitioner().apply { id = "B" } }
+            .addAfter("c", "a", "b") { deps ->
+                val aId = (deps["a"]!!.first() as Patient).id
+                val bId = (deps["b"]!!.first() as Practitioner).id
+                Basic().apply { id = "$aId+$bId" }
+            }
+            .addAfter("d", "c", Basic::class) { c ->
+                Encounter().apply { id = "D-from-${c.id}" }
+            }
+            .run()
+
+        assertThat(result.getKeys(), containsInAnyOrder("a", "b", "c", "d"))
+
+        val c = result.getAll("c").first() as Basic
+        assertThat(c.id, `is`("A+B"))
+
+        val d = result.getAll("d").first() as Encounter
+        assertThat(d.id, `is`("D-from-A+B"))
+
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `diamond DAG A and B execute concurrently — total wall time is less than A plus B`() = runBlocking {
+        val start = System.currentTimeMillis()
+
+        AsyncOperationResult()
+            .add("a") { delay(80); Patient() }
+            .add("b") { delay(80); Practitioner() }
+            .addAfter("c", "a", "b") { Basic() }
+            .run()
+
+        val elapsed = System.currentTimeMillis() - start
+        assertTrue(elapsed < 150, "Expected concurrent execution but elapsed was ${elapsed}ms")
+    }
+
+    // ── Scenario 2: wide fan-in — 5 independent tasks → 1 collector ──────────
+
+    @Test
+    fun `five independent tasks all feed into a single collector task`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("t1") { Patient().apply { id = "1" } }
+            .add("t2") { Patient().apply { id = "2" } }
+            .add("t3") { Patient().apply { id = "3" } }
+            .add("t4") { Patient().apply { id = "4" } }
+            .add("t5") { Patient().apply { id = "5" } }
+            .addAfter("collector", "t1", "t2", "t3", "t4", "t5") { deps ->
+                val ids = (1..5).map { i -> (deps["t$i"]!!.first() as Patient).id }
+                Basic().apply { id = ids.joinToString(",") }
+            }
+            .run()
+
+        assertThat(result.totalCount(), `is`(6))
+        val collector = result.getAll("collector").first() as Basic
+        assertThat(collector.id, `is`("1,2,3,4,5"))
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `five independent tasks run concurrently — wall time is less than sum of all`() = runBlocking {
+        val start = System.currentTimeMillis()
+
+        AsyncOperationResult()
+            .add("t1") { delay(60); Patient() }
+            .add("t2") { delay(60); Patient() }
+            .add("t3") { delay(60); Patient() }
+            .add("t4") { delay(60); Patient() }
+            .add("t5") { delay(60); Patient() }
+            .addAfter("collector", "t1", "t2", "t3", "t4", "t5") { Basic() }
+            .run()
+
+        val elapsed = System.currentTimeMillis() - start
+        assertTrue(elapsed < 220, "Expected concurrent execution but elapsed was ${elapsed}ms")
+    }
+
+    // ── Scenario 3: five-level linear cascade A → B → C → D → E ─────────────
+
+    @Test
+    fun `five-level linear chain passes data through correctly at every level`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("a") { Patient().apply { id = "A" } }
+            .addAfter("b", "a", Patient::class) { a ->
+                Patient().apply { id = "${a.id}-B" }
+            }
+            .addAfter("c", "b", Patient::class) { b ->
+                Patient().apply { id = "${b.id}-C" }
+            }
+            .addAfter("d", "c", Patient::class) { c ->
+                Patient().apply { id = "${c.id}-D" }
+            }
+            .addAfter("e", "d", Patient::class) { d ->
+                StringType("${d.id}-E")
+            }
+            .run()
+
+        assertThat(result.getKeys(), containsInAnyOrder("a", "b", "c", "d", "e"))
+
+        val e = result.getAll("e").first() as StringType
+        assertThat(e.value, `is`("A-B-C-D-E"))
+        assertFalse(result.hasErrors())
+    }
+
+    // ── Scenario 4: failure at tier 2 cascades to tiers 3 and 4 ─────────────
+
+    @Test
+    fun `failure at tier-2 skips all downstream dependents while independent task succeeds`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("a") { Patient().apply { id = "ok" } }
+            .add("b") { error("tier-2 boom") }
+            .addAfter("c", "b") { Basic() }
+            .addAfter("d", "c") { Basic() }
+            .run()
+
+        assertTrue(result.containsKey("a"))
+
+        assertFalse(result.containsKey("b"))
+        assertFalse(result.containsKey("c"))
+        assertFalse(result.containsKey("d"))
+
+        assertThat(result.getFailedTasks().keys, containsInAnyOrder("b", "c", "d"))
+        assertTrue(result.hasErrors())
+    }
+
+    // ── Scenario 5: partial failure — one branch fails, sibling branch succeeds
+
+    @Test
+    fun `partial failure — failing branch does not affect independent sibling branch`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("a") { error("a fails") }
+            .add("b") { Patient().apply { id = "B" } }
+            .addAfter("c", "a", Patient::class) { Patient().apply { id = "C" } }
+            .addAfter("d", "b", Patient::class) { p ->
+                Encounter().apply { id = "D-${p.id}" }
+            }
+            .run()
+
+        assertTrue(result.containsKey("b"))
+        assertTrue(result.containsKey("d"))
+        val d = result.getAll("d").first() as Encounter
+        assertThat(d.id, `is`("D-B"))
+
+        assertFalse(result.containsKey("a"))
+        assertFalse(result.containsKey("c"))
+        assertThat(result.getFailedTasks().keys, containsInAnyOrder("a", "c"))
+    }
+
+    // ── Scenario 6: DAG merge with cross-DAG dependency ──────────────────────
+
+    @Test
+    fun `outer task and inner merged task used together in a post-merge dependent task`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .merge {
+                AsyncOperationResult()
+                    .add("coverage") { Coverage().apply { id = "c1" } }
+            }
+            .addAfter("claim", "patient", "coverage") { deps ->
+                val patId = (deps["patient"]!!.first() as Patient).id
+                val covId = (deps["coverage"]!!.first() as Coverage).id
+                Claim().apply { id = "$patId+$covId" }
+            }
+            .run()
+
+        assertThat(result.getKeys(), containsInAnyOrder("patient", "coverage", "claim"))
+
+        val claim = result.getAll("claim").first() as Claim
+        assertThat(claim.id, `is`("p1+c1"))
+        assertFalse(result.hasErrors())
+    }
+
+    // ── Scenario 7: retry in DAG — retried task feeds a dependent ────────────
+
+    @Test
+    fun `retried async task eventually succeeds and its dependent task receives the correct value`() = runBlocking {
+        var attempts = 0
+
+        val result = AsyncOperationResult()
+            .addWithRetry("patient", maxAttempts = 3, initialDelayMs = 0) {
+                attempts++
+                if (attempts < 3) error("transient failure attempt $attempts")
+                Patient().apply { id = "retried-p1" }
+            }
+            .addAfter("encounter", "patient", Patient::class) { p ->
+                Encounter().apply { id = "enc-${p.id}" }
+            }
+            .run()
+
+        assertEquals(3, attempts)
+        assertTrue(result.containsKey("patient"))
+        assertTrue(result.containsKey("encounter"))
+
+        val enc = result.getAll("encounter").first() as Encounter
+        assertThat(enc.id, `is`("enc-retried-p1"))
+        assertFalse(result.hasErrors())
+    }
+
+    // ── Scenario 8: type-safe addAfter chained three levels deep ─────────────
+
+    @Test
+    fun `type-safe addAfter chained three levels receives correctly typed resource at each level`() = runBlocking {
+        var patientReceived: Patient? = null
+        var encounterReceived: Encounter? = null
+        var observationReceived: Observation? = null
+
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "P" } }
+            .addAfter("encounter", "patient", Patient::class) { p ->
+                patientReceived = p
+                Encounter().apply { id = "E-from-${p.id}" }
+            }
+            .addAfter("observation", "encounter", Encounter::class) { e ->
+                encounterReceived = e
+                Observation().apply { id = "O-from-${e.id}" }
+            }
+            .addAfter("outcome", "observation", Observation::class) { obs ->
+                observationReceived = obs
+                OperationOutcome().apply {
+                    addIssue().diagnostics = "processed-${obs.id}"
+                }
+            }
+            .run()
+
+        assertEquals("P", patientReceived!!.id)
+        assertEquals("E-from-P", encounterReceived!!.id)
+        assertEquals("O-from-E-from-P", observationReceived!!.id)
+
+        val oo = result.getAll("outcome").first() as OperationOutcome
+        assertThat(oo.issueFirstRep.diagnostics, `is`("processed-O-from-E-from-P"))
+
+        assertFalse(result.hasErrors())
+    }
+
+    // ── Scenario 9: post-processing async result with OperationResult pipeline ─
+
+    @Test
+    fun `async DAG result is post-processed with sync OperationResult pipeline to produce a Bundle`() = runBlocking {
+        val asyncResult = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1"; active = true } }
+            .addList("observations") {
+                listOf(
+                    Observation().apply { id = "obs1"; status = Observation.ObservationStatus.FINAL },
+                    Observation().apply { id = "obs2"; status = Observation.ObservationStatus.FINAL }
+                )
+            }
+            .run()
+
+        val encounterRule = ReferenceLinkRule(
+            sourceType = Observation::class,
+            targetType = Patient::class,
+            setter = { obs, p -> obs.subject = Reference("Patient/${p.idPart}") }
+        )
+
+        val bundle = asyncResult
+            .linkReferences(encounterRule)
+            .toBundle(Bundle.BundleType.COLLECTION)
+
+        assertThat(bundle.entry, hasSize(3))
+
+        val observations = bundle.entry
+            .map { it.resource }
+            .filterIsInstance<Observation>()
+        assertThat(observations, hasSize(2))
+        observations.forEach { obs ->
+            assertEquals("Patient/p1", obs.subject.reference)
+        }
+    }
+
+    // ── Scenario 10: metrics — three parallel tasks, total ≈ max(individual) ─
+
+    @Test
+    fun `timed DAG with three parallel tasks reports per-task metrics and total near max not sum`() {
+        val dag = AsyncOperationResult()
+            .timed()
+            .add("t1") { Thread.sleep(60); Patient().apply { id = "1" } }
+            .add("t2") { Thread.sleep(60); Patient().apply { id = "2" } }
+            .add("t3") { Thread.sleep(60); Patient().apply { id = "3" } }
+
+        dag.runBlocking()
+
+        val metrics = dag.getMetrics()
+        assertEquals(3, metrics.size)
+        assertTrue(metrics.containsKey("t1"))
+        assertTrue(metrics.containsKey("t2"))
+        assertTrue(metrics.containsKey("t3"))
+
+        assertTrue(metrics["t1"]!!.success)
+        assertTrue(metrics["t2"]!!.success)
+        assertTrue(metrics["t3"]!!.success)
+
+        assertTrue(metrics["t1"]!!.durationMs >= 50)
+        assertTrue(metrics["t2"]!!.durationMs >= 50)
+        assertTrue(metrics["t3"]!!.durationMs >= 50)
+
+        assertTrue(dag.getTotalDuration() < 220, "Expected parallel execution but total was ${dag.getTotalDuration()}ms")
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    @Suppress("unused")
+    private fun patient(id: String) = Patient().apply { setId(id) }
+}

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultConditionalTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultConditionalTest.kt
@@ -1,0 +1,115 @@
+package dev.ratkay.operation.dstu3
+
+import kotlinx.coroutines.runBlocking
+import org.hl7.fhir.dstu3.model.Encounter
+import org.hl7.fhir.dstu3.model.Patient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AsyncOperationResultConditionalTest {
+
+    private fun patient() = Patient().apply { setId("p1") }
+    private fun encounter() = Encounter().apply { setId("e1") }
+
+    // ── addIf ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `addIf true registers and runs the task`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addIf(true, "patient") { patient() }
+            .run()
+
+        assertTrue(result.containsKey("patient"))
+        assertFalse(result.hasErrors())
+        assertEquals(1, result.count("patient"))
+    }
+
+    @Test
+    fun `addIf false does not register the task and key is absent`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addIf(false, "patient") { patient() }
+            .run()
+
+        assertFalse(result.containsKey("patient"))
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `addIf false has no effect on other registered tasks`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("encounter") { encounter() }
+            .addIf(false, "patient") { patient() }
+            .run()
+
+        assertTrue(result.containsKey("encounter"))
+        assertFalse(result.containsKey("patient"))
+        assertFalse(result.hasErrors())
+    }
+
+    // ── addListIf ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `addListIf true registers and runs the list task`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addListIf(true, "patients") { listOf(patient(), patient()) }
+            .run()
+
+        assertTrue(result.containsKey("patients"))
+        assertEquals(2, result.count("patients"))
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `addListIf false does not register the task and key is absent`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addListIf(false, "patients") { listOf(patient(), patient()) }
+            .run()
+
+        assertFalse(result.containsKey("patients"))
+        assertFalse(result.hasErrors())
+    }
+
+    // ── Chaining behaviour ────────────────────────────────────────────────────
+
+    @Test
+    fun `addIf false then addIf true — only the true task is registered`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addIf(false, "patient") { patient() }
+            .addIf(true, "encounter") { encounter() }
+            .run()
+
+        assertFalse(result.containsKey("patient"))
+        assertTrue(result.containsKey("encounter"))
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `addIf true with duplicate key still throws IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult()
+                .add("patient") { patient() }
+                .addIf(true, "patient") { patient() }
+        }
+    }
+
+    @Test
+    fun `addIf false with key that would be duplicate does not throw`() {
+        AsyncOperationResult()
+            .add("patient") { patient() }
+            .addIf(false, "patient") { patient() }
+    }
+
+    // ── Dependency contract ───────────────────────────────────────────────────
+
+    @Test
+    fun `key skipped by addIf false cannot be referenced as a dependency`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult()
+                .addIf(false, "patient") { patient() }
+                .addAfter("encounter", "patient") { encounter() }
+        }
+    }
+}

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultDagTimeoutTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultDagTimeoutTest.kt
@@ -1,0 +1,147 @@
+package dev.ratkay.operation.dstu3
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.hl7.fhir.dstu3.model.Patient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AsyncOperationResultDagTimeoutTest {
+
+    private fun patient(id: String = "p1") = Patient().apply { setId(id) }
+
+    // ── Completes within deadline ─────────────────────────────────────────────
+
+    @Test
+    fun `DAG completing before timeout returns all task results`() = runBlocking {
+        val result = AsyncOperationResult()
+            .timeout(500)
+            .add("patient") { patient() }
+            .run()
+
+        assertTrue(result.containsKey("patient"))
+        assertFalse(result.hasErrors())
+    }
+
+    // ── Exceeds deadline ──────────────────────────────────────────────────────
+
+    @Test
+    fun `DAG exceeding timeout returns error and no task results`() = runBlocking {
+        val result = AsyncOperationResult()
+            .timeout(20)
+            .add("patient") { delay(200); patient() }
+            .run()
+
+        assertFalse(result.containsKey("patient"))
+        assertTrue(result.hasErrors())
+        assertTrue(result.getKeys().isEmpty())
+    }
+
+    @Test
+    fun `DAG timeout outcome diagnostics mention exceeded timeout`() = runBlocking {
+        val result = AsyncOperationResult()
+            .timeout(20)
+            .add("patient") { delay(200); patient() }
+            .run()
+
+        val diagnostics = result.getOutcomes().first().issueFirstRep.diagnostics
+        assertThat(diagnostics, containsString("exceeded timeout"))
+        assertThat(diagnostics, containsString("20ms"))
+    }
+
+    @Test
+    fun `DAG timeout outcome has exactly one OperationOutcome`() = runBlocking {
+        val result = AsyncOperationResult()
+            .timeout(20)
+            .add("a") { delay(200); patient("a") }
+            .add("b") { delay(200); patient("b") }
+            .run()
+
+        assertEquals(1, result.getOutcomes().size)
+    }
+
+    // ── runBlocking respects DAG timeout ──────────────────────────────────────
+
+    @Test
+    fun `runBlocking respects DAG timeout`() {
+        val result = AsyncOperationResult()
+            .timeout(20)
+            .add("patient") { delay(200); patient() }
+            .runBlocking()
+
+        assertFalse(result.containsKey("patient"))
+        assertTrue(result.hasErrors())
+    }
+
+    // ── Fluency and chaining ──────────────────────────────────────────────────
+
+    @Test
+    fun `timeout is fluent and returns this`() = runBlocking {
+        val dag = AsyncOperationResult()
+        val returned = dag.timeout(500)
+
+        assertTrue(returned === dag)
+    }
+
+    @Test
+    fun `timeout can be chained with other methods`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("a") { patient("a") }
+            .timeout(500)
+            .add("b") { patient("b") }
+            .run()
+
+        assertTrue(result.containsKey("a"))
+        assertTrue(result.containsKey("b"))
+        assertFalse(result.hasErrors())
+    }
+
+    // ── getTotalDuration after timeout ────────────────────────────────────────
+
+    @Test
+    fun `getTotalDuration is 0 after DAG timeout`() = runBlocking {
+        val dag = AsyncOperationResult()
+            .timeout(20)
+            .add("patient") { delay(200); patient() }
+
+        dag.run()
+
+        assertEquals(0L, dag.getTotalDuration())
+    }
+
+    // ── Per-task timeout and DAG timeout coexist ──────────────────────────────
+
+    @Test
+    fun `per-task timeout and DAG timeout can both be set — DAG timeout is outer bound`() = runBlocking {
+        val result = AsyncOperationResult()
+            .timeout(20)
+            .addWithTimeout("patient", 200) { delay(150); patient() }
+            .run()
+
+        assertFalse(result.containsKey("patient"))
+        assertTrue(result.hasErrors())
+        assertEquals(1, result.getOutcomes().size)
+        assertThat(result.getOutcomes().first().issueFirstRep.diagnostics, containsString("exceeded timeout"))
+    }
+
+    // ── Parameter validation ──────────────────────────────────────────────────
+
+    @Test
+    fun `timeout throws when durationMs is zero`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult().timeout(0)
+        }
+    }
+
+    @Test
+    fun `timeout throws when durationMs is negative`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult().timeout(-100)
+        }
+    }
+}

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultDefaultTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultDefaultTest.kt
@@ -1,0 +1,181 @@
+package dev.ratkay.operation.dstu3
+
+import dev.ratkay.operation.StepMetrics
+
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.instanceOf
+import org.hl7.fhir.dstu3.model.Encounter
+import org.hl7.fhir.dstu3.model.Patient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AsyncOperationResultDefaultTest {
+
+    private fun patient(id: String = "p1") = Patient().apply { setId(id) }
+    private fun encounter(id: String = "e1") = Encounter().apply { setId("e1") }
+
+    // ── addWithDefault: success path ──────────────────────────────────────────
+
+    @Test
+    fun `addWithDefault returns block result when block succeeds`() = runBlocking {
+        val blockPatient = patient("from-block")
+        val defaultPatient = patient("default")
+
+        val result = AsyncOperationResult()
+            .addWithDefault("patient", defaultPatient) { blockPatient }
+            .run()
+
+        assertTrue(result.containsKey("patient"))
+        assertEquals("from-block", (result.getAll("patient").first() as Patient).idElement.idPart)
+        assertFalse(result.hasErrors())
+    }
+
+    // ── addWithDefault: failure path ──────────────────────────────────────────
+
+    @Test
+    fun `addWithDefault stores default when block throws and key is present`() = runBlocking {
+        val defaultPatient = patient("default")
+
+        val result = AsyncOperationResult()
+            .addWithDefault("patient", defaultPatient) { throw RuntimeException("transient") }
+            .run()
+
+        assertTrue(result.containsKey("patient"))
+        assertEquals("default", (result.getAll("patient").first() as Patient).idElement.idPart)
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `addWithDefault stores default on BaseServerResponseException`() = runBlocking {
+        val defaultPatient = patient("default")
+
+        val result = AsyncOperationResult()
+            .addWithDefault("patient", defaultPatient) { throw InternalErrorException("server error") }
+            .run()
+
+        assertTrue(result.containsKey("patient"))
+        assertEquals("default", (result.getAll("patient").first() as Patient).idElement.idPart)
+        assertFalse(result.hasErrors())
+    }
+
+    // ── addListWithDefault: success path ──────────────────────────────────────
+
+    @Test
+    fun `addListWithDefault returns block list when block succeeds`() = runBlocking {
+        val blockList = listOf(patient("a"), patient("b"))
+        val defaultList = listOf(patient("default"))
+
+        val result = AsyncOperationResult()
+            .addListWithDefault("patients", defaultList) { blockList }
+            .run()
+
+        assertTrue(result.containsKey("patients"))
+        assertEquals(2, result.count("patients"))
+        assertFalse(result.hasErrors())
+    }
+
+    // ── addListWithDefault: failure path ──────────────────────────────────────
+
+    @Test
+    fun `addListWithDefault stores default list when block throws`() = runBlocking {
+        val defaultList = listOf(patient("default"))
+
+        val result = AsyncOperationResult()
+            .addListWithDefault("patients", defaultList) { throw RuntimeException("boom") }
+            .run()
+
+        assertTrue(result.containsKey("patients"))
+        assertEquals(1, result.count("patients"))
+        assertEquals("default", (result.getAll("patients").first() as Patient).idElement.idPart)
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `addListWithDefault with empty default list — key absent since nothing accumulated`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addListWithDefault("patients", emptyList()) { throw RuntimeException("boom") }
+            .run()
+
+        assertEquals(0, result.count("patients"))
+        assertFalse(result.hasErrors())
+    }
+
+    // ── Downstream dependency contract ────────────────────────────────────────
+
+    @Test
+    fun `downstream addAfter receives default value when addWithDefault falls back`() = runBlocking {
+        val defaultPatient = patient("default")
+
+        val result = AsyncOperationResult()
+            .addWithDefault("patient", defaultPatient) { throw RuntimeException("transient") }
+            .addAfter("encounter", "patient") { _ -> encounter() }
+            .run()
+
+        assertTrue(result.containsKey("patient"))
+        assertTrue(result.containsKey("encounter"))
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `downstream addAfter receives actual result when addWithDefault succeeds`() = runBlocking {
+        val blockPatient = patient("real")
+        val defaultPatient = patient("default")
+
+        val result = AsyncOperationResult()
+            .addWithDefault("patient", defaultPatient) { blockPatient }
+            .addAfter("encounter", "patient", Patient::class) { p ->
+                Encounter().apply { subject.reference = "Patient/${p.idElement.idPart}" }
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounter"))
+        val enc = result.getAll("encounter").first() as Encounter
+        assertEquals("Patient/real", enc.subject.reference)
+        assertFalse(result.hasErrors())
+    }
+
+    // ── Metrics integration ───────────────────────────────────────────────────
+
+    @Test
+    fun `timed — addWithDefault falling back records success=true in StepMetrics`() = runBlocking {
+        val defaultPatient = patient("default")
+
+        val dag = AsyncOperationResult()
+            .timed()
+            .addWithDefault("patient", defaultPatient) { throw RuntimeException("transient") }
+
+        dag.run()
+
+        val metrics = dag.getMetrics()
+        assertTrue(metrics.containsKey("patient"))
+        assertTrue(metrics["patient"]!!.success)
+    }
+
+    @Test
+    fun `timed — addWithDefault succeeding records success=true in StepMetrics`() = runBlocking {
+        val dag = AsyncOperationResult()
+            .timed()
+            .addWithDefault("patient", patient("default")) { patient("real") }
+
+        dag.run()
+
+        val metrics = dag.getMetrics()
+        assertTrue(metrics.containsKey("patient"))
+        assertTrue(metrics["patient"]!!.success)
+    }
+
+    // ── Type check ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `addWithDefault result has correct FHIR type`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addWithDefault("patient", patient()) { throw RuntimeException() }
+            .run()
+
+        assertThat(result.getAll("patient").first(), instanceOf(Patient::class.java))
+    }
+}

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultDependentRetryTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultDependentRetryTest.kt
@@ -1,0 +1,244 @@
+package dev.ratkay.operation.dstu3
+
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.instanceOf
+import org.hl7.fhir.dstu3.model.Encounter
+import org.hl7.fhir.dstu3.model.Patient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AsyncOperationResultDependentRetryTest {
+
+    private fun patient() = Patient().apply { setId("p1") }
+    private fun encounter() = Encounter().apply { setId("e1") }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `addAfterWithRetry succeeds on first attempt`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addAfterWithRetry("encounter", "patient", maxAttempts = 3, initialDelayMs = 0) { _ ->
+                encounter()
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounter"))
+        assertFalse(result.hasErrors())
+        assertThat(result.getAll("encounter").first(), instanceOf(Encounter::class.java))
+    }
+
+    @Test
+    fun `addAfterWithRetry succeeds on second attempt after transient failure`() = runBlocking {
+        var attempts = 0
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addAfterWithRetry("encounter", "patient", maxAttempts = 3, initialDelayMs = 0) { _ ->
+                attempts++
+                if (attempts < 2) throw RuntimeException("transient")
+                encounter()
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounter"))
+        assertFalse(result.hasErrors())
+        assertEquals(2, attempts)
+    }
+
+    @Test
+    fun `addAfterWithRetry succeeds on last attempt`() = runBlocking {
+        var attempts = 0
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addAfterWithRetry("encounter", "patient", maxAttempts = 3, initialDelayMs = 0) { _ ->
+                attempts++
+                if (attempts < 3) throw RuntimeException("transient")
+                encounter()
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounter"))
+        assertFalse(result.hasErrors())
+        assertEquals(3, attempts)
+    }
+
+    // ── Failure paths ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `addAfterWithRetry exhausts all attempts and records error`() = runBlocking {
+        var attempts = 0
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addAfterWithRetry("encounter", "patient", maxAttempts = 3, initialDelayMs = 0) { _ ->
+                attempts++
+                throw RuntimeException("always fails")
+            }
+            .run()
+
+        assertFalse(result.containsKey("encounter"))
+        assertTrue(result.hasErrors())
+        assertEquals(3, attempts)
+        assertTrue(result.getFailedTasks().containsKey("encounter"))
+    }
+
+    @Test
+    fun `addAfterWithRetry with maxAttempts=1 does not retry`() = runBlocking {
+        var attempts = 0
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addAfterWithRetry("encounter", "patient", maxAttempts = 1, initialDelayMs = 0) { _ ->
+                attempts++
+                throw RuntimeException("fails")
+            }
+            .run()
+
+        assertFalse(result.containsKey("encounter"))
+        assertTrue(result.hasErrors())
+        assertEquals(1, attempts)
+    }
+
+    @Test
+    fun `addAfterWithRetry retryOn predicate stops retrying immediately when false`() = runBlocking {
+        var attempts = 0
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addAfterWithRetry(
+                "encounter", "patient",
+                maxAttempts = 5,
+                initialDelayMs = 0,
+                retryOn = { false }
+            ) { _ ->
+                attempts++
+                throw RuntimeException("non-retryable")
+            }
+            .run()
+
+        assertFalse(result.containsKey("encounter"))
+        assertTrue(result.hasErrors())
+        assertEquals(1, attempts)
+    }
+
+    @Test
+    fun `addAfterWithRetry retryOn predicate filters by exception type`() = runBlocking {
+        var attempts = 0
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addAfterWithRetry(
+                "encounter", "patient",
+                maxAttempts = 5,
+                initialDelayMs = 0,
+                retryOn = { e -> e is IllegalStateException }
+            ) { _ ->
+                attempts++
+                if (attempts == 1) throw IllegalStateException("transient — retryable")
+                throw InternalErrorException("permanent — not retryable")
+            }
+            .run()
+
+        assertFalse(result.containsKey("encounter"))
+        assertTrue(result.hasErrors())
+        assertEquals(2, attempts)
+    }
+
+    // ── Parameter validation ──────────────────────────────────────────────────
+
+    @Test
+    fun `addAfterWithRetry throws when maxAttempts is less than 1`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult()
+                .add("patient") { patient() }
+                .addAfterWithRetry("encounter", "patient", maxAttempts = 0, initialDelayMs = 0) { _ ->
+                    encounter()
+                }
+        }
+    }
+
+    @Test
+    fun `addAfterWithRetry throws when initialDelayMs is negative`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult()
+                .add("patient") { patient() }
+                .addAfterWithRetry("encounter", "patient", maxAttempts = 3, initialDelayMs = -1) { _ ->
+                    encounter()
+                }
+        }
+    }
+
+    // ── Dependency failure contract ───────────────────────────────────────────
+
+    @Test
+    fun `addAfterWithRetry does not run retry loop when dependency fails`() = runBlocking {
+        var attempts = 0
+        val result = AsyncOperationResult()
+            .add("patient") { throw RuntimeException("dep failed") }
+            .addAfterWithRetry("encounter", "patient", maxAttempts = 5, initialDelayMs = 0) { _ ->
+                attempts++
+                encounter()
+            }
+            .run()
+
+        assertFalse(result.containsKey("encounter"))
+        assertTrue(result.hasErrors())
+        assertEquals(0, attempts)
+        assertTrue(result.getFailedTasks().containsKey("patient"))
+        assertTrue(result.getFailedTasks().containsKey("encounter"))
+    }
+
+    // ── addListAfterWithRetry ─────────────────────────────────────────────────
+
+    @Test
+    fun `addListAfterWithRetry succeeds and stores list result`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addListAfterWithRetry("encounters", "patient", maxAttempts = 3, initialDelayMs = 0) { _ ->
+                listOf(encounter(), encounter())
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounters"))
+        assertEquals(2, result.count("encounters"))
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `addListAfterWithRetry retries on failure`() = runBlocking {
+        var attempts = 0
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addListAfterWithRetry("encounters", "patient", maxAttempts = 3, initialDelayMs = 0) { _ ->
+                attempts++
+                if (attempts < 2) throw RuntimeException("transient")
+                listOf(encounter())
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounters"))
+        assertFalse(result.hasErrors())
+        assertEquals(2, attempts)
+    }
+
+    // ── Integration ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `addAfterWithRetry coexists with add and addAfter tasks`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .add("coverage") { Patient().apply { setId("coverage1") } }
+            .addAfterWithRetry("encounter", "patient", maxAttempts = 2, initialDelayMs = 0) { _ ->
+                encounter()
+            }
+            .addAfter("summary", "encounter", "coverage") { _ -> Patient().apply { setId("summary") } }
+            .run()
+
+        assertTrue(result.containsKey("patient"))
+        assertTrue(result.containsKey("coverage"))
+        assertTrue(result.containsKey("encounter"))
+        assertTrue(result.containsKey("summary"))
+        assertFalse(result.hasErrors())
+    }
+}

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultDescribeTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultDescribeTest.kt
@@ -1,0 +1,211 @@
+package dev.ratkay.operation.dstu3
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.not
+import org.hl7.fhir.dstu3.model.Appointment
+import org.hl7.fhir.dstu3.model.Coverage
+import org.hl7.fhir.dstu3.model.Patient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AsyncOperationResultDescribeTest {
+
+    // ── Empty DAG ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `describe returns empty sentinel when no tasks registered`() {
+        val output = AsyncOperationResult().describe()
+        assertThat(output, `is`("AsyncOperationResult DAG: (empty)"))
+    }
+
+    // ── Header ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `describe always starts with AsyncOperationResult DAG header`() {
+        val output = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .describe()
+        assertThat(output, containsString("AsyncOperationResult DAG:"))
+    }
+
+    // ── Single independent task ───────────────────────────────────────────────
+
+    @Test
+    fun `describe shows single independent task in Tier 1 without depends-on clause`() {
+        val output = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .describe()
+
+        assertThat(output, containsString("Tier 1 (parallel): [patient]"))
+        assertThat(output, not(containsString("depends on")))
+    }
+
+    // ── Multiple independent tasks ────────────────────────────────────────────
+
+    @Test
+    fun `describe groups all independent tasks into Tier 1`() {
+        val output = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .add("coverage") { Coverage() }
+            .describe()
+
+        assertThat(output, containsString("Tier 1 (parallel): [patient, coverage]"))
+        assertThat(output, not(containsString("Tier 2")))
+    }
+
+    // ── Two-tier DAG ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `describe shows correct two-tier structure`() {
+        val output = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .addAfter("appointment", "patient") { Patient() }
+            .describe()
+
+        val lines = output.lines()
+        assertThat(lines[1], containsString("Tier 1 (parallel): [patient]"))
+        assertThat(lines[2], containsString("Tier 2 (parallel): [appointment]"))
+        assertThat(lines[2], containsString("depends on [patient]"))
+    }
+
+    // ── Three-tier DAG (matches spec example) ─────────────────────────────────
+
+    @Test
+    fun `describe matches the spec example exactly`() {
+        val output = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .add("coverage") { Coverage() }
+            .addAfter("appointment", "patient") { Patient() }
+            .addAfter("claim", "appointment", "coverage") { Patient() }
+            .describe()
+
+        val expected = """
+            AsyncOperationResult DAG:
+              Tier 1 (parallel): [patient, coverage]
+              Tier 2 (parallel): [appointment] → depends on [patient]
+              Tier 3 (parallel): [claim] → depends on [appointment, coverage]
+        """.trimIndent()
+
+        assertEquals(expected, output)
+    }
+
+    // ── Tier placement with mixed dependencies ────────────────────────────────
+
+    @Test
+    fun `describe places task in correct tier when deps span multiple tiers`() {
+        val output = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .add("coverage") { Coverage() }
+            .addAfter("appointment", "patient") { Patient() }
+            .addAfter("claim", "appointment", "coverage") { Patient() }
+            .describe()
+
+        assertThat(output, containsString("Tier 3 (parallel): [claim]"))
+        assertThat(output, containsString("depends on [appointment, coverage]"))
+    }
+
+    @Test
+    fun `describe places task in tier after its deepest dependency`() {
+        val output = AsyncOperationResult()
+            .add("a") { Patient() }
+            .addAfter("b", "a") { Patient() }
+            .addAfter("c", "b") { Patient() }
+            .addAfter("d", "c") { Patient() }
+            .describe()
+
+        assertThat(output, containsString("Tier 1 (parallel): [a]"))
+        assertThat(output, containsString("Tier 2 (parallel): [b]"))
+        assertThat(output, containsString("Tier 3 (parallel): [c]"))
+        assertThat(output, containsString("Tier 4 (parallel): [d]"))
+    }
+
+    // ── Multiple tasks in a non-root tier ─────────────────────────────────────
+
+    @Test
+    fun `describe groups multiple tasks in the same tier on one line`() {
+        val output = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .addAfter("appointment", "patient") { Patient() }
+            .addAfter("coverage", "patient") { Patient() }
+            .describe()
+
+        assertThat(output, containsString("Tier 1 (parallel): [patient]"))
+        assertThat(output, containsString("Tier 2 (parallel): [appointment, coverage]"))
+        assertThat(output, containsString("depends on [patient]"))
+        assertThat(output, not(containsString("Tier 3")))
+    }
+
+    @Test
+    fun `describe union-merges dependencies when two Tier-2 tasks have different deps`() {
+        val output = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .add("coverage") { Coverage() }
+            .addAfter("appointment", "patient") { Patient() }
+            .addAfter("claim-item", "coverage") { Patient() }
+            .describe()
+
+        assertThat(output, containsString("Tier 2 (parallel): [appointment, claim-item]"))
+        assertThat(output, containsString("depends on [patient, coverage]"))
+    }
+
+    // ── Depends-on absent for Tier 1 ─────────────────────────────────────────
+
+    @Test
+    fun `describe never shows depends-on clause for Tier 1 tasks`() {
+        val output = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .add("coverage") { Coverage() }
+            .addAfter("appointment", "patient") { Patient() }
+            .describe()
+
+        val tier1Line = output.lines().first { it.contains("Tier 1") }
+        assertThat(tier1Line, not(containsString("depends on")))
+    }
+
+    // ── addList tasks appear in describe ─────────────────────────────────────
+
+    @Test
+    fun `describe includes tasks registered via addList`() {
+        val output = AsyncOperationResult()
+            .addList("items") { listOf(Patient(), Coverage()) }
+            .describe()
+
+        assertThat(output, containsString("Tier 1 (parallel): [items]"))
+    }
+
+    @Test
+    fun `describe includes tasks registered via addListAfter`() {
+        val output = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .addListAfter("appointments", "patient") { _ -> listOf(Appointment()) }
+            .describe()
+
+        assertThat(output, containsString("Tier 2 (parallel): [appointments]"))
+        assertThat(output, containsString("depends on [patient]"))
+    }
+
+    // ── Output format ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `describe output does not end with trailing newline`() {
+        val output = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .describe()
+
+        assertThat(output.last().toString(), not(`is`("\n")))
+    }
+
+    @Test
+    fun `describe produces one line per tier`() {
+        val output = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .addAfter("appointment", "patient") { Patient() }
+            .addAfter("claim", "appointment") { Patient() }
+            .describe()
+
+        val tierLines = output.lines().filter { it.contains("Tier") }
+        assertEquals(3, tierLines.size)
+    }
+}

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultMergeTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultMergeTest.kt
@@ -1,0 +1,344 @@
+package dev.ratkay.operation.dstu3
+
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.`is`
+import org.hl7.fhir.dstu3.model.Appointment
+import org.hl7.fhir.dstu3.model.Claim
+import org.hl7.fhir.dstu3.model.Coverage
+import org.hl7.fhir.dstu3.model.Encounter
+import org.hl7.fhir.dstu3.model.Patient
+import org.hl7.fhir.dstu3.model.Practitioner
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AsyncOperationResultMergeTest {
+
+    // ── Group 1: Basic merge behaviour ───────────────────────────────────────
+
+    @Test
+    fun `merge - inner nodes appear in result`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("outer") { Patient().apply { id = "p1" } }
+            .merge {
+                AsyncOperationResult()
+                    .add("inner") { Coverage().apply { id = "c1" } }
+            }
+            .run()
+
+        assertThat(result.containsKey("outer"), `is`(true))
+        assertThat(result.containsKey("inner"), `is`(true))
+    }
+
+    @Test
+    fun `merge - inner nodes execute and produce correct values`() = runBlocking {
+        val result = AsyncOperationResult()
+            .merge {
+                AsyncOperationResult()
+                    .add("coverage") { Coverage().apply { id = "cov1" } }
+            }
+            .run()
+
+        assertThat(result.count("coverage"), `is`(1))
+        assertThat((result.getAll("coverage").first() as Coverage).id, `is`("cov1"))
+    }
+
+    @Test
+    fun `merge - addAfter after merge can reference merged inner key`() = runBlocking {
+        val result = AsyncOperationResult()
+            .merge {
+                AsyncOperationResult()
+                    .add("patient") { Patient().apply { id = "p1" } }
+            }
+            .addAfter("encounter", "patient", Patient::class) { patient ->
+                Encounter().apply { id = "enc-${patient.id}" }
+            }
+            .run()
+
+        val encounter = result.getAll("encounter").first() as Encounter
+        assertThat(encounter.id, `is`("enc-p1"))
+    }
+
+    @Test
+    fun `merge - outer and inner keys coexist and all produce results`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("outerA") { Patient().apply { id = "a" } }
+            .add("outerB") { Coverage().apply { id = "b" } }
+            .merge {
+                AsyncOperationResult()
+                    .add("innerX") { Appointment().apply { id = "x" } }
+                    .add("innerY") { Practitioner().apply { id = "y" } }
+            }
+            .run()
+
+        assertThat(result.getKeys(), containsInAnyOrder("outerA", "outerB", "innerX", "innerY"))
+        assertThat(result.totalCount(), `is`(4))
+    }
+
+    // ── Group 2: Inner DAG's internal dependencies survive merge ─────────────
+
+    @Test
+    fun `merge - inner dependent node resolves correctly after merge`() = runBlocking {
+        val result = AsyncOperationResult()
+            .merge {
+                AsyncOperationResult()
+                    .add("base") { Patient().apply { id = "base" } }
+                    .addAfter("derived", "base", Patient::class) { p ->
+                        Coverage().apply { id = "derived-from-${p.id}" }
+                    }
+            }
+            .run()
+
+        val derived = result.getAll("derived").first() as Coverage
+        assertThat(derived.id, `is`("derived-from-base"))
+    }
+
+    @Test
+    fun `merge - inner three-tier chain resolves in order after merge`() = runBlocking {
+        val result = AsyncOperationResult()
+            .merge {
+                AsyncOperationResult()
+                    .add("a") { Patient().apply { id = "A" } }
+                    .addAfter("b", "a", Patient::class) { a ->
+                        Patient().apply { id = "${a.id}-B" }
+                    }
+                    .addAfter("c", "b", Patient::class) { b ->
+                        Patient().apply { id = "${b.id}-C" }
+                    }
+            }
+            .run()
+
+        assertThat((result.getAll("c").first() as Patient).id, `is`("A-B-C"))
+    }
+
+    // ── Group 3: Composing outer + inner ─────────────────────────────────────
+
+    @Test
+    fun `merge - addAfter after merge can depend on both outer and inner keys`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("outerPatient") { Patient().apply { id = "p1" } }
+            .merge {
+                AsyncOperationResult()
+                    .add("innerCoverage") { Coverage().apply { id = "c1" } }
+            }
+            .addAfter("claim", "outerPatient", "innerCoverage") { deps ->
+                val patient = deps["outerPatient"]!!.first() as Patient
+                val coverage = deps["innerCoverage"]!!.first() as Coverage
+                Claim().apply { id = "${patient.id}+${coverage.id}" }
+            }
+            .run()
+
+        val claim = result.getAll("claim").first() as Claim
+        assertThat(claim.id, `is`("p1+c1"))
+    }
+
+    // ── Group 4: Error handling ───────────────────────────────────────────────
+
+    @Test
+    fun `merge - inner task failure is captured as failed task`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("outer") { Patient() }
+            .merge {
+                AsyncOperationResult()
+                    .add("failing") { error("inner boom") }
+            }
+            .run()
+
+        assertThat(result.containsKey("outer"), `is`(true))
+        assertFalse(result.containsKey("failing"))
+        assertTrue(result.hasErrors())
+        assertTrue(result.getFailedTasks().containsKey("failing"))
+    }
+
+    @Test
+    fun `merge - inner failure does not affect independent outer tasks`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("outer") { Patient().apply { id = "ok" } }
+            .merge {
+                AsyncOperationResult()
+                    .add("failing") { error("boom") }
+            }
+            .run()
+
+        assertThat(result.containsKey("outer"), `is`(true))
+        assertThat(result.getFailedTasks().size, `is`(1))
+    }
+
+    // ── Group 5: Duplicate key validation ────────────────────────────────────
+
+    @Test
+    fun `merge - duplicate key between outer and inner throws IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult()
+                .add("patient") { Patient() }
+                .merge {
+                    AsyncOperationResult()
+                        .add("patient") { Coverage() }
+                }
+        }
+    }
+
+    @Test
+    fun `merge - duplicate key across two sequential merges throws IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult()
+                .merge {
+                    AsyncOperationResult().add("patient") { Patient() }
+                }
+                .merge {
+                    AsyncOperationResult().add("patient") { Coverage() }
+                }
+        }
+    }
+
+    // ── Group 6: Edge cases ───────────────────────────────────────────────────
+
+    @Test
+    fun `merge - empty inner DAG is a no-op`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .merge { AsyncOperationResult() }
+            .run()
+
+        assertThat(result.containsKey("patient"), `is`(true))
+        assertThat(result.totalCount(), `is`(1))
+    }
+
+    @Test
+    fun `merge - empty outer merged with non-empty inner works`() = runBlocking {
+        val result = AsyncOperationResult()
+            .merge {
+                AsyncOperationResult()
+                    .add("only") { Patient().apply { id = "sole" } }
+            }
+            .run()
+
+        assertThat(result.containsKey("only"), `is`(true))
+        assertThat((result.getAll("only").first() as Patient).id, `is`("sole"))
+    }
+
+    @Test
+    fun `merge - multiple sequential merges accumulate all nodes`() = runBlocking {
+        val result = AsyncOperationResult()
+            .merge { AsyncOperationResult().add("a") { Patient() } }
+            .merge { AsyncOperationResult().add("b") { Coverage() } }
+            .merge { AsyncOperationResult().add("c") { Appointment() } }
+            .run()
+
+        assertThat(result.getKeys(), containsInAnyOrder("a", "b", "c"))
+        assertThat(result.totalCount(), `is`(3))
+    }
+
+    @Test
+    fun `merge - addAfter chain after merge referencing inner key resolves correctly`() = runBlocking {
+        val result = AsyncOperationResult()
+            .merge {
+                AsyncOperationResult()
+                    .add("patient") { Patient().apply { id = "p1" } }
+            }
+            .addAfter("coverage", "patient", Patient::class) { p ->
+                Coverage().apply { id = "cov-${p.id}" }
+            }
+            .addAfter("claim", "coverage", Coverage::class) { c ->
+                Claim().apply { id = "claim-${c.id}" }
+            }
+            .run()
+
+        val claim = result.getAll("claim").first() as Claim
+        assertThat(claim.id, `is`("claim-cov-p1"))
+    }
+
+    // ── Group 7: Instance overload ────────────────────────────────────────────
+
+    @Test
+    fun `merge instance overload - pre-built inner DAG merges correctly`() = runBlocking {
+        val innerDag = AsyncOperationResult()
+            .add("coverage") { Coverage().apply { id = "c1" } }
+
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .merge(innerDag)
+            .run()
+
+        assertThat(result.getKeys(), containsInAnyOrder("patient", "coverage"))
+    }
+
+    @Test
+    fun `merge instance overload - duplicate key throws IllegalArgumentException`() {
+        val innerDag = AsyncOperationResult().add("patient") { Coverage() }
+
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult()
+                .add("patient") { Patient() }
+                .merge(innerDag)
+        }
+    }
+
+    // ── Group 8: describe() integration ──────────────────────────────────────
+
+    @Test
+    fun `merge - describe shows merged nodes in correct tiers`() {
+        val output = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .merge {
+                AsyncOperationResult()
+                    .add("coverage") { Coverage() }
+                    .addAfter("claim", "coverage") { _ -> Claim() }
+            }
+            .describe()
+
+        assertThat(output, containsString("patient"))
+        assertThat(output, containsString("coverage"))
+        assertThat(output, containsString("claim"))
+        assertThat(output, containsString("depends on [coverage]"))
+    }
+
+    @Test
+    fun `merge - describe reflects cross-DAG dependency added after merge`() {
+        val output = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .merge {
+                AsyncOperationResult().add("coverage") { Coverage() }
+            }
+            .addAfter("claim", "patient", "coverage") { _ -> Claim() }
+            .describe()
+
+        assertThat(output, containsString("claim"))
+        assertThat(output, containsString("depends on [patient, coverage]"))
+    }
+
+    // ── Group 9: Timing / metrics ─────────────────────────────────────────────
+
+    @Test
+    fun `merge - timed outer DAG captures metrics for merged inner tasks`() {
+        val dag = AsyncOperationResult()
+            .timed()
+            .merge {
+                AsyncOperationResult()
+                    .add("innerPatient") { Patient() }
+            }
+
+        dag.runBlocking()
+
+        assertTrue(dag.getMetrics().containsKey("innerPatient"))
+        assertTrue(dag.getMetrics()["innerPatient"]!!.success)
+    }
+
+    @Test
+    fun `merge - inner DAG timed setting does not enable metrics on outer`() {
+        val dag = AsyncOperationResult()
+            .merge {
+                AsyncOperationResult()
+                    .timed()
+                    .add("innerTask") { Patient() }
+            }
+
+        dag.runBlocking()
+
+        assertTrue(dag.getMetrics().isEmpty())
+    }
+}

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultMetricsTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultMetricsTest.kt
@@ -1,0 +1,232 @@
+package dev.ratkay.operation.dstu3
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import org.hl7.fhir.dstu3.model.Encounter
+import org.hl7.fhir.dstu3.model.Patient
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+
+class AsyncOperationResultMetricsTest {
+
+    // ── Log capture setup ─────────────────────────────────────────────────────
+
+    private lateinit var logAppender: ListAppender<ILoggingEvent>
+    private lateinit var logger: Logger
+
+    @BeforeEach
+    fun attachLogAppender() {
+        logger = LoggerFactory.getLogger(AsyncOperationResult::class.java) as Logger
+        logger.level = Level.DEBUG
+        logAppender = ListAppender<ILoggingEvent>().also { it.start() }
+        logger.addAppender(logAppender)
+    }
+
+    @AfterEach
+    fun detachLogAppender() {
+        logger.detachAppender(logAppender)
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun patient() = Patient().apply { setId("p1") }
+    private fun encounter() = Encounter().apply { status = Encounter.EncounterStatus.FINISHED }
+
+    private fun debugMessages() = logAppender.list
+        .filter { it.level == Level.DEBUG }
+        .map { it.formattedMessage }
+
+    // ── getMetrics disabled by default ────────────────────────────────────────
+
+    @Test
+    fun `getMetrics returns empty map when timed is not called`() {
+        val dag = AsyncOperationResult()
+            .add("patient") { patient() }
+            .add("encounter") { encounter() }
+
+        dag.runBlocking()
+
+        assertTrue(dag.getMetrics().isEmpty())
+    }
+
+    // ── getMetrics with timed() enabled ──────────────────────────────────────
+
+    @Test
+    fun `getMetrics contains an entry for each registered task`() {
+        val dag = AsyncOperationResult()
+            .timed()
+            .add("patient") { patient() }
+            .add("encounter") { encounter() }
+
+        dag.runBlocking()
+
+        val metrics = dag.getMetrics()
+        assertEquals(2, metrics.size)
+        assertTrue(metrics.containsKey("patient"))
+        assertTrue(metrics.containsKey("encounter"))
+    }
+
+    @Test
+    fun `getMetrics task entry has correct resourceType`() {
+        val dag = AsyncOperationResult()
+            .timed()
+            .add("patient") { patient() }
+
+        dag.runBlocking()
+
+        assertEquals("Patient", dag.getMetrics()["patient"]!!.resourceType)
+    }
+
+    @Test
+    fun `getMetrics task entry has non-negative duration`() {
+        val dag = AsyncOperationResult()
+            .timed()
+            .add("patient") { patient() }
+
+        dag.runBlocking()
+
+        assertTrue(dag.getMetrics()["patient"]!!.durationMs >= 0)
+    }
+
+    @Test
+    fun `getMetrics success is true for completed tasks`() {
+        val dag = AsyncOperationResult()
+            .timed()
+            .add("patient") { patient() }
+
+        dag.runBlocking()
+
+        assertTrue(dag.getMetrics()["patient"]!!.success)
+    }
+
+    @Test
+    fun `getMetrics success is false for failed tasks`() {
+        val dag = AsyncOperationResult()
+            .timed()
+            .add("bad") { throw RuntimeException("boom") }
+
+        dag.runBlocking()
+
+        val m = dag.getMetrics()["bad"]!!
+        assertFalse(m.success)
+        assertEquals("bad", m.stepName)
+    }
+
+    @Test
+    fun `getMetrics includes parallel tasks that ran concurrently`() {
+        val dag = AsyncOperationResult()
+            .timed()
+            .add("patient") { patient() }
+            .add("encounter") { encounter() }
+
+        dag.runBlocking()
+
+        assertEquals(2, dag.getMetrics().size)
+        assertTrue(dag.getMetrics()["patient"]!!.success)
+        assertTrue(dag.getMetrics()["encounter"]!!.success)
+    }
+
+    @Test
+    fun `getMetrics includes dependent task with correct step name`() {
+        val dag = AsyncOperationResult()
+            .timed()
+            .add("patient") { patient() }
+            .addAfter("encounter", "patient", Patient::class) { _ -> encounter() }
+
+        dag.runBlocking()
+
+        assertTrue(dag.getMetrics().containsKey("encounter"))
+        assertEquals("encounter", dag.getMetrics()["encounter"]!!.stepName)
+    }
+
+    // ── getTotalDuration ──────────────────────────────────────────────────────
+
+    @Test
+    fun `getTotalDuration is zero before run`() {
+        val dag = AsyncOperationResult().add("patient") { patient() }
+        assertEquals(0L, dag.getTotalDuration())
+    }
+
+    @Test
+    fun `getTotalDuration is positive after run`() {
+        val dag = AsyncOperationResult()
+            .add("patient") { patient() }
+            .add("encounter") { encounter() }
+
+        dag.runBlocking()
+
+        assertTrue(dag.getTotalDuration() >= 0)
+    }
+
+    // ── DEBUG log messages ────────────────────────────────────────────────────
+
+    @Test
+    fun `each task emits STARTED and COMPLETED DEBUG log messages`() {
+        AsyncOperationResult()
+            .add("patient") { patient() }
+            .runBlocking()
+
+        val msgs = debugMessages()
+        assertTrue(msgs.any { it.contains("task='patient'") && it.contains("status=STARTED") })
+        assertTrue(msgs.any { it.contains("task='patient'") && it.contains("status=COMPLETED") })
+    }
+
+    @Test
+    fun `COMPLETED log includes duration`() {
+        AsyncOperationResult()
+            .add("patient") { patient() }
+            .runBlocking()
+
+        val completedMsg = debugMessages().first {
+            it.contains("task='patient'") && it.contains("COMPLETED")
+        }
+        assertTrue(completedMsg.contains("duration="))
+    }
+
+    @Test
+    fun `DAG completion emits a summary DEBUG log`() {
+        AsyncOperationResult()
+            .add("patient") { patient() }
+            .add("encounter") { encounter() }
+            .runBlocking()
+
+        val msgs = debugMessages()
+        assertTrue(msgs.any { it.contains("dag=COMPLETED") && it.contains("totalDuration=") })
+    }
+
+    @Test
+    fun `DAG completion log includes task count`() {
+        AsyncOperationResult()
+            .add("patient") { patient() }
+            .add("encounter") { encounter() }
+            .runBlocking()
+
+        val dagMsg = debugMessages().first { it.contains("dag=COMPLETED") }
+        assertTrue(dagMsg.contains("tasks=2"))
+    }
+
+    @Test
+    fun `failed task emits FAILED status in log`() {
+        AsyncOperationResult()
+            .add("broken") { throw RuntimeException("nope") }
+            .runBlocking()
+
+        assertTrue(debugMessages().any { it.contains("task='broken'") && it.contains("status=FAILED") })
+    }
+
+    @Test
+    fun `log messages use FHIRMason dot async prefix`() {
+        AsyncOperationResult()
+            .add("patient") { patient() }
+            .runBlocking()
+
+        assertTrue(debugMessages().all { it.startsWith("FHIRMason.async") })
+    }
+}

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultRetryTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultRetryTest.kt
@@ -1,0 +1,186 @@
+package dev.ratkay.operation.dstu3
+
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.instanceOf
+import org.hl7.fhir.dstu3.model.Encounter
+import org.hl7.fhir.dstu3.model.Patient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AsyncOperationResultRetryTest {
+
+    private fun patient() = Patient().apply { setId("p1") }
+    private fun encounter() = Encounter().apply { setId("e1") }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `addWithRetry succeeds on first attempt`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addWithRetry("enc", maxAttempts = 3, initialDelayMs = 0) { encounter() }
+            .run()
+
+        assertTrue(result.containsKey("enc"))
+        assertFalse(result.hasErrors())
+        assertThat(result.getAll("enc").first(), instanceOf(Encounter::class.java))
+    }
+
+    @Test
+    fun `addWithRetry succeeds on second attempt after transient failure`() = runBlocking {
+        var attempts = 0
+        val result = AsyncOperationResult()
+            .addWithRetry("enc", maxAttempts = 3, initialDelayMs = 0) {
+                attempts++
+                if (attempts < 2) throw RuntimeException("transient")
+                encounter()
+            }
+            .run()
+
+        assertTrue(result.containsKey("enc"))
+        assertFalse(result.hasErrors())
+        assertEquals(2, attempts)
+    }
+
+    @Test
+    fun `addWithRetry succeeds on last attempt`() = runBlocking {
+        var attempts = 0
+        val result = AsyncOperationResult()
+            .addWithRetry("enc", maxAttempts = 3, initialDelayMs = 0) {
+                attempts++
+                if (attempts < 3) throw RuntimeException("transient")
+                encounter()
+            }
+            .run()
+
+        assertTrue(result.containsKey("enc"))
+        assertFalse(result.hasErrors())
+        assertEquals(3, attempts)
+    }
+
+    // ── Failure paths ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `addWithRetry records error outcome after all attempts exhausted`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addWithRetry("enc", maxAttempts = 2, initialDelayMs = 0) {
+                throw RuntimeException("always fails")
+            }
+            .run()
+
+        assertFalse(result.containsKey("enc"))
+        assertTrue(result.hasErrors())
+    }
+
+    @Test
+    fun `addWithRetry with maxAttempts=1 does not retry`() = runBlocking {
+        var attempts = 0
+        val result = AsyncOperationResult()
+            .addWithRetry("enc", maxAttempts = 1, initialDelayMs = 0) {
+                attempts++
+                throw RuntimeException("fail")
+            }
+            .run()
+
+        assertEquals(1, attempts)
+        assertTrue(result.hasErrors())
+    }
+
+    @Test
+    fun `addWithRetry makes exactly maxAttempts calls on repeated failure`() = runBlocking {
+        var attempts = 0
+        AsyncOperationResult()
+            .addWithRetry("enc", maxAttempts = 4, initialDelayMs = 0) {
+                attempts++
+                throw RuntimeException("fail")
+            }
+            .run()
+
+        assertEquals(4, attempts)
+    }
+
+    // ── retryOn predicate ─────────────────────────────────────────────────────
+
+    @Test
+    fun `addWithRetry stops immediately when retryOn returns false`() = runBlocking {
+        var attempts = 0
+        val result = AsyncOperationResult()
+            .addWithRetry("enc", maxAttempts = 5, initialDelayMs = 0, retryOn = { false }) {
+                attempts++
+                throw RuntimeException("non-retryable")
+            }
+            .run()
+
+        assertEquals(1, attempts)
+        assertTrue(result.hasErrors())
+    }
+
+    @Test
+    fun `addWithRetry retries only for matching exception type`() = runBlocking {
+        var attempts = 0
+        val result = AsyncOperationResult()
+            .addWithRetry(
+                "enc",
+                maxAttempts = 5,
+                initialDelayMs = 0,
+                retryOn = { e -> e is IllegalStateException }
+            ) {
+                attempts++
+                if (attempts == 1) throw IllegalStateException("retryable")
+                throw RuntimeException("non-retryable")
+            }
+            .run()
+
+        assertEquals(2, attempts)
+        assertTrue(result.hasErrors())
+    }
+
+    // ── Parameter validation ──────────────────────────────────────────────────
+
+    @Test
+    fun `addWithRetry throws when maxAttempts is less than 1`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult()
+                .addWithRetry("enc", maxAttempts = 0, initialDelayMs = 0) { encounter() }
+        }
+    }
+
+    @Test
+    fun `addWithRetry throws when initialDelayMs is negative`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult()
+                .addWithRetry("enc", maxAttempts = 3, initialDelayMs = -1) { encounter() }
+        }
+    }
+
+    // ── Integration with other tasks ──────────────────────────────────────────
+
+    @Test
+    fun `addWithRetry coexists with regular add tasks`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addWithRetry("enc", maxAttempts = 3, initialDelayMs = 0) { encounter() }
+            .run()
+
+        assertTrue(result.containsKey("patient"))
+        assertTrue(result.containsKey("enc"))
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `addWithRetry error outcome diagnostics come from last exception`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addWithRetry("enc", maxAttempts = 2, initialDelayMs = 0) {
+                throw RuntimeException("final failure message")
+            }
+            .run()
+
+        assertNotNull(result.getOutcomes().firstOrNull())
+        val diagnostics = result.getOutcomes().first().issueFirstRep.diagnostics
+        assertEquals("final failure message", diagnostics)
+    }
+}

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultTest.kt
@@ -1,0 +1,439 @@
+package dev.ratkay.operation.dstu3
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.hamcrest.Matchers.empty
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.instanceOf
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.not
+import org.hl7.fhir.dstu3.model.Appointment
+import org.hl7.fhir.dstu3.model.Basic
+import org.hl7.fhir.dstu3.model.Claim
+import org.hl7.fhir.dstu3.model.Coverage
+import org.hl7.fhir.dstu3.model.Group
+import org.hl7.fhir.dstu3.model.Observation
+import org.hl7.fhir.dstu3.model.OperationOutcome
+import org.hl7.fhir.dstu3.model.Patient
+import org.hl7.fhir.dstu3.model.Practitioner
+import org.hl7.fhir.dstu3.model.StringType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AsyncOperationResultTest {
+
+    // ── Group 1: Basic accumulation ───────────────────────────────────────────
+
+    @Test
+    fun `add - single root task accumulates under given key`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .run()
+
+        assertThat(result.containsKey("patient"), `is`(true))
+        assertThat(result.count("patient"), `is`(1))
+        assertThat(result.getAll("patient").first(), instanceOf(Patient::class.java))
+    }
+
+    @Test
+    fun `addList - list-returning task accumulates all entries under key`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("appointments") {
+                listOf(
+                    Appointment().apply { id = "a1" },
+                    Appointment().apply { id = "a2" }
+                )
+            }
+            .run()
+
+        assertThat(result.count("appointments"), `is`(2))
+    }
+
+    @Test
+    fun `multiple independent tasks accumulate under their own keys`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .add("practitioner") { Practitioner().apply { id = "pr1" } }
+            .run()
+
+        assertThat(result.getKeys(), containsInAnyOrder("patient", "practitioner"))
+        assertThat(result.totalCount(), `is`(2))
+    }
+
+    // ── Group 2: Dependency resolution ───────────────────────────────────────
+
+    @Test
+    fun `addAfter - dependent task receives upstream result`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .addAfter("coverage", "patient") { deps ->
+                val patient = deps["patient"]!!.first() as Patient
+                Coverage().apply { id = "cov-for-${patient.id}" }
+            }
+            .run()
+
+        val coverage = result.getAll("coverage").first() as Coverage
+        assertThat(coverage.id, `is`("cov-for-p1"))
+    }
+
+    @Test
+    fun `addAfter - task with multiple deps receives all of them`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .add("appointment") { Appointment().apply { id = "a1" } }
+            .addAfter("summary", "patient", "appointment") { deps ->
+                val patientId = (deps["patient"]!!.first() as Patient).id
+                val apptId = (deps["appointment"]!!.first() as Appointment).id
+                Basic().apply { id = "$patientId+$apptId" }
+            }
+            .run()
+
+        val summary = result.getAll("summary").first() as Basic
+        assertThat(summary.id, `is`("p1+a1"))
+    }
+
+    @Test
+    fun `addAfter - two-level chain A to B to C resolves in order`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("a") { Patient().apply { id = "A" } }
+            .addAfter("b", "a") { deps ->
+                val aId = (deps["a"]!!.first() as Patient).id
+                Patient().apply { id = "$aId-B" }
+            }
+            .addAfter("c", "b") { deps ->
+                val bId = (deps["b"]!!.first() as Patient).id
+                Patient().apply { id = "$bId-C" }
+            }
+            .run()
+
+        assertThat((result.getAll("c").first() as Patient).id, `is`("A-B-C"))
+    }
+
+    @Test
+    fun `addListAfter - dependent list task receives upstream results`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .addListAfter("observations", "patient") { deps ->
+                val patientId = (deps["patient"]!!.first() as Patient).id
+                listOf(
+                    Observation().apply { id = "obs1-$patientId" },
+                    Observation().apply { id = "obs2-$patientId" }
+                )
+            }
+            .run()
+
+        assertThat(result.count("observations"), `is`(2))
+        assertThat((result.getAll("observations").first() as Observation).id, `is`("obs1-p1"))
+    }
+
+    // ── Group 3: Parallelism ──────────────────────────────────────────────────
+
+    @Test
+    fun `independent tasks run concurrently and all produce results`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("slow") { delay(50); Patient().apply { id = "slow" } }
+            .add("fast") { delay(10); Patient().apply { id = "fast" } }
+            .run()
+
+        assertThat(result.getKeys(), containsInAnyOrder("slow", "fast"))
+        assertThat((result.getAll("slow").first() as Patient).id, `is`("slow"))
+        assertThat((result.getAll("fast").first() as Patient).id, `is`("fast"))
+    }
+
+    // ── Group 4: Error handling ───────────────────────────────────────────────
+
+    @Test
+    fun `exception in a task is captured as OperationOutcome instead of propagating`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("failing") { error("task exploded") }
+            .run()
+
+        assertTrue(result.hasErrors())
+        assertFalse(result.containsKey("failing"))
+        assertTrue(result.getFailedTasks().containsKey("failing"))
+    }
+
+    @Test
+    fun `independent tasks continue running when one task fails`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("failing") { error("boom") }
+            .add("succeeding") { Patient().apply { id = "p1" } }
+            .run()
+
+        assertTrue(result.containsKey("succeeding"))
+        assertFalse(result.containsKey("failing"))
+        assertTrue(result.hasErrors())
+        assertEquals(1, result.getFailedTasks().size)
+    }
+
+    @Test
+    fun `dependent task is skipped when its dependency fails`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("failing") { error("boom") }
+            .addAfter("dependent", "failing") { Patient().apply { id = "d1" } }
+            .run()
+
+        assertFalse(result.containsKey("failing"))
+        assertFalse(result.containsKey("dependent"))
+        assertEquals(2, result.getFailedTasks().size)
+        assertTrue(result.getFailedTasks().containsKey("failing"))
+        assertTrue(result.getFailedTasks().containsKey("dependent"))
+    }
+
+    @Test
+    fun `getFailedTasks - independent success tasks are not included`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .add("failing") { error("boom") }
+            .addAfter("dependent", "failing") { Patient() }
+            .run()
+
+        assertThat(result.getFailedTasks().keys, containsInAnyOrder("failing", "dependent"))
+        assertThat(result.getAll("patient"), hasSize(1))
+    }
+
+    // ── Group 5: Validation ───────────────────────────────────────────────────
+
+    @Test
+    fun `duplicate key registration throws IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult()
+                .add("patient") { Patient() }
+                .add("patient") { Patient() }
+        }
+    }
+
+    @Test
+    fun `unregistered dependency throws IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult()
+                .addAfter("coverage", "patient") { Patient() }
+        }
+    }
+
+    @Test
+    fun `cyclic dependency throws IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult()
+                .add("a") { Patient() }
+                .addAfter("b", "a") { Patient() }
+                .addAfter("a", "b") { Patient() }
+        }
+    }
+
+    // ── Group 6: Integration with OperationResult ─────────────────────────────
+
+    @Test
+    fun `result supports getByType`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .add("practitioner") { Practitioner().apply { id = "pr1" } }
+            .run()
+
+        val patients = result.getByType(Patient::class)
+        assertThat(patients, hasSize(1))
+        assertThat(patients.first().id, `is`("p1"))
+    }
+
+    @Test
+    fun `result supports totalCount`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient() }
+            .addList("appointments") { listOf(Appointment(), Appointment()) }
+            .run()
+
+        assertThat(result.totalCount(), `is`(3))
+    }
+
+    @Test
+    fun `result supports toParameters`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .run()
+
+        val params = result.toParameters()
+        assertThat(params.parameter, hasSize(1))
+        assertThat(params.parameter.first().name, `is`("patient"))
+    }
+
+    // ── Group 7: runBlocking variant ──────────────────────────────────────────
+
+    @Test
+    fun `runBlocking produces same result as suspend run`() {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .runBlocking()
+
+        assertThat(result.containsKey("patient"), `is`(true))
+        assertThat((result.getAll("patient").first() as Patient).id, `is`("p1"))
+    }
+
+    // ── Group 8: Type-safe single-dependency methods ────────────────────────
+
+    @Test
+    fun `addAfter with type - dependent task receives typed upstream result`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .addAfter("coverage", "patient", Patient::class) { patient ->
+                Coverage().apply { id = "cov-for-${patient.id}" }
+            }
+            .run()
+
+        val coverage = result.getAll("coverage").first() as Coverage
+        assertThat(coverage.id, `is`("cov-for-p1"))
+    }
+
+    @Test
+    fun `addAfter with type - captures NoSuchElementException as failed task when upstream has no matching type`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("data") { StringType("hello") }
+            .addAfter("out", "data", Patient::class) { patient ->
+                Basic().apply { id = patient.id }
+            }
+            .run()
+
+        assertTrue(result.getFailedTasks().containsKey("out"))
+        assertFalse(result.containsKey("out"))
+    }
+
+    @Test
+    fun `addAfter with type - works in multi-level chain`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "P" } }
+            .addAfter("coverage", "patient", Patient::class) { patient ->
+                Coverage().apply { id = "cov-${patient.id}" }
+            }
+            .addAfter("claim", "coverage", Coverage::class) { coverage ->
+                Claim().apply { id = "claim-${coverage.id}" }
+            }
+            .run()
+
+        val claim = result.getAll("claim").first() as Claim
+        assertThat(claim.id, `is`("claim-cov-P"))
+    }
+
+    @Test
+    fun `addListAfter with type - returns list from typed single dependency`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .addListAfter("observations", "patient", Patient::class) { patient ->
+                listOf(
+                    Observation().apply { id = "obs1-${patient.id}" },
+                    Observation().apply { id = "obs2-${patient.id}" }
+                )
+            }
+            .run()
+
+        assertThat(result.count("observations"), `is`(2))
+        assertThat((result.getAll("observations").first() as Observation).id, `is`("obs1-p1"))
+    }
+
+    // ── Group 9: Type-safe list-injection methods ───────────────────────────
+
+    @Test
+    fun `addAfterAll - receives typed list of all upstream values`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("observations") {
+                listOf(
+                    Observation().apply { id = "obs1" },
+                    Observation().apply { id = "obs2" },
+                    Observation().apply { id = "obs3" }
+                )
+            }
+            .addAfterAll("summary", "observations", Observation::class) { observations ->
+                Basic().apply { id = "count-${observations.size}" }
+            }
+            .run()
+
+        val summary = result.getAll("summary").first() as Basic
+        assertThat(summary.id, `is`("count-3"))
+    }
+
+    @Test
+    fun `addAfterAll - filters by type when upstream has mixed types`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("mixed") {
+                listOf(
+                    Patient().apply { id = "p1" },
+                    Observation().apply { id = "obs1" },
+                    Patient().apply { id = "p2" }
+                )
+            }
+            .addAfterAll("patientCount", "mixed", Patient::class) { patients ->
+                Basic().apply { id = "patients-${patients.size}" }
+            }
+            .run()
+
+        val summary = result.getAll("patientCount").first() as Basic
+        assertThat(summary.id, `is`("patients-2"))
+    }
+
+    @Test
+    fun `addAfterAll - receives empty list when no values match type`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("data") { StringType("hello") }
+            .addAfterAll("out", "data", Patient::class) { patients ->
+                Basic().apply { id = "found-${patients.size}" }
+            }
+            .run()
+
+        val out = result.getAll("out").first() as Basic
+        assertThat(out.id, `is`("found-0"))
+    }
+
+    @Test
+    fun `addListAfterAll - receives typed list and returns list`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("observations") {
+                listOf(
+                    Observation().apply { id = "obs1" },
+                    Observation().apply { id = "obs2" }
+                )
+            }
+            .addListAfterAll("derived", "observations", Observation::class) { observations ->
+                observations.map { obs ->
+                    Observation().apply { id = "derived-${obs.id}" }
+                }
+            }
+            .run()
+
+        assertThat(result.count("derived"), `is`(2))
+        assertThat((result.getAll("derived").first() as Observation).id, `is`("derived-obs1"))
+    }
+
+    // ── Group 10: Backward compatibility ────────────────────────────────────
+
+    @Test
+    fun `original addAfter still works with map-based deps`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .addAfter("coverage", "patient") { deps ->
+                val patient = deps["patient"]!!.first() as Patient
+                Coverage().apply { id = "cov-${patient.id}" }
+            }
+            .run()
+
+        val coverage = result.getAll("coverage").first() as Coverage
+        assertThat(coverage.id, `is`("cov-p1"))
+    }
+
+    @Test
+    fun `original addListAfter still works with map-based deps`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .addListAfter("observations", "patient") { deps ->
+                val patient = deps["patient"]!!.first() as Patient
+                listOf(
+                    Observation().apply { id = "obs-${patient.id}" }
+                )
+            }
+            .run()
+
+        assertThat(result.count("observations"), `is`(1))
+    }
+}

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultTimeoutTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultTimeoutTest.kt
@@ -1,0 +1,202 @@
+package dev.ratkay.operation.dstu3
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.hl7.fhir.dstu3.model.Encounter
+import org.hl7.fhir.dstu3.model.Patient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AsyncOperationResultTimeoutTest {
+
+    private fun patient() = Patient().apply { setId("p1") }
+    private fun encounter() = Encounter().apply { setId("e1") }
+
+    // ── addWithTimeout: completes in time ─────────────────────────────────────
+
+    @Test
+    fun `addWithTimeout task completing before deadline stores result`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addWithTimeout("patient", 500) { patient() }
+            .run()
+
+        assertTrue(result.containsKey("patient"))
+        assertFalse(result.hasErrors())
+    }
+
+    // ── addWithTimeout: exceeds deadline ──────────────────────────────────────
+
+    @Test
+    fun `addWithTimeout task exceeding deadline leaves key absent and records error`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addWithTimeout("patient", 20) { delay(200); patient() }
+            .run()
+
+        assertFalse(result.containsKey("patient"))
+        assertTrue(result.hasErrors())
+        assertTrue(result.getFailedTasks().containsKey("patient"))
+    }
+
+    @Test
+    fun `addWithTimeout timeout outcome diagnostics mention timeout`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addWithTimeout("patient", 20) { delay(200); patient() }
+            .run()
+
+        val diagnostics = result.getOutcomes().first().issueFirstRep.diagnostics
+        assertThat(diagnostics, containsString("Timed out"))
+    }
+
+    // ── addListWithTimeout ────────────────────────────────────────────────────
+
+    @Test
+    fun `addListWithTimeout task completing before deadline stores list`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addListWithTimeout("patients", 500) { listOf(patient(), patient()) }
+            .run()
+
+        assertTrue(result.containsKey("patients"))
+        assertEquals(2, result.count("patients"))
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `addListWithTimeout task exceeding deadline leaves key absent and records error`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addListWithTimeout("patients", 20) { delay(200); listOf(patient()) }
+            .run()
+
+        assertFalse(result.containsKey("patients"))
+        assertTrue(result.hasErrors())
+    }
+
+    // ── addAfterWithTimeout ───────────────────────────────────────────────────
+
+    @Test
+    fun `addAfterWithTimeout dep resolves and task completes in time`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addAfterWithTimeout("encounter", "patient", timeoutMs = 500) { _ -> encounter() }
+            .run()
+
+        assertTrue(result.containsKey("encounter"))
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `addAfterWithTimeout dep resolves but task exceeds deadline`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addAfterWithTimeout("encounter", "patient", timeoutMs = 20) { _ ->
+                delay(200)
+                encounter()
+            }
+            .run()
+
+        assertFalse(result.containsKey("encounter"))
+        assertTrue(result.hasErrors())
+        assertTrue(result.getFailedTasks().containsKey("encounter"))
+    }
+
+    @Test
+    fun `addAfterWithTimeout dep fails — task is skipped without timeout firing`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { throw RuntimeException("dep failed") }
+            .addAfterWithTimeout("encounter", "patient", timeoutMs = 20) { _ ->
+                delay(200)
+                encounter()
+            }
+            .run()
+
+        assertFalse(result.containsKey("encounter"))
+        assertTrue(result.hasErrors())
+        assertTrue(result.getFailedTasks().containsKey("patient"))
+        assertTrue(result.getFailedTasks().containsKey("encounter"))
+    }
+
+    // ── addListAfterWithTimeout ───────────────────────────────────────────────
+
+    @Test
+    fun `addListAfterWithTimeout completes in time stores list`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addListAfterWithTimeout("encounters", "patient", timeoutMs = 500) { _ ->
+                listOf(encounter(), encounter())
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounters"))
+        assertEquals(2, result.count("encounters"))
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `addListAfterWithTimeout exceeding deadline records error`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addListAfterWithTimeout("encounters", "patient", timeoutMs = 20) { _ ->
+                delay(200)
+                listOf(encounter())
+            }
+            .run()
+
+        assertFalse(result.containsKey("encounters"))
+        assertTrue(result.hasErrors())
+    }
+
+    // ── Coexistence ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `timeout task coexists with non-timeout tasks`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addWithTimeout("encounter", 500) { encounter() }
+            .run()
+
+        assertTrue(result.containsKey("patient"))
+        assertTrue(result.containsKey("encounter"))
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `one timing-out task does not affect independent non-timeout tasks`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addWithTimeout("encounter", 20) { delay(200); encounter() }
+            .run()
+
+        assertTrue(result.containsKey("patient"))
+        assertFalse(result.containsKey("encounter"))
+        assertTrue(result.hasErrors())
+    }
+
+    // ── Parameter validation ──────────────────────────────────────────────────
+
+    @Test
+    fun `addWithTimeout throws when timeoutMs is zero`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult().addWithTimeout("patient", 0) { patient() }
+        }
+    }
+
+    @Test
+    fun `addWithTimeout throws when timeoutMs is negative`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult().addWithTimeout("patient", -100) { patient() }
+        }
+    }
+
+    @Test
+    fun `addAfterWithTimeout throws when timeoutMs is zero`() {
+        assertThrows<IllegalArgumentException> {
+            AsyncOperationResult()
+                .add("patient") { patient() }
+                .addAfterWithTimeout("encounter", "patient", timeoutMs = 0) { _ -> encounter() }
+        }
+    }
+}

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultTypedDepOverloadsTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultTypedDepOverloadsTest.kt
@@ -1,0 +1,290 @@
+package dev.ratkay.operation.dstu3
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.instanceOf
+import org.hl7.fhir.dstu3.model.Coverage
+import org.hl7.fhir.dstu3.model.Encounter
+import org.hl7.fhir.dstu3.model.Patient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AsyncOperationResultTypedDepOverloadsTest {
+
+    private fun patient(id: String = "p1") = Patient().apply { setId(id) }
+    private fun encounter() = Encounter().apply { setId("e1") }
+    private fun coverage() = Coverage().apply { setId("c1") }
+
+    // ── addAfterWithTimeout typed ─────────────────────────────────────────────
+
+    @Test
+    fun `addAfterWithTimeout typed — block receives typed dep value`() = runBlocking {
+        var received: Patient? = null
+        val result = AsyncOperationResult()
+            .add("patient") { patient("typed") }
+            .addAfterWithTimeout("encounter", "patient", Patient::class, timeoutMs = 500) { p ->
+                received = p
+                encounter()
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounter"))
+        assertFalse(result.hasErrors())
+        assertEquals("typed", received!!.idElement.idPart)
+    }
+
+    @Test
+    fun `addAfterWithTimeout typed — times out and key absent`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addAfterWithTimeout("encounter", "patient", Patient::class, timeoutMs = 20) { _ ->
+                delay(200)
+                encounter()
+            }
+            .run()
+
+        assertFalse(result.containsKey("encounter"))
+        assertTrue(result.hasErrors())
+    }
+
+    // ── addListAfterWithTimeout typed ─────────────────────────────────────────
+
+    @Test
+    fun `addListAfterWithTimeout typed — block receives typed dep value and returns list`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient("p") }
+            .addListAfterWithTimeout("encounters", "patient", Patient::class, timeoutMs = 500) { p ->
+                listOf(encounter(), Encounter().apply { subject.reference = "Patient/${p.idElement.idPart}" })
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounters"))
+        assertEquals(2, result.count("encounters"))
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `addListAfterWithTimeout typed — times out and key absent`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addListAfterWithTimeout("encounters", "patient", Patient::class, timeoutMs = 20) { _ ->
+                delay(200)
+                listOf(encounter())
+            }
+            .run()
+
+        assertFalse(result.containsKey("encounters"))
+        assertTrue(result.hasErrors())
+    }
+
+    // ── addAfterAllWithTimeout typed ──────────────────────────────────────────
+
+    @Test
+    fun `addAfterAllWithTimeout typed — block receives full typed list`() = runBlocking {
+        var receivedList: List<Patient>? = null
+        val result = AsyncOperationResult()
+            .addList("patients") { listOf(patient("a"), patient("b")) }
+            .addAfterAllWithTimeout("encounter", "patients", Patient::class, timeoutMs = 500) { patients ->
+                receivedList = patients
+                encounter()
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounter"))
+        assertFalse(result.hasErrors())
+        assertEquals(2, receivedList!!.size)
+        assertEquals("a", receivedList!![0].idElement.idPart)
+        assertEquals("b", receivedList!![1].idElement.idPart)
+    }
+
+    @Test
+    fun `addAfterAllWithTimeout typed — empty list when type does not match`() = runBlocking {
+        var receivedSize = -1
+        val result = AsyncOperationResult()
+            .addList("patients") { listOf(patient("a"), patient("b")) }
+            .addAfterAllWithTimeout("encounter", "patients", Coverage::class, timeoutMs = 500) { coverages ->
+                receivedSize = coverages.size
+                encounter()
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounter"))
+        assertEquals(0, receivedSize)
+    }
+
+    // ── addListAfterAllWithTimeout typed ──────────────────────────────────────
+
+    @Test
+    fun `addListAfterAllWithTimeout typed — block receives typed list and returns list`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("patients") { listOf(patient("a"), patient("b"), patient("c")) }
+            .addListAfterAllWithTimeout("encounters", "patients", Patient::class, timeoutMs = 500) { patients ->
+                patients.map { Encounter().apply { subject.reference = "Patient/${it.idElement.idPart}" } }
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounters"))
+        assertEquals(3, result.count("encounters"))
+        assertFalse(result.hasErrors())
+    }
+
+    // ── addAfterWithRetry typed ───────────────────────────────────────────────
+
+    @Test
+    fun `addAfterWithRetry typed — block receives typed dep and succeeds`() = runBlocking {
+        var received: Patient? = null
+        val result = AsyncOperationResult()
+            .add("patient") { patient("typed") }
+            .addAfterWithRetry("encounter", "patient", Patient::class, maxAttempts = 3, initialDelayMs = 0) { p ->
+                received = p
+                encounter()
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounter"))
+        assertFalse(result.hasErrors())
+        assertEquals("typed", received!!.idElement.idPart)
+    }
+
+    @Test
+    fun `addAfterWithRetry typed — retries and succeeds on second attempt`() = runBlocking {
+        var attempts = 0
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addAfterWithRetry("encounter", "patient", Patient::class, maxAttempts = 3, initialDelayMs = 0) { _ ->
+                attempts++
+                if (attempts < 2) throw RuntimeException("transient")
+                encounter()
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounter"))
+        assertFalse(result.hasErrors())
+        assertEquals(2, attempts)
+    }
+
+    @Test
+    fun `addAfterWithRetry typed — all attempts exhausted records error`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addAfterWithRetry("encounter", "patient", Patient::class, maxAttempts = 2, initialDelayMs = 0) { _ ->
+                throw RuntimeException("always fails")
+            }
+            .run()
+
+        assertFalse(result.containsKey("encounter"))
+        assertTrue(result.hasErrors())
+        assertTrue(result.getFailedTasks().containsKey("encounter"))
+    }
+
+    // ── addListAfterWithRetry typed ───────────────────────────────────────────
+
+    @Test
+    fun `addListAfterWithRetry typed — block receives typed dep and returns list`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient("p") }
+            .addListAfterWithRetry("encounters", "patient", Patient::class, maxAttempts = 3, initialDelayMs = 0) { p ->
+                listOf(encounter(), Encounter().apply { subject.reference = "Patient/${p.idElement.idPart}" })
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounters"))
+        assertEquals(2, result.count("encounters"))
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `addListAfterWithRetry typed — retries on failure`() = runBlocking {
+        var attempts = 0
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addListAfterWithRetry("encounters", "patient", Patient::class, maxAttempts = 3, initialDelayMs = 0) { _ ->
+                attempts++
+                if (attempts < 3) throw RuntimeException("transient")
+                listOf(encounter())
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounters"))
+        assertEquals(3, attempts)
+        assertFalse(result.hasErrors())
+    }
+
+    // ── addAfterAllWithRetry typed ────────────────────────────────────────────
+
+    @Test
+    fun `addAfterAllWithRetry typed — block receives full typed list`() = runBlocking {
+        var receivedList: List<Patient>? = null
+        val result = AsyncOperationResult()
+            .addList("patients") { listOf(patient("x"), patient("y")) }
+            .addAfterAllWithRetry("encounter", "patients", Patient::class, maxAttempts = 3, initialDelayMs = 0) { patients ->
+                receivedList = patients
+                encounter()
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounter"))
+        assertFalse(result.hasErrors())
+        assertEquals(listOf("x", "y"), receivedList!!.map { it.idElement.idPart })
+    }
+
+    @Test
+    fun `addAfterAllWithRetry typed — retries with same typed list each attempt`() = runBlocking {
+        var attempts = 0
+        val result = AsyncOperationResult()
+            .addList("patients") { listOf(patient("a"), patient("b")) }
+            .addAfterAllWithRetry("encounter", "patients", Patient::class, maxAttempts = 3, initialDelayMs = 0) { patients ->
+                attempts++
+                if (attempts < 2) throw RuntimeException("transient")
+                assertEquals(2, patients.size)
+                encounter()
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounter"))
+        assertEquals(2, attempts)
+    }
+
+    // ── addListAfterAllWithRetry typed ────────────────────────────────────────
+
+    @Test
+    fun `addListAfterAllWithRetry typed — maps typed list to result list`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("patients") { listOf(patient("a"), patient("b")) }
+            .addListAfterAllWithRetry("encounters", "patients", Patient::class, maxAttempts = 3, initialDelayMs = 0) { patients ->
+                patients.map { Encounter().apply { subject.reference = "Patient/${it.idElement.idPart}" } }
+            }
+            .run()
+
+        assertTrue(result.containsKey("encounters"))
+        assertEquals(2, result.count("encounters"))
+        val refs = result.getAll("encounters").map { (it as Encounter).subject.reference }
+        assertEquals(listOf("Patient/a", "Patient/b"), refs)
+        assertFalse(result.hasErrors())
+    }
+
+    // ── Result type sanity ────────────────────────────────────────────────────
+
+    @Test
+    fun `addAfterWithTimeout typed result has correct FHIR type`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addAfterWithTimeout("encounter", "patient", Patient::class, timeoutMs = 500) { _ -> encounter() }
+            .run()
+
+        assertThat(result.getAll("encounter").first(), instanceOf(Encounter::class.java))
+    }
+
+    @Test
+    fun `addAfterWithRetry typed result has correct FHIR type`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { patient() }
+            .addAfterWithRetry("encounter", "patient", Patient::class, maxAttempts = 1, initialDelayMs = 0) { _ -> encounter() }
+            .run()
+
+        assertThat(result.getAll("encounter").first(), instanceOf(Encounter::class.java))
+    }
+}


### PR DESCRIPTION
- Add DSTU3 porting policy to CLAUDE.md: new features must be ported to
  DSTU3 unless they rely on R4-exclusive constructs; R4 always has priority
- Add kotlinx-coroutines-core dependency to fhirmason-dstu3/pom.xml
- Implement AsyncOperationResult in dev.ratkay.operation.dstu3 — identical
  feature set to the R4 version (DAG execution, typed deps, retry, timeout,
  default fallbacks, conditional registration, merge, describe, metrics)
- Port all 12 R4 async test files to the DSTU3 test directory, adapting
  imports to org.hl7.fhir.dstu3.model.*
- Update README.md: module table and project structure tree