### PR TITLE
feat: make AsyncOperationResult list-producing methods typed with <R : Base>

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,7 +965,7 @@ result.containsKey("observations")  // true
 ```kotlin
 AsyncOperationResult()
     .add("patient") { fetchPatient() }        // suspending lambda → single Base
-    .addList("observations") { fetchObs() }   // suspending lambda → List<Base>
+    .addList("observations") { fetchObs() }   // suspending lambda → List<R>
 ```
 
 #### Dependent tasks — raw Map API
@@ -992,28 +992,28 @@ When a task has exactly one dependency, use the typed overloads to skip the manu
 | Method | Lambda receives | Returns |
 |---|---|---|
 | `addAfter(key, dep, type) { t -> Base }` | single typed value | `Base` |
-| `addListAfter(key, dep, type) { t -> List<Base> }` | single typed value | `List<Base>` |
+| `addListAfter(key, dep, type) { t -> List<R> }` | single typed value | `List<R>` |
 | `addAfterAll(key, dep, type) { list -> Base }` | typed list | `Base` |
-| `addListAfterAll(key, dep, type) { list -> List<Base> }` | typed list | `List<Base>` |
+| `addListAfterAll(key, dep, type) { list -> List<R> }` | typed list | `List<R>` |
 | `addWithRetry(key, …) { Base }` | none | `Base` |
 | `addAfterWithRetry(key, *deps, …) { Map → Base }` | dep map | `Base` |
-| `addListAfterWithRetry(key, *deps, …) { Map → List<Base> }` | dep map | `List<Base>` |
+| `addListAfterWithRetry(key, *deps, …) { Map → List<R> }` | dep map | `List<R>` |
 | `addAfterWithRetry(key, dep, type, …) { t -> Base }` | single typed value | `Base` |
-| `addListAfterWithRetry(key, dep, type, …) { t -> List<Base> }` | single typed value | `List<Base>` |
+| `addListAfterWithRetry(key, dep, type, …) { t -> List<R> }` | single typed value | `List<R>` |
 | `addAfterAllWithRetry(key, dep, type, …) { list -> Base }` | typed list | `Base` |
-| `addListAfterAllWithRetry(key, dep, type, …) { list -> List<Base> }` | typed list | `List<Base>` |
+| `addListAfterAllWithRetry(key, dep, type, …) { list -> List<R> }` | typed list | `List<R>` |
 | `addWithTimeout(key, timeoutMs) { Base }` | none | `Base` |
-| `addListWithTimeout(key, timeoutMs) { List<Base> }` | none | `List<Base>` |
+| `addListWithTimeout(key, timeoutMs) { List<R> }` | none | `List<R>` |
 | `addAfterWithTimeout(key, *deps, timeoutMs) { Map → Base }` | dep map | `Base` |
-| `addListAfterWithTimeout(key, *deps, timeoutMs) { Map → List<Base> }` | dep map | `List<Base>` |
+| `addListAfterWithTimeout(key, *deps, timeoutMs) { Map → List<R> }` | dep map | `List<R>` |
 | `addAfterWithTimeout(key, dep, type, timeoutMs) { t -> Base }` | single typed value | `Base` |
-| `addListAfterWithTimeout(key, dep, type, timeoutMs) { t -> List<Base> }` | single typed value | `List<Base>` |
+| `addListAfterWithTimeout(key, dep, type, timeoutMs) { t -> List<R> }` | single typed value | `List<R>` |
 | `addAfterAllWithTimeout(key, dep, type, timeoutMs) { list -> Base }` | typed list | `Base` |
-| `addListAfterAllWithTimeout(key, dep, type, timeoutMs) { list -> List<Base> }` | typed list | `List<Base>` |
+| `addListAfterAllWithTimeout(key, dep, type, timeoutMs) { list -> List<R> }` | typed list | `List<R>` |
 | `addIf(condition, key) { Base }` | none | `Base` (or no-op) |
-| `addListIf(condition, key) { List<Base> }` | none | `List<Base>` (or no-op) |
+| `addListIf(condition, key) { List<R> }` | none | `List<R>` (or no-op) |
 | `addWithDefault(key, default) { Base }` | none | `Base` |
