### PR TITLE
Add identifier-based filtering to OperationResult (R4 + DSTU3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,51 @@ val result4 = OperationResult.of(patients, "patients")
     }
 ```
 
+#### From all parameters, filtered by FHIR Identifier
+
+Three method families filter accumulated resources by their `identifier` property. Resources with no `identifier` element (e.g. `OperationOutcome`) are excluded automatically. A resource is included when **any** of its identifiers satisfies the filter.
+
+| Method | Filters by | Returns |
+|---|---|---|
+| `addFromHavingIdentifierWithSystem(type, system) { list -> R }` | `identifier.system` | `OperationResult<R>` |
+| `addFromHavingIdentifierWithSystem(name, type, system) { list -> R }` | `identifier.system` (named) | `OperationResult<R>` |
+| `addAllFromHavingIdentifierWithSystem(type, system) { list -> List<R> }` | `identifier.system` | `OperationResult<List<R>>` |
+| `addAllFromHavingIdentifierWithSystem(name, type, system) { list -> List<R> }` | `identifier.system` (named) | `OperationResult<List<R>>` |
+| `addFromHavingIdentifierWithValue(type, identifierValue) { list -> R }` | `identifier.value` | `OperationResult<R>` |
+| `addFromHavingIdentifierWithValue(name, type, identifierValue) { list -> R }` | `identifier.value` (named) | `OperationResult<R>` |
+| `addAllFromHavingIdentifierWithValue(type, identifierValue) { list -> List<R> }` | `identifier.value` | `OperationResult<List<R>>` |
+| `addAllFromHavingIdentifierWithValue(name, type, identifierValue) { list -> List<R> }` | `identifier.value` (named) | `OperationResult<List<R>>` |
+| `addFromHavingIdentifier(type, system, identifierValue) { list -> R }` | system + value exact pair | `OperationResult<R>` |
+| `addFromHavingIdentifier(name, type, system, identifierValue) { list -> R }` | system + value exact pair (named) | `OperationResult<R>` |
+| `addAllFromHavingIdentifier(type, system, identifierValue) { list -> List<R> }` | system + value exact pair | `OperationResult<List<R>>` |
+| `addAllFromHavingIdentifier(name, type, system, identifierValue) { list -> List<R> }` | system + value exact pair (named) | `OperationResult<List<R>>` |
+
+All unnamed variants have reified inline overloads so the `KClass` argument can be omitted in Kotlin. Named variants intentionally have no reified overload — a reified overload whose first argument is a `String` would be ambiguous with the unnamed reified overload.
+
+```kotlin
+// System only — all Patients from this hospital's MRN namespace
+val result = OperationResult.of(patients, "patients")
+    .addFromHavingIdentifierWithSystem(Patient::class, "http://hospital.org/mrn") { filtered ->
+        OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+    }
+
+// Value only — any Patient with this identifier value regardless of system
+val result2 = OperationResult.of(patients, "patients")
+    .addAllFromHavingIdentifierWithValue<Patient, Patient>("MRN-001") { it }
+
+// Exact match — system + value
+val result3 = OperationResult.of(patients, "patients")
+    .addFromHavingIdentifier(Patient::class, "http://hospital.org/mrn", "MRN-001") { filtered ->
+        filtered.firstOrNull() ?: error("Patient not found")
+    }
+
+// Named output key (KClass form required)
+val result4 = OperationResult.of(patients, "patients")
+    .addFromHavingIdentifier("matched-patient", Patient::class, "http://hospital.org/mrn", "MRN-001") { filtered ->
+        buildResponse(filtered)
+    }
+```
+
 #### From all parameters, filtered by FHIRPath expression
 
 `addFromMatching` and `addAllFromMatching` evaluate a FHIRPath expression against every accumulated resource of a given type and pass only those that evaluate to `true` to the builder. The expression is relative to each candidate resource (write `"active = true"`, not `"Patient.active = true"`).
@@ -1582,7 +1627,8 @@ fhirmason-r4/
     │   ├── FhirDateTimeConverter.kt        # Java/Kotlin date-time → FHIR R4 type converter
     │   ├── OperationOutcomeExtensions.kt   # Exception → OperationOutcome helpers
     │   ├── FhirPathHelper.kt               # FhirPath evaluation helpers (internal)
-    │   └── FhirExtensionHelper.kt          # Deep extension retrieval utility
+    │   ├── FhirExtensionHelper.kt          # Deep extension retrieval utility
+    │   └── FhirIdentifierHelper.kt         # Identifier filtering helpers (internal)
     └── test/java/dev/ratkay/operation/r4/
         ├── OperationResultTest.kt
         ├── OperationResultFromTest.kt
@@ -1593,6 +1639,7 @@ fhirmason-r4/
         ├── OperationResultFhirErrorHandlingTest.kt
         ├── OperationResultRetryTest.kt
         ├── OperationResultFhirPathTest.kt
+        ├── OperationResultIdentifierTest.kt
         ├── OperationResultComplexTest.kt
         ├── AsyncOperationResultTest.kt
         ├── AsyncOperationResultMetricsTest.kt
@@ -1621,7 +1668,8 @@ fhirmason-dstu3/
     │   ├── FhirDateTimeConverter.kt        # Java/Kotlin date-time → FHIR DSTU3 type converter
     │   ├── OperationOutcomeExtensions.kt   # Exception → OperationOutcome helpers
     │   ├── FhirPathHelper.kt               # FhirPath evaluation helpers (internal)
-    │   └── FhirExtensionHelper.kt          # Deep extension retrieval utility
+    │   ├── FhirExtensionHelper.kt          # Deep extension retrieval utility
+    │   └── FhirIdentifierHelper.kt         # Identifier filtering helpers (internal)
     └── test/java/dev/ratkay/operation/dstu3/
         ├── OperationResultTest.kt
         ├── OperationResultFromTest.kt
@@ -1632,6 +1680,7 @@ fhirmason-dstu3/
         ├── OperationResultFhirErrorHandlingTest.kt
         ├── OperationResultRetryTest.kt
         ├── OperationResultFhirPathTest.kt
+        ├── OperationResultIdentifierTest.kt
         ├── OperationResultComplexTest.kt
         ├── AsyncOperationResultTest.kt
         ├── AsyncOperationResultMetricsTest.kt

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirIdentifierHelper.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirIdentifierHelper.kt
@@ -1,0 +1,36 @@
+package dev.ratkay.operation.dstu3
+
+import org.hl7.fhir.dstu3.model.Base
+import org.hl7.fhir.dstu3.model.Identifier
+import kotlin.reflect.KClass
+
+internal fun identifiersOf(resource: Base): List<Identifier> =
+    resource.children()
+        .firstOrNull { it.name == "identifier" }
+        ?.values
+        ?.filterIsInstance<Identifier>()
+        ?: emptyList()
+
+internal fun <I : Base> filterByIdentifierSystem(
+    allValues: List<Base>,
+    type: KClass<I>,
+    system: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> identifiersOf(resource).any { it.system == system } }
+
+internal fun <I : Base> filterByIdentifierValue(
+    allValues: List<Base>,
+    type: KClass<I>,
+    identifierValue: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> identifiersOf(resource).any { it.value == identifierValue } }
+
+internal fun <I : Base> filterByIdentifier(
+    allValues: List<Base>,
+    type: KClass<I>,
+    system: String,
+    identifierValue: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource ->
+        identifiersOf(resource).any { it.system == system && it.value == identifierValue }
+    }

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
@@ -52,6 +52,7 @@ import kotlin.time.measureTimedValue
  * | Step runners *(private)* | `runStep`, `runBuilderStep`, `runPrimitiveStep` |
  * | Storage helpers *(private)* | `storeAndCopy`, `storeListAndCopy` |
  * | Extension URL filters | `addFromHavingAllExtensions`, `addFromHavingAnyExtension`, `addAllFrom…`, `addFromHavingExtensionWithValueType`, `addFromHavingExtensionValueMatching`, … |
+ * | Identifier filters | `addFromHavingIdentifierWithSystem`, `addFromHavingIdentifierWithValue`, `addFromHavingIdentifier`, `addAllFrom…` |
  * | FHIRPath filters | `addFromMatching`, `addAllFromMatching` |
  * | Core builders | `add`, `addUsing`, `addAll`, `addAllUsing`, `addFrom`, `addAllFrom`, `addOrSkip`, `addOrDefault`, `addWithRetry`, `addWithRetryUsing` |
  * | Primitive values | `addString`, `addBoolean`, `addInteger`, `addDecimal`, `addDate([DateTimeInput])`, `addDateTime([DateTimeInput])`, `addInstant([DateTimeInput])`, `addTime([DateTimeInput])`, `addCoding`, `addReference`, `addIdentifier`, `addPeriod`, `addQuantity`, `addCodeableConcept` |
@@ -559,6 +560,255 @@ class OperationResult<T> private constructor(
         noinline predicate: (V) -> Boolean,
         noinline builder: (List<I>) -> List<R>
     ): OperationResult<List<R>> = addAllFromHavingExtensionValueMatching(I::class, url, V::class, predicate, builder)
+
+    // Builder methods — filter all accumulated parameters by type and FHIR Identifier fields
+
+    private fun <I : Base> collectByIdentifierSystem(type: KClass<I>, system: String): List<I> =
+        filterByIdentifierSystem(parameters.values.flatten(), type, system)
+
+    private fun <I : Base> collectByIdentifierValue(type: KClass<I>, identifierValue: String): List<I> =
+        filterByIdentifierValue(parameters.values.flatten(), type, identifierValue)
+
+    private fun <I : Base> collectByIdentifier(type: KClass<I>, system: String, identifierValue: String): List<I> =
+        filterByIdentifier(parameters.values.flatten(), type, system, identifierValue)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * [Identifier] whose [Identifier.system] equals [system], passes the typed list to [builder],
+     * and stores the single result under the result's fhirType (lowercase).
+     *
+     * Resources with no `identifier` property (e.g. `OperationOutcome`) are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingIdentifierWithSystem] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingIdentifierWithSystem(
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByIdentifierSystem(type, system)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /**
+     * Like [addFromHavingIdentifierWithSystem] but stores the result under the explicit [name].
+     * [name] is placed before [system] so the Java call-site remains unambiguous.
+     */
+    fun <I : Base, R : Base> addFromHavingIdentifierWithSystem(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByIdentifierSystem(type, system)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /**
+     * Like [addFromHavingIdentifierWithSystem] but [builder] returns a `List<R>`.
+     * The output name defaults to the result elements' fhirType (lowercase).
+     */
+    fun <I : Base, R : Base> addAllFromHavingIdentifierWithSystem(
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByIdentifierSystem(type, system)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingIdentifierWithSystem] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingIdentifierWithSystem(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByIdentifierSystem(type, system)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /**
+     * Reified overload of [addFromHavingIdentifierWithSystem] (unnamed output key).
+     *
+     * **Named variants are intentionally not reified** — a reified overload whose first argument
+     * is a `String` would be ambiguous with this one. Use the KClass overload when an explicit
+     * output key is required.
+     */
+    inline fun <reified I : Base, R : Base> addFromHavingIdentifierWithSystem(
+        system: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingIdentifierWithSystem(I::class, system, builder)
+
+    /** Reified overload of [addAllFromHavingIdentifierWithSystem] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingIdentifierWithSystem(
+        system: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingIdentifierWithSystem(I::class, system, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * [Identifier] whose [Identifier.value] equals [identifierValue], passes the typed list
+     * to [builder], and stores the single result under the result's fhirType (lowercase).
+     *
+     * Resources with no `identifier` property are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingIdentifierWithValue] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingIdentifierWithValue(
+        type: KClass<I>,
+        identifierValue: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByIdentifierValue(type, identifierValue)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingIdentifierWithValue] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingIdentifierWithValue(
+        name: String,
+        type: KClass<I>,
+        identifierValue: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByIdentifierValue(type, identifierValue)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingIdentifierWithValue] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingIdentifierWithValue(
+        type: KClass<I>,
+        identifierValue: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByIdentifierValue(type, identifierValue)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingIdentifierWithValue] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingIdentifierWithValue(
+        name: String,
+        type: KClass<I>,
+        identifierValue: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByIdentifierValue(type, identifierValue)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /**
+     * Reified overload of [addFromHavingIdentifierWithValue] (unnamed output key).
+     *
+     * **Named variants are intentionally not reified** — a reified overload whose first argument
+     * is a `String` would be ambiguous with this one. Use the KClass overload when an explicit
+     * output key is required.
+     */
+    inline fun <reified I : Base, R : Base> addFromHavingIdentifierWithValue(
+        identifierValue: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingIdentifierWithValue(I::class, identifierValue, builder)
+
+    /** Reified overload of [addAllFromHavingIdentifierWithValue] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingIdentifierWithValue(
+        identifierValue: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingIdentifierWithValue(I::class, identifierValue, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * [Identifier] whose [Identifier.system] equals [system] **and** [Identifier.value] equals
+     * [identifierValue], passes the typed list to [builder], and stores the single result under
+     * the result's fhirType (lowercase).
+     *
+     * Resources with no `identifier` property are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingIdentifier] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingIdentifier(
+        type: KClass<I>,
+        system: String,
+        identifierValue: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByIdentifier(type, system, identifierValue)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingIdentifier] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingIdentifier(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        identifierValue: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByIdentifier(type, system, identifierValue)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingIdentifier] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingIdentifier(
+        type: KClass<I>,
+        system: String,
+        identifierValue: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByIdentifier(type, system, identifierValue)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingIdentifier] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingIdentifier(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        identifierValue: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByIdentifier(type, system, identifierValue)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /**
+     * Reified overload of [addFromHavingIdentifier] (unnamed output key).
+     *
+     * **Named variants are intentionally not reified** — a reified overload whose first argument
+     * is a `String` would be ambiguous with this one. Use the KClass overload when an explicit
+     * output key is required.
+     */
+    inline fun <reified I : Base, R : Base> addFromHavingIdentifier(
+        system: String,
+        identifierValue: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingIdentifier(I::class, system, identifierValue, builder)
+
+    /** Reified overload of [addAllFromHavingIdentifier] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingIdentifier(
+        system: String,
+        identifierValue: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingIdentifier(I::class, system, identifierValue, builder)
 
     // Builder methods — filter all accumulated parameters by type and FHIRPath expression
 

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultIdentifierTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultIdentifierTest.kt
@@ -1,0 +1,425 @@
+package dev.ratkay.operation.dstu3
+
+import dev.ratkay.operation.ErrorStrategy
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.`is`
+import org.hl7.fhir.dstu3.model.Identifier
+import org.hl7.fhir.dstu3.model.OperationOutcome
+import org.hl7.fhir.dstu3.model.Patient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class OperationResultIdentifierTest {
+
+    // ── addFromHavingIdentifierWithSystem ─────────────────────────────────────
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem returns only resources whose identifier system matches`() {
+        val withSystem = patient("http://example.org/mrn", "12345")
+        val otherSystem = patient("http://other.org/id", "12345")
+        val result = OperationResult.of(listOf(withSystem, otherSystem), "patients")
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem with multiple matching resources passes all to builder`() {
+        val a = patient("http://example.org/mrn", "001")
+        val b = patient("http://example.org/mrn", "002")
+        val c = patient("http://example.org/mrn", "003")
+        val result = OperationResult.of(listOf(a, b, c), "patients")
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=3", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem with no matches passes empty list to builder`() {
+        val result = OperationResult.of(patient("http://other.org/id", "001"), "patients")
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem excludes resources without identifier property`() {
+        val withMrn = patient("http://example.org/mrn", "001")
+        val noId = patientNoIdentifier()
+        val result = OperationResult.of(listOf(withMrn, noId), "patients")
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem stores result under fhirType when name is null`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { _ ->
+                OperationOutcome().apply { addIssue().diagnostics = "found" }
+            }
+
+        assertFalse(result.containsKey("patient"))
+        assertTrue(result.containsKey("operationoutcome"))
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem named overload stores result under explicit key`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
+            .addFromHavingIdentifierWithSystem("mrn-summary", Patient::class, "http://example.org/mrn") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.containsKey("mrn-summary"))
+        assertFalse(result.containsKey("operationoutcome"))
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem reified overload works without KClass argument`() {
+        val withSystem = patient("http://example.org/mrn", "001")
+        val result = OperationResult.of(listOf(withSystem, patientNoIdentifier()), "patients")
+            .addFromHavingIdentifierWithSystem<Patient, OperationOutcome>("http://example.org/mrn") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem records ERROR outcome when builder throws`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { _ ->
+                throw RuntimeException("builder failed")
+            }
+
+        assertTrue(result.hasErrors())
+        val issue = result.getOutcomes().first().issueFirstRep
+        assertThat(issue.severity, `is`(OperationOutcome.IssueSeverity.ERROR))
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem respects FAIL_FAST and skips when already errored`() {
+        var builderCalled = false
+        val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients", ErrorStrategy.FAIL_FAST)
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { _ ->
+                throw RuntimeException("first failure")
+            }
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { _ ->
+                builderCalled = true
+                OperationOutcome()
+            }
+
+        assertFalse(builderCalled)
+        assertTrue(result.hasErrors())
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem searches across all parameter keys`() {
+        val a = patient("http://example.org/mrn", "001")
+        val b = patient("http://example.org/mrn", "002")
+        val result = OperationResult.of(a, "group-a")
+            .add("group-b") { b }
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=2", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    // ── addAllFromHavingIdentifierWithSystem ──────────────────────────────────
+
+    @Test
+    fun `addAllFromHavingIdentifierWithSystem returns matching resources as list result`() {
+        val a = patient("http://example.org/mrn", "001")
+        val b = patient("http://example.org/mrn", "002")
+        val other = patient("http://other.org/id", "003")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    @Test
+    fun `addAllFromHavingIdentifierWithSystem named overload stores under explicit key`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
+            .addAllFromHavingIdentifierWithSystem("mrn-patients", Patient::class, "http://example.org/mrn") { it }
+
+        assertTrue(result.containsKey("mrn-patients"))
+    }
+
+    @Test
+    fun `addAllFromHavingIdentifierWithSystem reified overload works`() {
+        val a = patient("http://example.org/mrn", "001")
+        val result = OperationResult.of(listOf(a, patientNoIdentifier()), "patients")
+            .addAllFromHavingIdentifierWithSystem<Patient, Patient>("http://example.org/mrn") { it }
+
+        assertThat(result.getResult(), hasSize(1))
+    }
+
+    // ── addFromHavingIdentifierWithValue ──────────────────────────────────────
+
+    @Test
+    fun `addFromHavingIdentifierWithValue returns only resources whose identifier value matches`() {
+        val target = patient("http://example.org/mrn", "12345")
+        val other = patient("http://example.org/mrn", "99999")
+        val result = OperationResult.of(listOf(target, other), "patients")
+            .addFromHavingIdentifierWithValue(Patient::class, "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithValue with no matches passes empty list to builder`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "99999"), "patients")
+            .addFromHavingIdentifierWithValue(Patient::class, "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithValue excludes resources without identifier property`() {
+        val withValue = patient("http://example.org/mrn", "12345")
+        val result = OperationResult.of(listOf(withValue, patientNoIdentifier()), "patients")
+            .addFromHavingIdentifierWithValue(Patient::class, "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithValue stores result under fhirType when name is null`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
+            .addFromHavingIdentifierWithValue(Patient::class, "12345") { _ ->
+                OperationOutcome().apply { addIssue().diagnostics = "found" }
+            }
+
+        assertTrue(result.containsKey("operationoutcome"))
+        assertFalse(result.containsKey("patient"))
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithValue named overload stores under explicit key`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
+            .addFromHavingIdentifierWithValue("value-result", Patient::class, "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.containsKey("value-result"))
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithValue reified overload works without KClass argument`() {
+        val target = patient("http://example.org/mrn", "12345")
+        val result = OperationResult.of(listOf(target, patientNoIdentifier()), "patients")
+            .addFromHavingIdentifierWithValue<Patient, OperationOutcome>("12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addAllFromHavingIdentifierWithValue returns matching resources as list result`() {
+        val a = patient("http://example.org/mrn", "12345")
+        val b = patient("http://other.org/id", "12345")
+        val other = patient("http://example.org/mrn", "99999")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingIdentifierWithValue(Patient::class, "12345") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    // ── addFromHavingIdentifier (system + value) ──────────────────────────────
+
+    @Test
+    fun `addFromHavingIdentifier returns only resources matching both system and value`() {
+        val exact = patient("http://example.org/mrn", "12345")
+        val wrongValue = patient("http://example.org/mrn", "99999")
+        val wrongSystem = patient("http://other.org/id", "12345")
+        val result = OperationResult.of(listOf(exact, wrongValue, wrongSystem), "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifier does not match when system matches but value does not`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "99999"), "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifier does not match when value matches but system does not`() {
+        val result = OperationResult.of(patient("http://other.org/id", "12345"), "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifier matches if any identifier on resource satisfies both fields`() {
+        val multiId = Patient().apply {
+            addIdentifier().apply { system = "http://other.org/id"; value = "999" }
+            addIdentifier().apply { system = "http://example.org/mrn"; value = "12345" }
+        }
+        val result = OperationResult.of(multiId, "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifier with no matches passes empty list to builder`() {
+        val result = OperationResult.of(patientNoIdentifier(), "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifier excludes resources without identifier property`() {
+        val exact = patient("http://example.org/mrn", "12345")
+        val result = OperationResult.of(listOf(exact, patientNoIdentifier()), "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifier stores result under fhirType when name is null`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { _ ->
+                OperationOutcome().apply { addIssue().diagnostics = "found" }
+            }
+
+        assertTrue(result.containsKey("operationoutcome"))
+        assertFalse(result.containsKey("patient"))
+    }
+
+    @Test
+    fun `addFromHavingIdentifier named overload stores under explicit key`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
+            .addFromHavingIdentifier("matched-patient", Patient::class, "http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.containsKey("matched-patient"))
+        assertFalse(result.containsKey("operationoutcome"))
+    }
+
+    @Test
+    fun `addFromHavingIdentifier reified overload works without KClass argument`() {
+        val exact = patient("http://example.org/mrn", "12345")
+        val result = OperationResult.of(listOf(exact, patientNoIdentifier()), "patients")
+            .addFromHavingIdentifier<Patient, OperationOutcome>("http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifier records ERROR outcome when builder throws`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { _ ->
+                throw RuntimeException("builder failed")
+            }
+
+        assertTrue(result.hasErrors())
+        val issue = result.getOutcomes().first().issueFirstRep
+        assertThat(issue.severity, `is`(OperationOutcome.IssueSeverity.ERROR))
+    }
+
+    // ── addAllFromHavingIdentifier ────────────────────────────────────────────
+
+    @Test
+    fun `addAllFromHavingIdentifier returns matching resources as list result`() {
+        val a = patient("http://example.org/mrn", "12345")
+        val b = patient("http://example.org/mrn", "12345")
+        val other = patient("http://example.org/mrn", "99999")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    @Test
+    fun `addAllFromHavingIdentifier named overload stores under explicit key`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
+            .addAllFromHavingIdentifier("exact-matches", Patient::class, "http://example.org/mrn", "12345") { it }
+
+        assertTrue(result.containsKey("exact-matches"))
+    }
+
+    @Test
+    fun `addAllFromHavingIdentifier reified overload works`() {
+        val a = patient("http://example.org/mrn", "12345")
+        val result = OperationResult.of(listOf(a, patientNoIdentifier()), "patients")
+            .addAllFromHavingIdentifier<Patient, Patient>("http://example.org/mrn", "12345") { it }
+
+        assertThat(result.getResult(), hasSize(1))
+    }
+
+    // ── Cross-cutting ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `identifier filter methods compose with subsequent pipeline steps`() {
+        val withMrn = patient("http://example.org/mrn", "12345")
+        val result = OperationResult.of(listOf(withMrn, patientNoIdentifier()), "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+            .add("flag") { org.hl7.fhir.dstu3.model.StringType("done") }
+
+        assertTrue(result.isSuccessful())
+        assertTrue(result.containsKey("flag"))
+        assertTrue(result.containsKey("operationoutcome"))
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun patient(system: String, value: String) = Patient().apply {
+        addIdentifier().apply {
+            this.system = system
+            this.value = value
+        }
+    }
+
+    private fun patientNoIdentifier() = Patient().apply {
+        addName().apply { family = "NoId" }
+    }
+}

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/FhirIdentifierHelper.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/FhirIdentifierHelper.kt
@@ -1,0 +1,36 @@
+package dev.ratkay.operation.r4
+
+import org.hl7.fhir.r4.model.Base
+import org.hl7.fhir.r4.model.Identifier
+import kotlin.reflect.KClass
+
+internal fun identifiersOf(resource: Base): List<Identifier> =
+    resource.children()
+        .firstOrNull { it.name == "identifier" }
+        ?.values
+        ?.filterIsInstance<Identifier>()
+        ?: emptyList()
+
+internal fun <I : Base> filterByIdentifierSystem(
+    allValues: List<Base>,
+    type: KClass<I>,
+    system: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> identifiersOf(resource).any { it.system == system } }
+
+internal fun <I : Base> filterByIdentifierValue(
+    allValues: List<Base>,
+    type: KClass<I>,
+    identifierValue: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> identifiersOf(resource).any { it.value == identifierValue } }
+
+internal fun <I : Base> filterByIdentifier(
+    allValues: List<Base>,
+    type: KClass<I>,
+    system: String,
+    identifierValue: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource ->
+        identifiersOf(resource).any { it.system == system && it.value == identifierValue }
+    }

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -53,6 +53,7 @@ import kotlin.time.measureTimedValue
  * | Step runners *(private)* | `runStep`, `runBuilderStep`, `runPrimitiveStep` |
  * | Storage helpers *(private)* | `storeAndCopy`, `storeListAndCopy` |
  * | Extension URL filters | `addFromHavingAllExtensions`, `addFromHavingAnyExtension`, `addAllFrom…`, `addFromHavingExtensionWithValueType`, `addFromHavingExtensionValueMatching`, … |
+ * | Identifier filters | `addFromHavingIdentifierWithSystem`, `addFromHavingIdentifierWithValue`, `addFromHavingIdentifier`, `addAllFrom…` |
  * | FHIRPath filters | `addFromMatching`, `addAllFromMatching` |
  * | Core builders | `add`, `addUsing`, `addAll`, `addAllUsing`, `addFrom`, `addAllFrom`, `addOrSkip`, `addOrDefault`, `addWithRetry`, `addWithRetryUsing` |
  * | Primitive values | `addString`, `addBoolean`, `addInteger`, `addDecimal`, `addDate([DateTimeInput])`, `addDateTime([DateTimeInput])`, `addInstant([DateTimeInput])`, `addTime([DateTimeInput])`, `addCanonical`, `addCoding`, `addReference`, `addIdentifier`, `addPeriod`, `addQuantity`, `addCodeableConcept` |
@@ -560,6 +561,255 @@ class OperationResult<T> private constructor(
         noinline predicate: (V) -> Boolean,
         noinline builder: (List<I>) -> List<R>
     ): OperationResult<List<R>> = addAllFromHavingExtensionValueMatching(I::class, url, V::class, predicate, builder)
+
+    // Builder methods — filter all accumulated parameters by type and FHIR Identifier fields
+
+    private fun <I : Base> collectByIdentifierSystem(type: KClass<I>, system: String): List<I> =
+        filterByIdentifierSystem(parameters.values.flatten(), type, system)
+
+    private fun <I : Base> collectByIdentifierValue(type: KClass<I>, identifierValue: String): List<I> =
+        filterByIdentifierValue(parameters.values.flatten(), type, identifierValue)
+
+    private fun <I : Base> collectByIdentifier(type: KClass<I>, system: String, identifierValue: String): List<I> =
+        filterByIdentifier(parameters.values.flatten(), type, system, identifierValue)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * [Identifier] whose [Identifier.system] equals [system], passes the typed list to [builder],
+     * and stores the single result under the result's fhirType (lowercase).
+     *
+     * Resources with no `identifier` property (e.g. `OperationOutcome`) are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingIdentifierWithSystem] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingIdentifierWithSystem(
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByIdentifierSystem(type, system)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /**
+     * Like [addFromHavingIdentifierWithSystem] but stores the result under the explicit [name].
+     * [name] is placed before [system] so the Java call-site remains unambiguous.
+     */
+    fun <I : Base, R : Base> addFromHavingIdentifierWithSystem(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByIdentifierSystem(type, system)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /**
+     * Like [addFromHavingIdentifierWithSystem] but [builder] returns a `List<R>`.
+     * The output name defaults to the result elements' fhirType (lowercase).
+     */
+    fun <I : Base, R : Base> addAllFromHavingIdentifierWithSystem(
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByIdentifierSystem(type, system)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingIdentifierWithSystem] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingIdentifierWithSystem(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByIdentifierSystem(type, system)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /**
+     * Reified overload of [addFromHavingIdentifierWithSystem] (unnamed output key).
+     *
+     * **Named variants are intentionally not reified** — a reified overload whose first argument
+     * is a `String` would be ambiguous with this one. Use the KClass overload when an explicit
+     * output key is required.
+     */
+    inline fun <reified I : Base, R : Base> addFromHavingIdentifierWithSystem(
+        system: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingIdentifierWithSystem(I::class, system, builder)
+
+    /** Reified overload of [addAllFromHavingIdentifierWithSystem] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingIdentifierWithSystem(
+        system: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingIdentifierWithSystem(I::class, system, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * [Identifier] whose [Identifier.value] equals [identifierValue], passes the typed list
+     * to [builder], and stores the single result under the result's fhirType (lowercase).
+     *
+     * Resources with no `identifier` property are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingIdentifierWithValue] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingIdentifierWithValue(
+        type: KClass<I>,
+        identifierValue: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByIdentifierValue(type, identifierValue)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingIdentifierWithValue] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingIdentifierWithValue(
+        name: String,
+        type: KClass<I>,
+        identifierValue: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByIdentifierValue(type, identifierValue)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingIdentifierWithValue] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingIdentifierWithValue(
+        type: KClass<I>,
+        identifierValue: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByIdentifierValue(type, identifierValue)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingIdentifierWithValue] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingIdentifierWithValue(
+        name: String,
+        type: KClass<I>,
+        identifierValue: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByIdentifierValue(type, identifierValue)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /**
+     * Reified overload of [addFromHavingIdentifierWithValue] (unnamed output key).
+     *
+     * **Named variants are intentionally not reified** — a reified overload whose first argument
+     * is a `String` would be ambiguous with this one. Use the KClass overload when an explicit
+     * output key is required.
+     */
+    inline fun <reified I : Base, R : Base> addFromHavingIdentifierWithValue(
+        identifierValue: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingIdentifierWithValue(I::class, identifierValue, builder)
+
+    /** Reified overload of [addAllFromHavingIdentifierWithValue] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingIdentifierWithValue(
+        identifierValue: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingIdentifierWithValue(I::class, identifierValue, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * [Identifier] whose [Identifier.system] equals [system] **and** [Identifier.value] equals
+     * [identifierValue], passes the typed list to [builder], and stores the single result under
+     * the result's fhirType (lowercase).
+     *
+     * Resources with no `identifier` property are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingIdentifier] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingIdentifier(
+        type: KClass<I>,
+        system: String,
+        identifierValue: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByIdentifier(type, system, identifierValue)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingIdentifier] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingIdentifier(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        identifierValue: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByIdentifier(type, system, identifierValue)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingIdentifier] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingIdentifier(
+        type: KClass<I>,
+        system: String,
+        identifierValue: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByIdentifier(type, system, identifierValue)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingIdentifier] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingIdentifier(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        identifierValue: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByIdentifier(type, system, identifierValue)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /**
+     * Reified overload of [addFromHavingIdentifier] (unnamed output key).
+     *
+     * **Named variants are intentionally not reified** — a reified overload whose first argument
+     * is a `String` would be ambiguous with this one. Use the KClass overload when an explicit
+     * output key is required.
+     */
+    inline fun <reified I : Base, R : Base> addFromHavingIdentifier(
+        system: String,
+        identifierValue: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingIdentifier(I::class, system, identifierValue, builder)
+
+    /** Reified overload of [addAllFromHavingIdentifier] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingIdentifier(
+        system: String,
+        identifierValue: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingIdentifier(I::class, system, identifierValue, builder)
 
     // Builder methods — filter all accumulated parameters by type and FHIRPath expression
 

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultIdentifierTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultIdentifierTest.kt
@@ -1,0 +1,425 @@
+package dev.ratkay.operation.r4
+
+import dev.ratkay.operation.ErrorStrategy
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.`is`
+import org.hl7.fhir.r4.model.Identifier
+import org.hl7.fhir.r4.model.OperationOutcome
+import org.hl7.fhir.r4.model.Patient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class OperationResultIdentifierTest {
+
+    // ── addFromHavingIdentifierWithSystem ─────────────────────────────────────
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem returns only resources whose identifier system matches`() {
+        val withSystem = patient("http://example.org/mrn", "12345")
+        val otherSystem = patient("http://other.org/id", "12345")
+        val result = OperationResult.of(listOf(withSystem, otherSystem), "patients")
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem with multiple matching resources passes all to builder`() {
+        val a = patient("http://example.org/mrn", "001")
+        val b = patient("http://example.org/mrn", "002")
+        val c = patient("http://example.org/mrn", "003")
+        val result = OperationResult.of(listOf(a, b, c), "patients")
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=3", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem with no matches passes empty list to builder`() {
+        val result = OperationResult.of(patient("http://other.org/id", "001"), "patients")
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem excludes resources without identifier property`() {
+        val withMrn = patient("http://example.org/mrn", "001")
+        val noId = patientNoIdentifier()
+        val result = OperationResult.of(listOf(withMrn, noId), "patients")
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem stores result under fhirType when name is null`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { _ ->
+                OperationOutcome().apply { addIssue().diagnostics = "found" }
+            }
+
+        assertFalse(result.containsKey("patient"))
+        assertTrue(result.containsKey("operationoutcome"))
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem named overload stores result under explicit key`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
+            .addFromHavingIdentifierWithSystem("mrn-summary", Patient::class, "http://example.org/mrn") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.containsKey("mrn-summary"))
+        assertFalse(result.containsKey("operationoutcome"))
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem reified overload works without KClass argument`() {
+        val withSystem = patient("http://example.org/mrn", "001")
+        val result = OperationResult.of(listOf(withSystem, patientNoIdentifier()), "patients")
+            .addFromHavingIdentifierWithSystem<Patient, OperationOutcome>("http://example.org/mrn") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem records ERROR outcome when builder throws`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { _ ->
+                throw RuntimeException("builder failed")
+            }
+
+        assertTrue(result.hasErrors())
+        val issue = result.getOutcomes().first().issueFirstRep
+        assertThat(issue.severity, `is`(OperationOutcome.IssueSeverity.ERROR))
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem respects FAIL_FAST and skips when already errored`() {
+        var builderCalled = false
+        val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients", ErrorStrategy.FAIL_FAST)
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { _ ->
+                throw RuntimeException("first failure")
+            }
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { _ ->
+                builderCalled = true
+                OperationOutcome()
+            }
+
+        assertFalse(builderCalled)
+        assertTrue(result.hasErrors())
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithSystem searches across all parameter keys`() {
+        val a = patient("http://example.org/mrn", "001")
+        val b = patient("http://example.org/mrn", "002")
+        val result = OperationResult.of(a, "group-a")
+            .add("group-b") { b }
+            .addFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=2", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    // ── addAllFromHavingIdentifierWithSystem ──────────────────────────────────
+
+    @Test
+    fun `addAllFromHavingIdentifierWithSystem returns matching resources as list result`() {
+        val a = patient("http://example.org/mrn", "001")
+        val b = patient("http://example.org/mrn", "002")
+        val other = patient("http://other.org/id", "003")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingIdentifierWithSystem(Patient::class, "http://example.org/mrn") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    @Test
+    fun `addAllFromHavingIdentifierWithSystem named overload stores under explicit key`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
+            .addAllFromHavingIdentifierWithSystem("mrn-patients", Patient::class, "http://example.org/mrn") { it }
+
+        assertTrue(result.containsKey("mrn-patients"))
+    }
+
+    @Test
+    fun `addAllFromHavingIdentifierWithSystem reified overload works`() {
+        val a = patient("http://example.org/mrn", "001")
+        val result = OperationResult.of(listOf(a, patientNoIdentifier()), "patients")
+            .addAllFromHavingIdentifierWithSystem<Patient, Patient>("http://example.org/mrn") { it }
+
+        assertThat(result.getResult(), hasSize(1))
+    }
+
+    // ── addFromHavingIdentifierWithValue ──────────────────────────────────────
+
+    @Test
+    fun `addFromHavingIdentifierWithValue returns only resources whose identifier value matches`() {
+        val target = patient("http://example.org/mrn", "12345")
+        val other = patient("http://example.org/mrn", "99999")
+        val result = OperationResult.of(listOf(target, other), "patients")
+            .addFromHavingIdentifierWithValue(Patient::class, "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithValue with no matches passes empty list to builder`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "99999"), "patients")
+            .addFromHavingIdentifierWithValue(Patient::class, "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithValue excludes resources without identifier property`() {
+        val withValue = patient("http://example.org/mrn", "12345")
+        val result = OperationResult.of(listOf(withValue, patientNoIdentifier()), "patients")
+            .addFromHavingIdentifierWithValue(Patient::class, "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithValue stores result under fhirType when name is null`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
+            .addFromHavingIdentifierWithValue(Patient::class, "12345") { _ ->
+                OperationOutcome().apply { addIssue().diagnostics = "found" }
+            }
+
+        assertTrue(result.containsKey("operationoutcome"))
+        assertFalse(result.containsKey("patient"))
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithValue named overload stores under explicit key`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
+            .addFromHavingIdentifierWithValue("value-result", Patient::class, "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.containsKey("value-result"))
+    }
+
+    @Test
+    fun `addFromHavingIdentifierWithValue reified overload works without KClass argument`() {
+        val target = patient("http://example.org/mrn", "12345")
+        val result = OperationResult.of(listOf(target, patientNoIdentifier()), "patients")
+            .addFromHavingIdentifierWithValue<Patient, OperationOutcome>("12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addAllFromHavingIdentifierWithValue returns matching resources as list result`() {
+        val a = patient("http://example.org/mrn", "12345")
+        val b = patient("http://other.org/id", "12345")
+        val other = patient("http://example.org/mrn", "99999")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingIdentifierWithValue(Patient::class, "12345") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    // ── addFromHavingIdentifier (system + value) ──────────────────────────────
+
+    @Test
+    fun `addFromHavingIdentifier returns only resources matching both system and value`() {
+        val exact = patient("http://example.org/mrn", "12345")
+        val wrongValue = patient("http://example.org/mrn", "99999")
+        val wrongSystem = patient("http://other.org/id", "12345")
+        val result = OperationResult.of(listOf(exact, wrongValue, wrongSystem), "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifier does not match when system matches but value does not`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "99999"), "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifier does not match when value matches but system does not`() {
+        val result = OperationResult.of(patient("http://other.org/id", "12345"), "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifier matches if any identifier on resource satisfies both fields`() {
+        val multiId = Patient().apply {
+            addIdentifier().apply { system = "http://other.org/id"; value = "999" }
+            addIdentifier().apply { system = "http://example.org/mrn"; value = "12345" }
+        }
+        val result = OperationResult.of(multiId, "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifier with no matches passes empty list to builder`() {
+        val result = OperationResult.of(patientNoIdentifier(), "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifier excludes resources without identifier property`() {
+        val exact = patient("http://example.org/mrn", "12345")
+        val result = OperationResult.of(listOf(exact, patientNoIdentifier()), "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifier stores result under fhirType when name is null`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { _ ->
+                OperationOutcome().apply { addIssue().diagnostics = "found" }
+            }
+
+        assertTrue(result.containsKey("operationoutcome"))
+        assertFalse(result.containsKey("patient"))
+    }
+
+    @Test
+    fun `addFromHavingIdentifier named overload stores under explicit key`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
+            .addFromHavingIdentifier("matched-patient", Patient::class, "http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.containsKey("matched-patient"))
+        assertFalse(result.containsKey("operationoutcome"))
+    }
+
+    @Test
+    fun `addFromHavingIdentifier reified overload works without KClass argument`() {
+        val exact = patient("http://example.org/mrn", "12345")
+        val result = OperationResult.of(listOf(exact, patientNoIdentifier()), "patients")
+            .addFromHavingIdentifier<Patient, OperationOutcome>("http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingIdentifier records ERROR outcome when builder throws`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { _ ->
+                throw RuntimeException("builder failed")
+            }
+
+        assertTrue(result.hasErrors())
+        val issue = result.getOutcomes().first().issueFirstRep
+        assertThat(issue.severity, `is`(OperationOutcome.IssueSeverity.ERROR))
+    }
+
+    // ── addAllFromHavingIdentifier ────────────────────────────────────────────
+
+    @Test
+    fun `addAllFromHavingIdentifier returns matching resources as list result`() {
+        val a = patient("http://example.org/mrn", "12345")
+        val b = patient("http://example.org/mrn", "12345")
+        val other = patient("http://example.org/mrn", "99999")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    @Test
+    fun `addAllFromHavingIdentifier named overload stores under explicit key`() {
+        val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
+            .addAllFromHavingIdentifier("exact-matches", Patient::class, "http://example.org/mrn", "12345") { it }
+
+        assertTrue(result.containsKey("exact-matches"))
+    }
+
+    @Test
+    fun `addAllFromHavingIdentifier reified overload works`() {
+        val a = patient("http://example.org/mrn", "12345")
+        val result = OperationResult.of(listOf(a, patientNoIdentifier()), "patients")
+            .addAllFromHavingIdentifier<Patient, Patient>("http://example.org/mrn", "12345") { it }
+
+        assertThat(result.getResult(), hasSize(1))
+    }
+
+    // ── Cross-cutting ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `identifier filter methods compose with subsequent pipeline steps`() {
+        val withMrn = patient("http://example.org/mrn", "12345")
+        val result = OperationResult.of(listOf(withMrn, patientNoIdentifier()), "patients")
+            .addFromHavingIdentifier(Patient::class, "http://example.org/mrn", "12345") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+            .add("flag") { org.hl7.fhir.r4.model.StringType("done") }
+
+        assertTrue(result.isSuccessful())
+        assertTrue(result.containsKey("flag"))
+        assertTrue(result.containsKey("operationoutcome"))
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun patient(system: String, value: String) = Patient().apply {
+        addIdentifier().apply {
+            this.system = system
+            this.value = value
+        }
+    }
+
+    private fun patientNoIdentifier() = Patient().apply {
+        addName().apply { family = "NoId" }
+    }
+}


### PR DESCRIPTION
Three new filter families let callers narrow accumulated FHIR resources
by their `identifier` property without writing a raw FHIRPath expression:

- `addFromHavingIdentifierWithSystem` / `addAllFrom…` — filter by system URL
- `addFromHavingIdentifierWithValue` / `addAllFrom…`  — filter by value
- `addFromHavingIdentifier` / `addAllFrom…`           — exact system+value pair

Each family provides an unnamed KClass overload, a named KClass overload,
and a reified Kotlin overload. Resources with no `identifier` element are
excluded automatically. All variants follow Pattern A error handling.

Implementation mirrors the extension-filter pattern: new
`FhirIdentifierHelper.kt` files (R4 and DSTU3) expose three `internal`
filter functions; `OperationResult` delegates to them via private
`collectBy*` helpers. 34 tests added per FHIR version (68 total).