### PR TITLE
Enforce CLAUDE.md compliance: fix wildcard import and input-type stepName

### DIFF
--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
@@ -258,8 +258,7 @@ class OperationResult<T> private constructor(
         vararg extUrls: String,
         builder: (List<I>) -> R
     ): OperationResult<R> {
-        val stepName = type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) {
+        return runBuilderStep(null) {
             val (value, duration) = measureTimedValue { builder(collectByExtension(type, extUrls, matchAll = true)) }
             storeAndCopy(null, value, duration.inWholeMilliseconds)
         }
@@ -292,8 +291,7 @@ class OperationResult<T> private constructor(
         vararg extUrls: String,
         builder: (List<I>) -> R
     ): OperationResult<R> {
-        val stepName = type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) {
+        return runBuilderStep(null) {
             val (value, duration) = measureTimedValue { builder(collectByExtension(type, extUrls, matchAll = false)) }
             storeAndCopy(null, value, duration.inWholeMilliseconds)
         }
@@ -322,8 +320,7 @@ class OperationResult<T> private constructor(
         vararg extUrls: String,
         builder: (List<I>) -> List<R>
     ): OperationResult<List<R>> {
-        val stepName = type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) {
+        return runBuilderStep(null) {
             val (values, duration) = measureTimedValue { builder(collectByExtension(type, extUrls, matchAll = true)) }
             storeListAndCopy(null, values, duration.inWholeMilliseconds)
         }
@@ -350,8 +347,7 @@ class OperationResult<T> private constructor(
         vararg extUrls: String,
         builder: (List<I>) -> List<R>
     ): OperationResult<List<R>> {
-        val stepName = type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) {
+        return runBuilderStep(null) {
             val (values, duration) = measureTimedValue { builder(collectByExtension(type, extUrls, matchAll = false)) }
             storeListAndCopy(null, values, duration.inWholeMilliseconds)
         }
@@ -491,8 +487,7 @@ class OperationResult<T> private constructor(
         predicate: (V) -> Boolean,
         builder: (List<I>) -> R
     ): OperationResult<R> {
-        val stepName = type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) {
+        return runBuilderStep(null) {
             val (value, duration) = measureTimedValue { builder(collectByExtensionAndValueType(type, url, valueType, predicate)) }
             storeAndCopy(null, value, duration.inWholeMilliseconds)
         }
@@ -525,8 +520,7 @@ class OperationResult<T> private constructor(
         predicate: (V) -> Boolean,
         builder: (List<I>) -> List<R>
     ): OperationResult<List<R>> {
-        val stepName = type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) {
+        return runBuilderStep(null) {
             val (values, duration) = measureTimedValue { builder(collectByExtensionAndValueType(type, url, valueType, predicate)) }
             storeListAndCopy(null, values, duration.inWholeMilliseconds)
         }
@@ -592,8 +586,7 @@ class OperationResult<T> private constructor(
         expression: String,
         builder: (List<I>) -> R
     ): OperationResult<R> {
-        val stepName = name ?: type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) {
+        return runBuilderStep(name) {
             val (value, duration) = measureTimedValue { builder(collectByPath(type, expression)) }
             storeAndCopy(name, value, duration.inWholeMilliseconds)
         }
@@ -611,8 +604,7 @@ class OperationResult<T> private constructor(
         expression: String,
         builder: (List<I>) -> List<R>
     ): OperationResult<List<R>> {
-        val stepName = name ?: type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) {
+        return runBuilderStep(name) {
             val (values, duration) = measureTimedValue { builder(collectByPath(type, expression)) }
             storeListAndCopy(name, values, duration.inWholeMilliseconds)
         }

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -259,8 +259,7 @@ class OperationResult<T> private constructor(
         vararg extUrls: String,
         builder: (List<I>) -> R
     ): OperationResult<R> {
-        val stepName = type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) {
+        return runBuilderStep(null) {
             val (value, duration) = measureTimedValue { builder(collectByExtension(type, extUrls, matchAll = true)) }
             storeAndCopy(null, value, duration.inWholeMilliseconds)
         }
@@ -293,8 +292,7 @@ class OperationResult<T> private constructor(
         vararg extUrls: String,
         builder: (List<I>) -> R
     ): OperationResult<R> {
-        val stepName = type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) {
+        return runBuilderStep(null) {
             val (value, duration) = measureTimedValue { builder(collectByExtension(type, extUrls, matchAll = false)) }
             storeAndCopy(null, value, duration.inWholeMilliseconds)
         }
@@ -323,8 +321,7 @@ class OperationResult<T> private constructor(
         vararg extUrls: String,
         builder: (List<I>) -> List<R>
     ): OperationResult<List<R>> {
-        val stepName = type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) {
+        return runBuilderStep(null) {
             val (values, duration) = measureTimedValue { builder(collectByExtension(type, extUrls, matchAll = true)) }
             storeListAndCopy(null, values, duration.inWholeMilliseconds)
         }
@@ -351,8 +348,7 @@ class OperationResult<T> private constructor(
         vararg extUrls: String,
         builder: (List<I>) -> List<R>
     ): OperationResult<List<R>> {
-        val stepName = type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) {
+        return runBuilderStep(null) {
             val (values, duration) = measureTimedValue { builder(collectByExtension(type, extUrls, matchAll = false)) }
             storeListAndCopy(null, values, duration.inWholeMilliseconds)
         }
@@ -492,8 +488,7 @@ class OperationResult<T> private constructor(
         predicate: (V) -> Boolean,
         builder: (List<I>) -> R
     ): OperationResult<R> {
-        val stepName = type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) {
+        return runBuilderStep(null) {
             val (value, duration) = measureTimedValue { builder(collectByExtensionAndValueType(type, url, valueType, predicate)) }
             storeAndCopy(null, value, duration.inWholeMilliseconds)
         }
@@ -526,8 +521,7 @@ class OperationResult<T> private constructor(
         predicate: (V) -> Boolean,
         builder: (List<I>) -> List<R>
     ): OperationResult<List<R>> {
-        val stepName = type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) {
+        return runBuilderStep(null) {
             val (values, duration) = measureTimedValue { builder(collectByExtensionAndValueType(type, url, valueType, predicate)) }
             storeListAndCopy(null, values, duration.inWholeMilliseconds)
         }
@@ -593,8 +587,7 @@ class OperationResult<T> private constructor(
         expression: String,
         builder: (List<I>) -> R
     ): OperationResult<R> {
-        val stepName = name ?: type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) {
+        return runBuilderStep(name) {
             val (value, duration) = measureTimedValue { builder(collectByPath(type, expression)) }
             storeAndCopy(name, value, duration.inWholeMilliseconds)
         }
@@ -612,8 +605,7 @@ class OperationResult<T> private constructor(
         expression: String,
         builder: (List<I>) -> List<R>
     ): OperationResult<List<R>> {
-        val stepName = name ?: type.java.simpleName.lowercase()
-        return runBuilderStep(stepName) {
+        return runBuilderStep(name) {
             val (values, duration) = measureTimedValue { builder(collectByPath(type, expression)) }
             storeListAndCopy(name, values, duration.inWholeMilliseconds)
         }

--- a/fhirmason-spring/src/test/java/dev/ratkay/spring/FhirMasonAutoConfigurationTest.kt
+++ b/fhirmason-spring/src/test/java/dev/ratkay/spring/FhirMasonAutoConfigurationTest.kt
@@ -2,7 +2,11 @@ package dev.ratkay.spring
 
 import dev.ratkay.operation.ErrorStrategy
 import org.hl7.fhir.r4.model.Patient
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.ApplicationContextRunner


### PR DESCRIPTION
- Replace `import org.junit.jupiter.api.Assertions.*` with individual
  imports in FhirMasonAutoConfigurationTest (no wildcard imports rule)
- Remove `val stepName = type.java.simpleName.lowercase()` from the
  unnamed overloads of addFromHavingAllExtensions, addFromHavingAnyExtension,
  addAllFromHavingAllExtensions, addAllFromHavingAnyExtension,
  addFromHavingExtensionValueMatching, addAllFromHavingExtensionValueMatching
  — pass null to runBuilderStep so the error-path metric name no longer
  uses the input type (storage key was already correct via storeAndCopy(null,…))
- Simplify addFromMatching / addAllFromMatching to pass `name` directly
  instead of `name ?: type.java.simpleName.lowercase()`
- Applied identically to both R4 and DSTU3 modules (DSTU3 porting policy)

https://claude.ai/code/session_01PRoH69pEYFsS3Qem2Q1PKQ