-| `addListWithDefault(key, default) { List<Base> }` | none | `List<Base>` |
+| `addListWithDefault(key, default) { List<R> }` | none | `List<R>` |
 | `merge { AsyncOperationResult() … }` | — (lambda builds inner DAG) | `this` |
 | `merge(other: AsyncOperationResult)` | — (pre-built inner DAG) | `this` |
 
@@ -1125,9 +1125,9 @@ When a task has exactly one dependency, use the typed overloads to avoid the man
 | Method | Lambda receives |
 |---|---|
 | `addAfterWithRetry(key, dep, type, …) { t -> Base }` | single typed value |
-| `addListAfterWithRetry(key, dep, type, …) { t -> List<Base> }` | single typed value |
+| `addListAfterWithRetry(key, dep, type, …) { t -> List<R> }` | single typed value |
 | `addAfterAllWithRetry(key, dep, type, …) { list -> Base }` | typed list |
-| `addListAfterAllWithRetry(key, dep, type, …) { list -> List<Base> }` | typed list |
+| `addListAfterAllWithRetry(key, dep, type, …) { list -> List<R> }` | typed list |
 
 ```kotlin
 val dag = AsyncOperationResult()
@@ -1149,9 +1149,9 @@ Wrap any task in a coroutine timeout. If the block does not finish within the de
 | Method | Lambda input | Result |
 |---|---|---|
 | `addWithTimeout(key, timeoutMs) { Base }` | none | `Base` |
-| `addListWithTimeout(key, timeoutMs) { List<Base> }` | none | `List<Base>` |
+| `addListWithTimeout(key, timeoutMs) { List<R> }` | none | `List<R>` |
 | `addAfterWithTimeout(key, *deps, timeoutMs) { Map → Base }` | dep map | `Base` |
-| `addListAfterWithTimeout(key, *deps, timeoutMs) { Map → List<Base> }` | dep map | `List<Base>` |
+| `addListAfterWithTimeout(key, *deps, timeoutMs) { Map → List<R> }` | dep map | `List<R>` |
 
 ```kotlin
 val dag = AsyncOperationResult()
@@ -1174,9 +1174,9 @@ When a task has exactly one dependency, use the typed overloads to avoid the man
 | Method | Lambda receives |
 |---|---|
 | `addAfterWithTimeout(key, dep, type, timeoutMs) { t -> Base }` | single typed value |
-| `addListAfterWithTimeout(key, dep, type, timeoutMs) { t -> List<Base> }` | single typed value |
+| `addListAfterWithTimeout(key, dep, type, timeoutMs) { t -> List<R> }` | single typed value |
 | `addAfterAllWithTimeout(key, dep, type, timeoutMs) { list -> Base }` | typed list |
-| `addListAfterAllWithTimeout(key, dep, type, timeoutMs) { list -> List<Base> }` | typed list |
+| `addListAfterAllWithTimeout(key, dep, type, timeoutMs) { list -> List<R> }` | typed list |
 
 ```kotlin
 val dag = AsyncOperationResult()
@@ -1605,6 +1605,8 @@ fhirmason-r4/
         ├── AsyncOperationResultConditionalTest.kt
         ├── AsyncOperationResultDefaultTest.kt
         ├── AsyncOperationResultComplexTest.kt
+        ├── AsyncOperationResultTypedDepOverloadsTest.kt
+        ├── AsyncOperationResultTypedListOutputTest.kt
         ├── FhirDateTimeConverterTest.kt
         └── FhirExtensionHelperTest.kt
 
@@ -1643,6 +1645,7 @@ fhirmason-dstu3/
         ├── AsyncOperationResultDefaultTest.kt
         ├── AsyncOperationResultComplexTest.kt
         ├── AsyncOperationResultTypedDepOverloadsTest.kt
+        ├── AsyncOperationResultTypedListOutputTest.kt
         ├── FhirDateTimeConverterTest.kt
         └── FhirExtensionHelperTest.kt
 

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/AsyncOperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/AsyncOperationResult.kt
@@ -106,7 +106,7 @@ class AsyncOperationResult {
         registerNode(key, TaskNode.Independent(key) { listOf(block()) })
     }
 
-    fun addList(key: String, block: suspend () -> List<Base>): AsyncOperationResult = also {
+    fun <R : Base> addList(key: String, block: suspend () -> List<R>): AsyncOperationResult = also {
         registerNode(key, TaskNode.Independent(key) { block() })
     }
 
@@ -121,15 +121,15 @@ class AsyncOperationResult {
         registerNode(key, TaskNode.Dependent(key, depList) { map -> listOf(block(map)) })
     }
 
-    fun addListAfter(
+    fun <R : Base> addListAfter(
         key: String,
         vararg deps: String,
-        block: suspend (Map<String, List<Base>>) -> List<Base>
+        block: suspend (Map<String, List<Base>>) -> List<R>
     ): AsyncOperationResult = also {
         val depList = deps.toList()
         requireKeysExist(depList)
         requireNoCycle(key, depList)
-        registerNode(key, TaskNode.Dependent(key, depList, block))
+        registerNode(key, TaskNode.Dependent(key, depList) { map -> block(map) })
     }
 
     // Type-safe single-dependency convenience methods
@@ -144,11 +144,11 @@ class AsyncOperationResult {
         block(value)
     }
 
-    fun <T : Base> addListAfter(
+    fun <T : Base, R : Base> addListAfter(
         key: String,
         dep: String,
         type: KClass<T>,
-        block: suspend (T) -> List<Base>
+        block: suspend (T) -> List<R>
     ): AsyncOperationResult = addListAfter(key, dep) { deps ->
         val value = deps[dep]!!.filterIsInstance(type.java).first()
         block(value)
@@ -166,11 +166,11 @@ class AsyncOperationResult {
         block(values)
     }
 
-    fun <T : Base> addListAfterAll(
+    fun <T : Base, R : Base> addListAfterAll(
         key: String,
         dep: String,
         type: KClass<T>,
-        block: suspend (List<T>) -> List<Base>
+        block: suspend (List<T>) -> List<R>
     ): AsyncOperationResult = addListAfter(key, dep) { deps ->
         val values = deps[dep]!!.filterIsInstance(type.java)
         block(values)
@@ -227,7 +227,7 @@ class AsyncOperationResult {
         })
     }
 
-    fun addListWithTimeout(key: String, timeoutMs: Long, block: suspend () -> List<Base>): AsyncOperationResult = also {
+    fun <R : Base> addListWithTimeout(key: String, timeoutMs: Long, block: suspend () -> List<R>): AsyncOperationResult = also {
         require(timeoutMs > 0) { "timeoutMs must be positive" }
         registerNode(key, TaskNode.Independent(key) {
             withTimeout(timeoutMs) { block() }
@@ -251,11 +251,11 @@ class AsyncOperationResult {
         })
     }
 
-    fun addListAfterWithTimeout(
+    fun <R : Base> addListAfterWithTimeout(
         key: String,
         vararg deps: String,
         timeoutMs: Long,
-        block: suspend (Map<String, List<Base>>) -> List<Base>
+        block: suspend (Map<String, List<Base>>) -> List<R>
     ): AsyncOperationResult = also {
         require(timeoutMs > 0) { "timeoutMs must be positive" }
         val depList = deps.toList()
@@ -279,12 +279,12 @@ class AsyncOperationResult {
         block(value)
     }
 
-    fun <T : Base> addListAfterWithTimeout(
+    fun <T : Base, R : Base> addListAfterWithTimeout(
         key: String,
         dep: String,
         type: KClass<T>,
         timeoutMs: Long,
-        block: suspend (T) -> List<Base>
+        block: suspend (T) -> List<R>
     ): AsyncOperationResult = addListAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
         val value = deps[dep]!!.filterIsInstance(type.java).first()
         block(value)
@@ -301,12 +301,12 @@ class AsyncOperationResult {
         block(values)
     }
 
-    fun <T : Base> addListAfterAllWithTimeout(
+    fun <T : Base, R : Base> addListAfterAllWithTimeout(
         key: String,
         dep: String,
         type: KClass<T>,
         timeoutMs: Long,
-        block: suspend (List<T>) -> List<Base>
+        block: suspend (List<T>) -> List<R>
     ): AsyncOperationResult = addListAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
         val values = deps[dep]!!.filterIsInstance(type.java)
         block(values)
@@ -334,13 +334,14 @@ class AsyncOperationResult {
         }
     }
 
-    fun addListAfterWithRetry(
+    @JvmOverloads
+    fun <R : Base> addListAfterWithRetry(
         key: String,
         vararg deps: String,
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
-        block: suspend (Map<String, List<Base>>) -> List<Base>
+        block: suspend (Map<String, List<Base>>) -> List<R>
     ): AsyncOperationResult {
         require(maxAttempts >= 1) { "maxAttempts must be at least 1" }
         require(initialDelayMs >= 0) { "initialDelayMs must be non-negative" }
@@ -374,14 +375,15 @@ class AsyncOperationResult {
         block(value)
     }
 
-    fun <T : Base> addListAfterWithRetry(
+    @JvmOverloads
+    fun <T : Base, R : Base> addListAfterWithRetry(
         key: String,
         dep: String,
         type: KClass<T>,
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
-        block: suspend (T) -> List<Base>
+        block: suspend (T) -> List<R>
     ): AsyncOperationResult = addListAfterWithRetry(
         key, dep,
         maxAttempts = maxAttempts,
@@ -410,14 +412,15 @@ class AsyncOperationResult {
         block(values)
     }
 
-    fun <T : Base> addListAfterAllWithRetry(
+    @JvmOverloads
+    fun <T : Base, R : Base> addListAfterAllWithRetry(
         key: String,
         dep: String,
         type: KClass<T>,
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
-        block: suspend (List<T>) -> List<Base>
+        block: suspend (List<T>) -> List<R>
     ): AsyncOperationResult = addListAfterWithRetry(
         key, dep,
         maxAttempts = maxAttempts,
@@ -463,7 +466,7 @@ class AsyncOperationResult {
     fun addIf(condition: Boolean, key: String, block: suspend () -> Base): AsyncOperationResult =
         if (condition) add(key, block) else this
 
-    fun addListIf(condition: Boolean, key: String, block: suspend () -> List<Base>): AsyncOperationResult =
+    fun <R : Base> addListIf(condition: Boolean, key: String, block: suspend () -> List<R>): AsyncOperationResult =
         if (condition) addList(key, block) else this
 
     // ── DAG composition ──────────────────────────────────────────────────────

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultTypedListOutputTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultTypedListOutputTest.kt
@@ -1,0 +1,151 @@
+package dev.ratkay.operation.dstu3
+
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.hl7.fhir.dstu3.model.Appointment
+import org.hl7.fhir.dstu3.model.Base
+import org.hl7.fhir.dstu3.model.Observation
+import org.hl7.fhir.dstu3.model.Patient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AsyncOperationResultTypedListOutputTest {
+
+    @Test
+    fun `addList - R inferred as concrete type from lambda`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("patients") {
+                listOf(Patient().apply { id = "p1" }, Patient().apply { id = "p2" })
+            }
+            .run()
+
+        assertThat(result.count("patients"), `is`(2))
+        val patients = result.getAll("patients")
+        assertEquals("p1", (patients[0] as Patient).id)
+    }
+
+    @Test
+    fun `addListAfter vararg - R inferred as concrete type from lambda`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .addListAfter("observations", "patient") { deps ->
+                val patientId = (deps["patient"]!!.first() as Patient).id
+                listOf(
+                    Observation().apply { id = "obs1-$patientId" },
+                    Observation().apply { id = "obs2-$patientId" }
+                )
+            }
+            .run()
+
+        assertThat(result.count("observations"), `is`(2))
+        assertEquals("obs1-p1", (result.getAll("observations").first() as Observation).id)
+    }
+
+    @Test
+    fun `addListAfterAll - both T and R inferred as concrete types`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("patients") { listOf(Patient().apply { id = "p1" }, Patient().apply { id = "p2" }) }
+            .addListAfterAll("observations", "patients", Patient::class) { patients ->
+                patients.map { p -> Observation().apply { id = "obs-${p.id}" } }
+            }
+            .run()
+
+        assertThat(result.count("observations"), `is`(2))
+    }
+
+    @Test
+    fun `addListWithTimeout - R inferred as concrete type`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addListWithTimeout("appointments", 5000L) {
+                listOf(Appointment().apply { id = "a1" }, Appointment().apply { id = "a2" })
+            }
+            .run()
+
+        assertThat(result.count("appointments"), `is`(2))
+    }
+
+    @Test
+    fun `addListAfterWithTimeout vararg - R inferred as concrete type`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .addListAfterWithTimeout("observations", "patient", timeoutMs = 5000L) { deps ->
+                val pid = (deps["patient"]!!.first() as Patient).id
+                listOf(Observation().apply { id = "obs-$pid" })
+            }
+            .run()
+
+        assertThat(result.count("observations"), `is`(1))
+    }
+
+    @Test
+    fun `addListAfterAllWithTimeout - both T and R inferred as concrete types`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("patients") { listOf(Patient().apply { id = "p1" }) }
+            .addListAfterAllWithTimeout("observations", "patients", Patient::class, 5000L) { patients ->
+                patients.map { p -> Observation().apply { id = "obs-${p.id}" } }
+            }
+            .run()
+
+        assertThat(result.count("observations"), `is`(1))
+    }
+
+    @Test
+    fun `addListAfterWithRetry vararg - R inferred as concrete type`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .addListAfterWithRetry("observations", "patient", maxAttempts = 1) { deps ->
+                val pid = (deps["patient"]!!.first() as Patient).id
+                listOf(Observation().apply { id = "obs-$pid" })
+            }
+            .run()
+
+        assertThat(result.count("observations"), `is`(1))
+    }
+
+    @Test
+    fun `addListAfterAllWithRetry - both T and R inferred as concrete types`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("patients") { listOf(Patient().apply { id = "p1" }, Patient().apply { id = "p2" }) }
+            .addListAfterAllWithRetry("observations", "patients", Patient::class, maxAttempts = 1) { patients ->
+                patients.map { p -> Observation().apply { id = "obs-${p.id}" } }
+            }
+            .run()
+
+        assertThat(result.count("observations"), `is`(2))
+    }
+
+    @Test
+    fun `addListIf true condition - R inferred as concrete type`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addListIf(true, "patients") {
+                listOf(Patient().apply { id = "p1" })
+            }
+            .run()
+
+        assertThat(result.count("patients"), `is`(1))
+    }
+
+    @Test
+    fun `addListIf false condition - block not executed`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addListIf(false, "patients") {
+                listOf(Patient().apply { id = "p1" })
+            }
+            .run()
+
+        assertThat(result.containsKey("patients"), `is`(false))
+    }
+
+    @Test
+    fun `addList with heterogeneous list - R inferred as Base regression guard`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("resources") {
+                @Suppress("UNCHECKED_CAST")
+                listOf<Base>(Patient().apply { id = "p1" }, Observation().apply { id = "o1" })
+            }
+            .run()
+
+        assertThat(result.count("resources"), `is`(2))
+    }
+}

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/AsyncOperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/AsyncOperationResult.kt
@@ -106,7 +106,7 @@ class AsyncOperationResult {
         registerNode(key, TaskNode.Independent(key) { listOf(block()) })
     }
 
-    fun addList(key: String, block: suspend () -> List<Base>): AsyncOperationResult = also {
+    fun <R : Base> addList(key: String, block: suspend () -> List<R>): AsyncOperationResult = also {
         registerNode(key, TaskNode.Independent(key) { block() })
     }
 
@@ -121,15 +121,15 @@ class AsyncOperationResult {
         registerNode(key, TaskNode.Dependent(key, depList) { map -> listOf(block(map)) })
     }
 
-    fun addListAfter(
+    fun <R : Base> addListAfter(
         key: String,
         vararg deps: String,
-        block: suspend (Map<String, List<Base>>) -> List<Base>
+        block: suspend (Map<String, List<Base>>) -> List<R>
     ): AsyncOperationResult = also {
         val depList = deps.toList()
         requireKeysExist(depList)
         requireNoCycle(key, depList)
-        registerNode(key, TaskNode.Dependent(key, depList, block))
+        registerNode(key, TaskNode.Dependent(key, depList) { map -> block(map) })
     }
 
     // Type-safe single-dependency convenience methods
@@ -144,11 +144,11 @@ class AsyncOperationResult {
         block(value)
     }
 
-    fun <T : Base> addListAfter(
+    fun <T : Base, R : Base> addListAfter(
         key: String,
         dep: String,
         type: KClass<T>,
-        block: suspend (T) -> List<Base>
+        block: suspend (T) -> List<R>
     ): AsyncOperationResult = addListAfter(key, dep) { deps ->
         val value = deps[dep]!!.filterIsInstance(type.java).first()
         block(value)
@@ -166,11 +166,11 @@ class AsyncOperationResult {
         block(values)
     }
 
-    fun <T : Base> addListAfterAll(
+    fun <T : Base, R : Base> addListAfterAll(
         key: String,
         dep: String,
         type: KClass<T>,
-        block: suspend (List<T>) -> List<Base>
+        block: suspend (List<T>) -> List<R>
     ): AsyncOperationResult = addListAfter(key, dep) { deps ->
         val values = deps[dep]!!.filterIsInstance(type.java)
         block(values)
@@ -273,7 +273,7 @@ class AsyncOperationResult {
      * @param timeoutMs maximum allowed execution time in milliseconds; must be > 0
      * @param block the suspending lambda to execute within the timeout
      */
-    fun addListWithTimeout(key: String, timeoutMs: Long, block: suspend () -> List<Base>): AsyncOperationResult = also {
+    fun <R : Base> addListWithTimeout(key: String, timeoutMs: Long, block: suspend () -> List<R>): AsyncOperationResult = also {
         require(timeoutMs > 0) { "timeoutMs must be positive" }
         registerNode(key, TaskNode.Independent(key) {
             withTimeout(timeoutMs) { block() }
@@ -319,11 +319,11 @@ class AsyncOperationResult {
      * @param timeoutMs maximum allowed execution time in milliseconds; must be > 0
      * @param block the suspending lambda to execute within the timeout
      */
-    fun addListAfterWithTimeout(
+    fun <R : Base> addListAfterWithTimeout(
         key: String,
         vararg deps: String,
         timeoutMs: Long,
-        block: suspend (Map<String, List<Base>>) -> List<Base>
+        block: suspend (Map<String, List<Base>>) -> List<R>
     ): AsyncOperationResult = also {
         require(timeoutMs > 0) { "timeoutMs must be positive" }
         val depList = deps.toList()
@@ -371,12 +371,12 @@ class AsyncOperationResult {
      * @param timeoutMs maximum allowed execution time in milliseconds; must be > 0
      * @param block the suspending lambda to execute within the timeout; receives the typed dep value
      */
-    fun <T : Base> addListAfterWithTimeout(
+    fun <T : Base, R : Base> addListAfterWithTimeout(
         key: String,
         dep: String,
         type: KClass<T>,
         timeoutMs: Long,
-        block: suspend (T) -> List<Base>
+        block: suspend (T) -> List<R>
     ): AsyncOperationResult = addListAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
         val value = deps[dep]!!.filterIsInstance(type.java).first()
         block(value)
@@ -415,12 +415,12 @@ class AsyncOperationResult {
      * @param timeoutMs maximum allowed execution time in milliseconds; must be > 0
      * @param block the suspending lambda to execute within the timeout; receives the typed dep list
      */
-    fun <T : Base> addListAfterAllWithTimeout(
+    fun <T : Base, R : Base> addListAfterAllWithTimeout(
         key: String,
         dep: String,
         type: KClass<T>,
         timeoutMs: Long,
-        block: suspend (List<T>) -> List<Base>
+        block: suspend (List<T>) -> List<R>
     ): AsyncOperationResult = addListAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
         val values = deps[dep]!!.filterIsInstance(type.java)
         block(values)
@@ -480,13 +480,14 @@ class AsyncOperationResult {
      * @param retryOn predicate called with each exception — return `false` to stop retrying immediately
      * @param block the suspending lambda to invoke; receives resolved dependency results
      */
-    fun addListAfterWithRetry(
+    @JvmOverloads
+    fun <R : Base> addListAfterWithRetry(
         key: String,
         vararg deps: String,
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
-        block: suspend (Map<String, List<Base>>) -> List<Base>
+        block: suspend (Map<String, List<Base>>) -> List<R>
     ): AsyncOperationResult {
         require(maxAttempts >= 1) { "maxAttempts must be at least 1" }
         require(initialDelayMs >= 0) { "initialDelayMs must be non-negative" }
@@ -549,14 +550,15 @@ class AsyncOperationResult {
      * @param retryOn predicate called with each exception — return `false` to stop retrying immediately
      * @param block the suspending lambda to invoke; receives the typed dep value
      */
-    fun <T : Base> addListAfterWithRetry(
+    @JvmOverloads
+    fun <T : Base, R : Base> addListAfterWithRetry(
         key: String,
         dep: String,
         type: KClass<T>,
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
-        block: suspend (T) -> List<Base>
+        block: suspend (T) -> List<R>
     ): AsyncOperationResult = addListAfterWithRetry(
         key, dep,
         maxAttempts = maxAttempts,
@@ -611,14 +613,15 @@ class AsyncOperationResult {
      * @param retryOn predicate called with each exception — return `false` to stop retrying immediately
      * @param block the suspending lambda to invoke; receives the typed dep list
      */
-    fun <T : Base> addListAfterAllWithRetry(
+    @JvmOverloads
+    fun <T : Base, R : Base> addListAfterAllWithRetry(
         key: String,
         dep: String,
         type: KClass<T>,
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
-        block: suspend (List<T>) -> List<Base>
+        block: suspend (List<T>) -> List<R>
     ): AsyncOperationResult = addListAfterWithRetry(
         key, dep,
         maxAttempts = maxAttempts,
@@ -709,7 +712,7 @@ class AsyncOperationResult {
      * Registers an independent list-producing DAG task via [addList] only when [condition] is `true`.
      * When [condition] is `false`, returns `this` unchanged. See [addIf] for full contract.
      */
-    fun addListIf(condition: Boolean, key: String, block: suspend () -> List<Base>): AsyncOperationResult =
+    fun <R : Base> addListIf(condition: Boolean, key: String, block: suspend () -> List<R>): AsyncOperationResult =
         if (condition) addList(key, block) else this
 
     // ── DAG composition ──────────────────────────────────────────────────────

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultTypedListOutputTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultTypedListOutputTest.kt
@@ -1,0 +1,151 @@
+package dev.ratkay.operation.r4
+
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.hl7.fhir.r4.model.Appointment
+import org.hl7.fhir.r4.model.Base
+import org.hl7.fhir.r4.model.Observation
+import org.hl7.fhir.r4.model.Patient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AsyncOperationResultTypedListOutputTest {
+
+    @Test
+    fun `addList - R inferred as concrete type from lambda`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("patients") {
+                listOf(Patient().apply { id = "p1" }, Patient().apply { id = "p2" })
+            }
+            .run()
+
+        assertThat(result.count("patients"), `is`(2))
+        val patients = result.getAll("patients")
+        assertEquals("p1", (patients[0] as Patient).id)
+    }
+
+    @Test
+    fun `addListAfter vararg - R inferred as concrete type from lambda`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .addListAfter("observations", "patient") { deps ->
+                val patientId = (deps["patient"]!!.first() as Patient).id
+                listOf(
+                    Observation().apply { id = "obs1-$patientId" },
+                    Observation().apply { id = "obs2-$patientId" }
+                )
+            }
+            .run()
+
+        assertThat(result.count("observations"), `is`(2))
+        assertEquals("obs1-p1", (result.getAll("observations").first() as Observation).id)
+    }
+
+    @Test
+    fun `addListAfterAll - both T and R inferred as concrete types`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("patients") { listOf(Patient().apply { id = "p1" }, Patient().apply { id = "p2" }) }
+            .addListAfterAll("observations", "patients", Patient::class) { patients ->
+                patients.map { p -> Observation().apply { id = "obs-${p.id}" } }
+            }
+            .run()
+
+        assertThat(result.count("observations"), `is`(2))
+    }
+
+    @Test
+    fun `addListWithTimeout - R inferred as concrete type`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addListWithTimeout("appointments", 5000L) {
+                listOf(Appointment().apply { id = "a1" }, Appointment().apply { id = "a2" })
+            }
+            .run()
+
+        assertThat(result.count("appointments"), `is`(2))
+    }
+
+    @Test
+    fun `addListAfterWithTimeout vararg - R inferred as concrete type`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .addListAfterWithTimeout("observations", "patient", timeoutMs = 5000L) { deps ->
+                val pid = (deps["patient"]!!.first() as Patient).id
+                listOf(Observation().apply { id = "obs-$pid" })
+            }
+            .run()
+
+        assertThat(result.count("observations"), `is`(1))
+    }
+
+    @Test
+    fun `addListAfterAllWithTimeout - both T and R inferred as concrete types`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("patients") { listOf(Patient().apply { id = "p1" }) }
+            .addListAfterAllWithTimeout("observations", "patients", Patient::class, 5000L) { patients ->
+                patients.map { p -> Observation().apply { id = "obs-${p.id}" } }
+            }
+            .run()
+
+        assertThat(result.count("observations"), `is`(1))
+    }
+
+    @Test
+    fun `addListAfterWithRetry vararg - R inferred as concrete type`() = runBlocking {
+        val result = AsyncOperationResult()
+            .add("patient") { Patient().apply { id = "p1" } }
+            .addListAfterWithRetry("observations", "patient", maxAttempts = 1) { deps ->
+                val pid = (deps["patient"]!!.first() as Patient).id
+                listOf(Observation().apply { id = "obs-$pid" })
+            }
+            .run()
+
+        assertThat(result.count("observations"), `is`(1))
+    }
+
+    @Test
+    fun `addListAfterAllWithRetry - both T and R inferred as concrete types`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("patients") { listOf(Patient().apply { id = "p1" }, Patient().apply { id = "p2" }) }
+            .addListAfterAllWithRetry("observations", "patients", Patient::class, maxAttempts = 1) { patients ->
+                patients.map { p -> Observation().apply { id = "obs-${p.id}" } }
+            }
+            .run()
+
+        assertThat(result.count("observations"), `is`(2))
+    }
+
+    @Test
+    fun `addListIf true condition - R inferred as concrete type`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addListIf(true, "patients") {
+                listOf(Patient().apply { id = "p1" })
+            }
+            .run()
+
+        assertThat(result.count("patients"), `is`(1))
+    }
+
+    @Test
+    fun `addListIf false condition - block not executed`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addListIf(false, "patients") {
+                listOf(Patient().apply { id = "p1" })
+            }
+            .run()
+
+        assertThat(result.containsKey("patients"), `is`(false))
+    }
+
+    @Test
+    fun `addList with heterogeneous list - R inferred as Base regression guard`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("resources") {
+                @Suppress("UNCHECKED_CAST")
+                listOf<Base>(Patient().apply { id = "p1" }, Observation().apply { id = "o1" })
+            }
+            .run()
+
+        assertThat(result.count("resources"), `is`(2))
+    }
+}


### PR DESCRIPTION
All addList* methods previously declared their lambda return type as
List<Base>, forcing callers to mentally upcast and preventing Java callers
from passing typed lists (Java generics are invariant). The sync
OperationResult already uses <R : Base> generics on all its list methods;
this change brings the async API in line.

Methods changed (R4 and DSTU3):
- addList, addListAfter (vararg + single-dep + all-list variants)
- addListWithTimeout, addListAfterWithTimeout (vararg + typed variants)
- addListAfterWithRetry (vararg + typed variants), addListAfterAllWithRetry
- addListIf

The three primary vararg-map methods wrap the caller block in an adapter
lambda so the internal TaskNode (which stores List<Base>) compiles cleanly
via Kotlin's covariant List<out E>.

Also adds @JvmOverloads to addListAfterWithRetry and its typed/all variants,
which have default parameters but were missing the annotation per CLAUDE.md.

New test files: AsyncOperationResultTypedListOutputTest.kt (R4 + DSTU3)
with 11 tests each covering type inference and backward compatibility.