### PR TITLE
Add meta.tag, meta.security, meta.profile filtering methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,64 @@ val result4 = OperationResult.of(patients, "patients")
     }
 ```
 
+#### From all parameters, filtered by meta.tag / meta.security / meta.profile
+
+`meta` is present on every FHIR resource. Three field groups are supported, each mirroring the identifier method shape. Non-resource objects (which have no `meta`) are excluded automatically.
+
+**meta.tag / meta.security** — each is a `List<Coding>` with `system` and `code` fields:
+
+| Method | Filters by | Returns |
+|---|---|---|
+| `addFromHavingMetaTagWithSystem(type, system) { list -> R }` | `meta.tag.system` | `OperationResult<R>` |
+| `addFromHavingMetaTagWithSystem(name, type, system) { list -> R }` | `meta.tag.system` (named) | `OperationResult<R>` |
+| `addAllFromHavingMetaTagWithSystem(type, system) { list -> List<R> }` | `meta.tag.system` | `OperationResult<List<R>>` |
+| `addAllFromHavingMetaTagWithSystem(name, type, system) { list -> List<R> }` | `meta.tag.system` (named) | `OperationResult<List<R>>` |
+| `addFromHavingMetaTagWithCode(type, code) { list -> R }` | `meta.tag.code` | `OperationResult<R>` |
+| `addFromHavingMetaTagWithCode(name, type, code) { list -> R }` | `meta.tag.code` (named) | `OperationResult<R>` |
+| `addAllFromHavingMetaTagWithCode(type, code) { list -> List<R> }` | `meta.tag.code` | `OperationResult<List<R>>` |
+| `addAllFromHavingMetaTagWithCode(name, type, code) { list -> List<R> }` | `meta.tag.code` (named) | `OperationResult<List<R>>` |
+| `addFromHavingMetaTag(type, system, code) { list -> R }` | system + code exact pair | `OperationResult<R>` |
+| `addFromHavingMetaTag(name, type, system, code) { list -> R }` | system + code exact pair (named) | `OperationResult<R>` |
+| `addAllFromHavingMetaTag(type, system, code) { list -> List<R> }` | system + code exact pair | `OperationResult<List<R>>` |
+| `addAllFromHavingMetaTag(name, type, system, code) { list -> List<R> }` | system + code exact pair (named) | `OperationResult<List<R>>` |
+
+The same 12 overloads exist for `meta.security` with method names `addFromHavingMetaSecurityWithSystem`, `addFromHavingMetaSecurityWithCode`, and `addFromHavingMetaSecurity`.
+
+**meta.profile** — a list of canonical URI strings:
+
+| Method | Filters by | Returns |
+|---|---|---|
+| `addFromHavingMetaProfile(type, url) { list -> R }` | profile URL | `OperationResult<R>` |
+| `addFromHavingMetaProfile(name, type, url) { list -> R }` | profile URL (named) | `OperationResult<R>` |
+| `addAllFromHavingMetaProfile(type, url) { list -> List<R> }` | profile URL | `OperationResult<List<R>>` |
+| `addAllFromHavingMetaProfile(name, type, url) { list -> List<R> }` | profile URL (named) | `OperationResult<List<R>>` |
+
+All unnamed variants have reified inline overloads (omit the `KClass` argument in Kotlin). Named variants intentionally have no reified overload to avoid ambiguity.
+
+```kotlin
+// Filter by tag system
+val result = OperationResult.of(resources, "resources")
+    .addAllFromHavingMetaTagWithSystem<Patient, Patient>("http://example.org/workflow-tags") { it }
+
+// Filter by exact tag (system + code)
+val result2 = OperationResult.of(resources, "resources")
+    .addFromHavingMetaTag(Patient::class, "http://example.org/workflow-tags", "reviewed") { filtered ->
+        OperationOutcome().apply { addIssue().diagnostics = "reviewed=${filtered.size}" }
+    }
+
+// Filter by security label
+val result3 = OperationResult.of(resources, "resources")
+    .addAllFromHavingMetaSecurity<Patient, Patient>(
+        "http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"
+    ) { it }
+
+// Filter by declared profile
+val result4 = OperationResult.of(resources, "resources")
+    .addAllFromHavingMetaProfile<Patient, Patient>(
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+    ) { it }
+```
+
 #### From all parameters, filtered by FHIRPath expression
 
 `addFromMatching` and `addAllFromMatching` evaluate a FHIRPath expression against every accumulated resource of a given type and pass only those that evaluate to `true` to the builder. The expression is relative to each candidate resource (write `"active = true"`, not `"Patient.active = true"`).
@@ -1628,7 +1686,8 @@ fhirmason-r4/
     │   ├── OperationOutcomeExtensions.kt   # Exception → OperationOutcome helpers
     │   ├── FhirPathHelper.kt               # FhirPath evaluation helpers (internal)
     │   ├── FhirExtensionHelper.kt          # Deep extension retrieval utility
-    │   └── FhirIdentifierHelper.kt         # Identifier filtering helpers (internal)
+    │   ├── FhirIdentifierHelper.kt         # Identifier filtering helpers (internal)
+    │   └── FhirMetaHelper.kt               # meta.tag / meta.security / meta.profile filtering helpers (internal)
     └── test/java/dev/ratkay/operation/r4/
         ├── OperationResultTest.kt
         ├── OperationResultFromTest.kt
@@ -1640,6 +1699,7 @@ fhirmason-r4/
         ├── OperationResultRetryTest.kt
         ├── OperationResultFhirPathTest.kt
         ├── OperationResultIdentifierTest.kt
+        ├── OperationResultMetaTest.kt
         ├── OperationResultComplexTest.kt
         ├── AsyncOperationResultTest.kt
         ├── AsyncOperationResultMetricsTest.kt
@@ -1669,7 +1729,8 @@ fhirmason-dstu3/
     │   ├── OperationOutcomeExtensions.kt   # Exception → OperationOutcome helpers
     │   ├── FhirPathHelper.kt               # FhirPath evaluation helpers (internal)
     │   ├── FhirExtensionHelper.kt          # Deep extension retrieval utility
-    │   └── FhirIdentifierHelper.kt         # Identifier filtering helpers (internal)
+    │   ├── FhirIdentifierHelper.kt         # Identifier filtering helpers (internal)
+    │   └── FhirMetaHelper.kt               # meta.tag / meta.security / meta.profile filtering helpers (internal)
     └── test/java/dev/ratkay/operation/dstu3/
         ├── OperationResultTest.kt
         ├── OperationResultFromTest.kt
@@ -1681,6 +1742,7 @@ fhirmason-dstu3/
         ├── OperationResultRetryTest.kt
         ├── OperationResultFhirPathTest.kt
         ├── OperationResultIdentifierTest.kt
+        ├── OperationResultMetaTest.kt
         ├── OperationResultComplexTest.kt
         ├── AsyncOperationResultTest.kt
         ├── AsyncOperationResultMetricsTest.kt

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirMetaHelper.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirMetaHelper.kt
@@ -1,0 +1,66 @@
+package dev.ratkay.operation.dstu3
+
+import org.hl7.fhir.dstu3.model.Base
+import org.hl7.fhir.dstu3.model.Coding
+import org.hl7.fhir.dstu3.model.Resource
+import kotlin.reflect.KClass
+
+internal fun metaTagsOf(resource: Base): List<Coding> =
+    if (resource is Resource) resource.meta.tag else emptyList()
+
+internal fun metaSecurityOf(resource: Base): List<Coding> =
+    if (resource is Resource) resource.meta.security else emptyList()
+
+internal fun metaProfilesOf(resource: Base): List<String> =
+    if (resource is Resource) resource.meta.profile.map { it.value } else emptyList()
+
+internal fun <I : Base> filterByMetaTagSystem(
+    allValues: List<Base>,
+    type: KClass<I>,
+    system: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> metaTagsOf(resource).any { it.system == system } }
+
+internal fun <I : Base> filterByMetaTagCode(
+    allValues: List<Base>,
+    type: KClass<I>,
+    code: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> metaTagsOf(resource).any { it.code == code } }
+
+internal fun <I : Base> filterByMetaTag(
+    allValues: List<Base>,
+    type: KClass<I>,
+    system: String,
+    code: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> metaTagsOf(resource).any { it.system == system && it.code == code } }
+
+internal fun <I : Base> filterByMetaSecuritySystem(
+    allValues: List<Base>,
+    type: KClass<I>,
+    system: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> metaSecurityOf(resource).any { it.system == system } }
+
+internal fun <I : Base> filterByMetaSecurityCode(
+    allValues: List<Base>,
+    type: KClass<I>,
+    code: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> metaSecurityOf(resource).any { it.code == code } }
+
+internal fun <I : Base> filterByMetaSecurity(
+    allValues: List<Base>,
+    type: KClass<I>,
+    system: String,
+    code: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> metaSecurityOf(resource).any { it.system == system && it.code == code } }
+
+internal fun <I : Base> filterByMetaProfile(
+    allValues: List<Base>,
+    type: KClass<I>,
+    url: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> metaProfilesOf(resource).any { it == url } }

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
@@ -810,6 +810,524 @@ class OperationResult<T> private constructor(
         noinline builder: (List<I>) -> List<R>
     ): OperationResult<List<R>> = addAllFromHavingIdentifier(I::class, system, identifierValue, builder)
 
+    // Builder methods — filter all accumulated parameters by type and meta.tag / meta.security / meta.profile
+
+    private fun <I : Base> collectByMetaTagSystem(type: KClass<I>, system: String): List<I> =
+        filterByMetaTagSystem(parameters.values.flatten(), type, system)
+
+    private fun <I : Base> collectByMetaTagCode(type: KClass<I>, code: String): List<I> =
+        filterByMetaTagCode(parameters.values.flatten(), type, code)
+
+    private fun <I : Base> collectByMetaTag(type: KClass<I>, system: String, code: String): List<I> =
+        filterByMetaTag(parameters.values.flatten(), type, system, code)
+
+    private fun <I : Base> collectByMetaSecuritySystem(type: KClass<I>, system: String): List<I> =
+        filterByMetaSecuritySystem(parameters.values.flatten(), type, system)
+
+    private fun <I : Base> collectByMetaSecurityCode(type: KClass<I>, code: String): List<I> =
+        filterByMetaSecurityCode(parameters.values.flatten(), type, code)
+
+    private fun <I : Base> collectByMetaSecurity(type: KClass<I>, system: String, code: String): List<I> =
+        filterByMetaSecurity(parameters.values.flatten(), type, system, code)
+
+    private fun <I : Base> collectByMetaProfile(type: KClass<I>, url: String): List<I> =
+        filterByMetaProfile(parameters.values.flatten(), type, url)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * `meta.tag` [Coding] whose [Coding.system] equals [system], passes the typed list to [builder],
+     * and stores the single result under the result's fhirType (lowercase).
+     *
+     * Non-resource objects (which carry no `meta`) are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingMetaTagWithSystem] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingMetaTagWithSystem(
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaTagSystem(type, system)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaTagWithSystem] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingMetaTagWithSystem(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaTagSystem(type, system)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaTagWithSystem] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingMetaTagWithSystem(
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaTagSystem(type, system)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingMetaTagWithSystem] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingMetaTagWithSystem(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaTagSystem(type, system)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /** Reified overload of [addFromHavingMetaTagWithSystem] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addFromHavingMetaTagWithSystem(
+        system: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingMetaTagWithSystem(I::class, system, builder)
+
+    /** Reified overload of [addAllFromHavingMetaTagWithSystem] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingMetaTagWithSystem(
+        system: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingMetaTagWithSystem(I::class, system, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * `meta.tag` [Coding] whose [Coding.code] equals [code], passes the typed list to [builder],
+     * and stores the single result under the result's fhirType (lowercase).
+     *
+     * Non-resource objects (which carry no `meta`) are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingMetaTagWithCode] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingMetaTagWithCode(
+        type: KClass<I>,
+        code: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaTagCode(type, code)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaTagWithCode] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingMetaTagWithCode(
+        name: String,
+        type: KClass<I>,
+        code: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaTagCode(type, code)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaTagWithCode] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingMetaTagWithCode(
+        type: KClass<I>,
+        code: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaTagCode(type, code)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingMetaTagWithCode] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingMetaTagWithCode(
+        name: String,
+        type: KClass<I>,
+        code: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaTagCode(type, code)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /** Reified overload of [addFromHavingMetaTagWithCode] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addFromHavingMetaTagWithCode(
+        code: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingMetaTagWithCode(I::class, code, builder)
+
+    /** Reified overload of [addAllFromHavingMetaTagWithCode] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingMetaTagWithCode(
+        code: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingMetaTagWithCode(I::class, code, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * `meta.tag` [Coding] whose [Coding.system] equals [system] **and** [Coding.code] equals [code],
+     * passes the typed list to [builder], and stores the single result under the result's fhirType (lowercase).
+     *
+     * Non-resource objects (which carry no `meta`) are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingMetaTag] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingMetaTag(
+        type: KClass<I>,
+        system: String,
+        code: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaTag(type, system, code)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaTag] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingMetaTag(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        code: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaTag(type, system, code)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaTag] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingMetaTag(
+        type: KClass<I>,
+        system: String,
+        code: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaTag(type, system, code)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingMetaTag] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingMetaTag(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        code: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaTag(type, system, code)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /** Reified overload of [addFromHavingMetaTag] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addFromHavingMetaTag(
+        system: String,
+        code: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingMetaTag(I::class, system, code, builder)
+
+    /** Reified overload of [addAllFromHavingMetaTag] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingMetaTag(
+        system: String,
+        code: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingMetaTag(I::class, system, code, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * `meta.security` [Coding] whose [Coding.system] equals [system], passes the typed list to [builder],
+     * and stores the single result under the result's fhirType (lowercase).
+     *
+     * Non-resource objects (which carry no `meta`) are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingMetaSecurityWithSystem] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingMetaSecurityWithSystem(
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaSecuritySystem(type, system)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaSecurityWithSystem] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingMetaSecurityWithSystem(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaSecuritySystem(type, system)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaSecurityWithSystem] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingMetaSecurityWithSystem(
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaSecuritySystem(type, system)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingMetaSecurityWithSystem] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingMetaSecurityWithSystem(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaSecuritySystem(type, system)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /** Reified overload of [addFromHavingMetaSecurityWithSystem] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addFromHavingMetaSecurityWithSystem(
+        system: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingMetaSecurityWithSystem(I::class, system, builder)
+
+    /** Reified overload of [addAllFromHavingMetaSecurityWithSystem] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingMetaSecurityWithSystem(
+        system: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingMetaSecurityWithSystem(I::class, system, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * `meta.security` [Coding] whose [Coding.code] equals [code], passes the typed list to [builder],
+     * and stores the single result under the result's fhirType (lowercase).
+     *
+     * Non-resource objects (which carry no `meta`) are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingMetaSecurityWithCode] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingMetaSecurityWithCode(
+        type: KClass<I>,
+        code: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaSecurityCode(type, code)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaSecurityWithCode] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingMetaSecurityWithCode(
+        name: String,
+        type: KClass<I>,
+        code: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaSecurityCode(type, code)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaSecurityWithCode] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingMetaSecurityWithCode(
+        type: KClass<I>,
+        code: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaSecurityCode(type, code)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingMetaSecurityWithCode] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingMetaSecurityWithCode(
+        name: String,
+        type: KClass<I>,
+        code: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaSecurityCode(type, code)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /** Reified overload of [addFromHavingMetaSecurityWithCode] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addFromHavingMetaSecurityWithCode(
+        code: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingMetaSecurityWithCode(I::class, code, builder)
+
+    /** Reified overload of [addAllFromHavingMetaSecurityWithCode] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingMetaSecurityWithCode(
+        code: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingMetaSecurityWithCode(I::class, code, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * `meta.security` [Coding] whose [Coding.system] equals [system] **and** [Coding.code] equals [code],
+     * passes the typed list to [builder], and stores the single result under the result's fhirType (lowercase).
+     *
+     * Non-resource objects (which carry no `meta`) are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingMetaSecurity] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingMetaSecurity(
+        type: KClass<I>,
+        system: String,
+        code: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaSecurity(type, system, code)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaSecurity] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingMetaSecurity(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        code: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaSecurity(type, system, code)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaSecurity] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingMetaSecurity(
+        type: KClass<I>,
+        system: String,
+        code: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaSecurity(type, system, code)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingMetaSecurity] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingMetaSecurity(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        code: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaSecurity(type, system, code)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /** Reified overload of [addFromHavingMetaSecurity] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addFromHavingMetaSecurity(
+        system: String,
+        code: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingMetaSecurity(I::class, system, code, builder)
+
+    /** Reified overload of [addAllFromHavingMetaSecurity] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingMetaSecurity(
+        system: String,
+        code: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingMetaSecurity(I::class, system, code, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that declare [url] in their
+     * `meta.profile` list, passes the typed list to [builder], and stores the single result under
+     * the result's fhirType (lowercase).
+     *
+     * Non-resource objects (which carry no `meta`) are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingMetaProfile] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingMetaProfile(
+        type: KClass<I>,
+        url: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaProfile(type, url)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaProfile] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingMetaProfile(
+        name: String,
+        type: KClass<I>,
+        url: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaProfile(type, url)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaProfile] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingMetaProfile(
+        type: KClass<I>,
+        url: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaProfile(type, url)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingMetaProfile] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingMetaProfile(
+        name: String,
+        type: KClass<I>,
+        url: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaProfile(type, url)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /** Reified overload of [addFromHavingMetaProfile] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addFromHavingMetaProfile(
+        url: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingMetaProfile(I::class, url, builder)
+
+    /** Reified overload of [addAllFromHavingMetaProfile] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingMetaProfile(
+        url: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingMetaProfile(I::class, url, builder)
+
     // Builder methods — filter all accumulated parameters by type and FHIRPath expression
 
     private fun <I : Base> collectByPath(type: KClass<I>, expression: String): List<I> =

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultMetaTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultMetaTest.kt
@@ -1,0 +1,527 @@
+package dev.ratkay.operation.dstu3
+
+import dev.ratkay.operation.ErrorStrategy
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.`is`
+import org.hl7.fhir.dstu3.model.OperationOutcome
+import org.hl7.fhir.dstu3.model.Patient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class OperationResultMetaTest {
+
+    // ── addFromHavingMetaTagWithSystem ────────────────────────────────────────
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem returns only resources whose tag system matches`() {
+        val withTag = patientWithTag("http://example.org/tags", "reviewed")
+        val otherSystem = patientWithTag("http://other.org/tags", "reviewed")
+        val result = OperationResult.of(listOf(withTag, otherSystem), "patients")
+            .addFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem with no matches passes empty list to builder`() {
+        val result = OperationResult.of(patientNoMeta(), "patients")
+            .addFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem stores result under fhirType when name is null`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
+            .addFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { _ -> OperationOutcome() }
+
+        assertTrue(result.containsKey("operationoutcome"))
+        assertFalse(result.containsKey("patient"))
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem named overload stores result under explicit key`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
+            .addFromHavingMetaTagWithSystem("tagged", Patient::class, "http://example.org/tags") { _ -> OperationOutcome() }
+
+        assertTrue(result.containsKey("tagged"))
+        assertFalse(result.containsKey("operationoutcome"))
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem reified overload works`() {
+        val withTag = patientWithTag("http://example.org/tags", "x")
+        val result = OperationResult.of(listOf(withTag, patientNoMeta()), "patients")
+            .addFromHavingMetaTagWithSystem<Patient, OperationOutcome>("http://example.org/tags") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem records ERROR outcome when builder throws`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
+            .addFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { _ ->
+                throw RuntimeException("builder failed")
+            }
+
+        assertTrue(result.hasErrors())
+        assertThat(result.getOutcomes().first().issueFirstRep.severity, `is`(OperationOutcome.IssueSeverity.ERROR))
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem respects FAIL_FAST`() {
+        var builderCalled = false
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients", ErrorStrategy.FAIL_FAST)
+            .addFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { _ ->
+                throw RuntimeException("first failure")
+            }
+            .addFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { _ ->
+                builderCalled = true
+                OperationOutcome()
+            }
+
+        assertFalse(builderCalled)
+        assertTrue(result.hasErrors())
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem searches across all parameter keys`() {
+        val a = patientWithTag("http://example.org/tags", "x")
+        val b = patientWithTag("http://example.org/tags", "y")
+        val result = OperationResult.of(a, "group-a")
+            .add("group-b") { b }
+            .addFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=2", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    // ── addAllFromHavingMetaTagWithSystem ─────────────────────────────────────
+
+    @Test
+    fun `addAllFromHavingMetaTagWithSystem returns matching resources as list result`() {
+        val a = patientWithTag("http://example.org/tags", "x")
+        val b = patientWithTag("http://example.org/tags", "y")
+        val other = patientWithTag("http://other.org/tags", "x")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    @Test
+    fun `addAllFromHavingMetaTagWithSystem named overload stores under explicit key`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
+            .addAllFromHavingMetaTagWithSystem("tagged-patients", Patient::class, "http://example.org/tags") { it }
+
+        assertTrue(result.containsKey("tagged-patients"))
+    }
+
+    // ── addFromHavingMetaTagWithCode ──────────────────────────────────────────
+
+    @Test
+    fun `addFromHavingMetaTagWithCode returns only resources whose tag code matches`() {
+        val target = patientWithTag("http://example.org/tags", "reviewed")
+        val other = patientWithTag("http://example.org/tags", "draft")
+        val result = OperationResult.of(listOf(target, other), "patients")
+            .addFromHavingMetaTagWithCode(Patient::class, "reviewed") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithCode named overload stores under explicit key`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "reviewed"), "patients")
+            .addFromHavingMetaTagWithCode("reviewed-result", Patient::class, "reviewed") { _ -> OperationOutcome() }
+
+        assertTrue(result.containsKey("reviewed-result"))
+    }
+
+    @Test
+    fun `addAllFromHavingMetaTagWithCode returns matching resources as list result`() {
+        val a = patientWithTag("http://sys1.org", "reviewed")
+        val b = patientWithTag("http://sys2.org", "reviewed")
+        val other = patientWithTag("http://sys1.org", "draft")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingMetaTagWithCode(Patient::class, "reviewed") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    // ── addFromHavingMetaTag (system + code) ──────────────────────────────────
+
+    @Test
+    fun `addFromHavingMetaTag returns only resources matching both system and code`() {
+        val exact = patientWithTag("http://example.org/tags", "reviewed")
+        val wrongCode = patientWithTag("http://example.org/tags", "draft")
+        val wrongSystem = patientWithTag("http://other.org/tags", "reviewed")
+        val result = OperationResult.of(listOf(exact, wrongCode, wrongSystem), "patients")
+            .addFromHavingMetaTag(Patient::class, "http://example.org/tags", "reviewed") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTag matches if any tag satisfies both fields`() {
+        val multiTag = Patient().apply {
+            meta.addTag().apply { system = "http://other.org/tags"; code = "other" }
+            meta.addTag().apply { system = "http://example.org/tags"; code = "reviewed" }
+        }
+        val result = OperationResult.of(multiTag, "patients")
+            .addFromHavingMetaTag(Patient::class, "http://example.org/tags", "reviewed") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTag named overload stores under explicit key`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "reviewed"), "patients")
+            .addFromHavingMetaTag("matched", Patient::class, "http://example.org/tags", "reviewed") { _ -> OperationOutcome() }
+
+        assertTrue(result.containsKey("matched"))
+        assertFalse(result.containsKey("operationoutcome"))
+    }
+
+    @Test
+    fun `addFromHavingMetaTag reified overload works`() {
+        val exact = patientWithTag("http://example.org/tags", "reviewed")
+        val result = OperationResult.of(listOf(exact, patientNoMeta()), "patients")
+            .addFromHavingMetaTag<Patient, OperationOutcome>("http://example.org/tags", "reviewed") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTag records ERROR outcome when builder throws`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "reviewed"), "patients")
+            .addFromHavingMetaTag(Patient::class, "http://example.org/tags", "reviewed") { _ ->
+                throw RuntimeException("builder failed")
+            }
+
+        assertTrue(result.hasErrors())
+        assertThat(result.getOutcomes().first().issueFirstRep.severity, `is`(OperationOutcome.IssueSeverity.ERROR))
+    }
+
+    @Test
+    fun `addAllFromHavingMetaTag returns matching resources as list result`() {
+        val a = patientWithTag("http://example.org/tags", "reviewed")
+        val b = patientWithTag("http://example.org/tags", "reviewed")
+        val other = patientWithTag("http://example.org/tags", "draft")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingMetaTag(Patient::class, "http://example.org/tags", "reviewed") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    // ── addFromHavingMetaSecurityWithSystem ───────────────────────────────────
+
+    @Test
+    fun `addFromHavingMetaSecurityWithSystem returns only resources whose security system matches`() {
+        val restricted = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val other = patientWithSecurity("http://other.org/security", "R")
+        val result = OperationResult.of(listOf(restricted, other), "patients")
+            .addFromHavingMetaSecurityWithSystem(Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurityWithSystem named overload stores under explicit key`() {
+        val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
+            .addFromHavingMetaSecurityWithSystem("restricted", Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode") { _ -> OperationOutcome() }
+
+        assertTrue(result.containsKey("restricted"))
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurityWithSystem reified overload works`() {
+        val restricted = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val result = OperationResult.of(listOf(restricted, patientNoMeta()), "patients")
+            .addFromHavingMetaSecurityWithSystem<Patient, OperationOutcome>("http://terminology.hl7.org/CodeSystem/v3-ActCode") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addAllFromHavingMetaSecurityWithSystem returns matching resources as list result`() {
+        val a = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val b = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N")
+        val other = patientWithSecurity("http://other.org/security", "R")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingMetaSecurityWithSystem(Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    // ── addFromHavingMetaSecurityWithCode ─────────────────────────────────────
+
+    @Test
+    fun `addFromHavingMetaSecurityWithCode returns only resources whose security code matches`() {
+        val restricted = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val normal = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N")
+        val result = OperationResult.of(listOf(restricted, normal), "patients")
+            .addFromHavingMetaSecurityWithCode(Patient::class, "R") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurityWithCode named overload stores under explicit key`() {
+        val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
+            .addFromHavingMetaSecurityWithCode("restricted-result", Patient::class, "R") { _ -> OperationOutcome() }
+
+        assertTrue(result.containsKey("restricted-result"))
+    }
+
+    @Test
+    fun `addAllFromHavingMetaSecurityWithCode returns matching resources as list result`() {
+        val a = patientWithSecurity("http://sys1.org", "R")
+        val b = patientWithSecurity("http://sys2.org", "R")
+        val other = patientWithSecurity("http://sys1.org", "N")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingMetaSecurityWithCode(Patient::class, "R") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    // ── addFromHavingMetaSecurity (system + code) ─────────────────────────────
+
+    @Test
+    fun `addFromHavingMetaSecurity returns only resources matching both system and code`() {
+        val exact = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val wrongCode = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N")
+        val wrongSystem = patientWithSecurity("http://other.org/security", "R")
+        val result = OperationResult.of(listOf(exact, wrongCode, wrongSystem), "patients")
+            .addFromHavingMetaSecurity(Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode", "R") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurity matches if any security label satisfies both fields`() {
+        val multiSec = Patient().apply {
+            meta.addSecurity().apply { system = "http://other.org/security"; code = "other" }
+            meta.addSecurity().apply { system = "http://terminology.hl7.org/CodeSystem/v3-ActCode"; code = "R" }
+        }
+        val result = OperationResult.of(multiSec, "patients")
+            .addFromHavingMetaSecurity(Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode", "R") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurity named overload stores under explicit key`() {
+        val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
+            .addFromHavingMetaSecurity("restricted", Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode", "R") { _ -> OperationOutcome() }
+
+        assertTrue(result.containsKey("restricted"))
+        assertFalse(result.containsKey("operationoutcome"))
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurity reified overload works`() {
+        val exact = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val result = OperationResult.of(listOf(exact, patientNoMeta()), "patients")
+            .addFromHavingMetaSecurity<Patient, OperationOutcome>("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurity records ERROR outcome when builder throws`() {
+        val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
+            .addFromHavingMetaSecurity(Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode", "R") { _ ->
+                throw RuntimeException("builder failed")
+            }
+
+        assertTrue(result.hasErrors())
+        assertThat(result.getOutcomes().first().issueFirstRep.severity, `is`(OperationOutcome.IssueSeverity.ERROR))
+    }
+
+    @Test
+    fun `addAllFromHavingMetaSecurity returns matching resources as list result`() {
+        val a = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val b = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val other = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingMetaSecurity(Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode", "R") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    // ── addFromHavingMetaProfile ──────────────────────────────────────────────
+
+    @Test
+    fun `addFromHavingMetaProfile returns only resources declaring the given profile URL`() {
+        val conforming = patientWithProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")
+        val other = patientWithProfile("http://example.org/fhir/StructureDefinition/custom-patient")
+        val result = OperationResult.of(listOf(conforming, other), "patients")
+            .addFromHavingMetaProfile(Patient::class, "http://hl7.org/fhir/StructureDefinition/us-core-patient") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile with no matches passes empty list to builder`() {
+        val result = OperationResult.of(patientNoMeta(), "patients")
+            .addFromHavingMetaProfile(Patient::class, "http://hl7.org/fhir/StructureDefinition/us-core-patient") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile stores result under fhirType when name is null`() {
+        val result = OperationResult.of(patientWithProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient"), "patients")
+            .addFromHavingMetaProfile(Patient::class, "http://hl7.org/fhir/StructureDefinition/us-core-patient") { _ -> OperationOutcome() }
+
+        assertTrue(result.containsKey("operationoutcome"))
+        assertFalse(result.containsKey("patient"))
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile named overload stores result under explicit key`() {
+        val result = OperationResult.of(patientWithProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient"), "patients")
+            .addFromHavingMetaProfile("us-core-result", Patient::class, "http://hl7.org/fhir/StructureDefinition/us-core-patient") { _ -> OperationOutcome() }
+
+        assertTrue(result.containsKey("us-core-result"))
+        assertFalse(result.containsKey("operationoutcome"))
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile reified overload works`() {
+        val conforming = patientWithProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")
+        val result = OperationResult.of(listOf(conforming, patientNoMeta()), "patients")
+            .addFromHavingMetaProfile<Patient, OperationOutcome>("http://hl7.org/fhir/StructureDefinition/us-core-patient") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile matches if any profile in list equals url`() {
+        val multiProfile = Patient().apply {
+            meta.addProfile("http://example.org/fhir/StructureDefinition/custom-patient")
+            meta.addProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")
+        }
+        val result = OperationResult.of(multiProfile, "patients")
+            .addFromHavingMetaProfile(Patient::class, "http://hl7.org/fhir/StructureDefinition/us-core-patient") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile records ERROR outcome when builder throws`() {
+        val result = OperationResult.of(patientWithProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient"), "patients")
+            .addFromHavingMetaProfile(Patient::class, "http://hl7.org/fhir/StructureDefinition/us-core-patient") { _ ->
+                throw RuntimeException("builder failed")
+            }
+
+        assertTrue(result.hasErrors())
+        assertThat(result.getOutcomes().first().issueFirstRep.severity, `is`(OperationOutcome.IssueSeverity.ERROR))
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile respects FAIL_FAST`() {
+        var builderCalled = false
+        val url = "http://hl7.org/fhir/StructureDefinition/us-core-patient"
+        val result = OperationResult.of(patientWithProfile(url), "patients", ErrorStrategy.FAIL_FAST)
+            .addFromHavingMetaProfile(Patient::class, url) { _ -> throw RuntimeException("first failure") }
+            .addFromHavingMetaProfile(Patient::class, url) { _ -> builderCalled = true; OperationOutcome() }
+
+        assertFalse(builderCalled)
+        assertTrue(result.hasErrors())
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile searches across all parameter keys`() {
+        val url = "http://hl7.org/fhir/StructureDefinition/us-core-patient"
+        val result = OperationResult.of(patientWithProfile(url), "group-a")
+            .add("group-b") { patientWithProfile(url) }
+            .addFromHavingMetaProfile(Patient::class, url) { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=2", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    // ── addAllFromHavingMetaProfile ───────────────────────────────────────────
+
+    @Test
+    fun `addAllFromHavingMetaProfile returns matching resources as list result`() {
+        val url = "http://hl7.org/fhir/StructureDefinition/us-core-patient"
+        val a = patientWithProfile(url)
+        val b = patientWithProfile(url)
+        val other = patientWithProfile("http://example.org/fhir/StructureDefinition/other")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingMetaProfile(Patient::class, url) { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    @Test
+    fun `addAllFromHavingMetaProfile named overload stores under explicit key`() {
+        val url = "http://hl7.org/fhir/StructureDefinition/us-core-patient"
+        val result = OperationResult.of(patientWithProfile(url), "patients")
+            .addAllFromHavingMetaProfile("us-core-patients", Patient::class, url) { it }
+
+        assertTrue(result.containsKey("us-core-patients"))
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun patientWithTag(system: String, code: String) = Patient().apply {
+        meta.addTag().apply { this.system = system; this.code = code }
+    }
+
+    private fun patientWithSecurity(system: String, code: String) = Patient().apply {
+        meta.addSecurity().apply { this.system = system; this.code = code }
+    }
+
+    private fun patientWithProfile(url: String) = Patient().apply {
+        meta.addProfile(url)
+    }
+
+    private fun patientNoMeta() = Patient().apply {
+        addName().family = "NoMeta"
+    }
+}

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/FhirMetaHelper.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/FhirMetaHelper.kt
@@ -1,0 +1,66 @@
+package dev.ratkay.operation.r4
+
+import org.hl7.fhir.r4.model.Base
+import org.hl7.fhir.r4.model.Coding
+import org.hl7.fhir.r4.model.Resource
+import kotlin.reflect.KClass
+
+internal fun metaTagsOf(resource: Base): List<Coding> =
+    if (resource is Resource) resource.meta.tag else emptyList()
+
+internal fun metaSecurityOf(resource: Base): List<Coding> =
+    if (resource is Resource) resource.meta.security else emptyList()
+
+internal fun metaProfilesOf(resource: Base): List<String> =
+    if (resource is Resource) resource.meta.profile.map { it.value } else emptyList()
+
+internal fun <I : Base> filterByMetaTagSystem(
+    allValues: List<Base>,
+    type: KClass<I>,
+    system: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> metaTagsOf(resource).any { it.system == system } }
+
+internal fun <I : Base> filterByMetaTagCode(
+    allValues: List<Base>,
+    type: KClass<I>,
+    code: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> metaTagsOf(resource).any { it.code == code } }
+
+internal fun <I : Base> filterByMetaTag(
+    allValues: List<Base>,
+    type: KClass<I>,
+    system: String,
+    code: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> metaTagsOf(resource).any { it.system == system && it.code == code } }
+
+internal fun <I : Base> filterByMetaSecuritySystem(
+    allValues: List<Base>,
+    type: KClass<I>,
+    system: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> metaSecurityOf(resource).any { it.system == system } }
+
+internal fun <I : Base> filterByMetaSecurityCode(
+    allValues: List<Base>,
+    type: KClass<I>,
+    code: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> metaSecurityOf(resource).any { it.code == code } }
+
+internal fun <I : Base> filterByMetaSecurity(
+    allValues: List<Base>,
+    type: KClass<I>,
+    system: String,
+    code: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> metaSecurityOf(resource).any { it.system == system && it.code == code } }
+
+internal fun <I : Base> filterByMetaProfile(
+    allValues: List<Base>,
+    type: KClass<I>,
+    url: String
+): List<I> = allValues.filterIsInstance(type.java)
+    .filter { resource -> metaProfilesOf(resource).any { it == url } }

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -811,6 +811,524 @@ class OperationResult<T> private constructor(
         noinline builder: (List<I>) -> List<R>
     ): OperationResult<List<R>> = addAllFromHavingIdentifier(I::class, system, identifierValue, builder)
 
+    // Builder methods — filter all accumulated parameters by type and meta.tag / meta.security / meta.profile
+
+    private fun <I : Base> collectByMetaTagSystem(type: KClass<I>, system: String): List<I> =
+        filterByMetaTagSystem(parameters.values.flatten(), type, system)
+
+    private fun <I : Base> collectByMetaTagCode(type: KClass<I>, code: String): List<I> =
+        filterByMetaTagCode(parameters.values.flatten(), type, code)
+
+    private fun <I : Base> collectByMetaTag(type: KClass<I>, system: String, code: String): List<I> =
+        filterByMetaTag(parameters.values.flatten(), type, system, code)
+
+    private fun <I : Base> collectByMetaSecuritySystem(type: KClass<I>, system: String): List<I> =
+        filterByMetaSecuritySystem(parameters.values.flatten(), type, system)
+
+    private fun <I : Base> collectByMetaSecurityCode(type: KClass<I>, code: String): List<I> =
+        filterByMetaSecurityCode(parameters.values.flatten(), type, code)
+
+    private fun <I : Base> collectByMetaSecurity(type: KClass<I>, system: String, code: String): List<I> =
+        filterByMetaSecurity(parameters.values.flatten(), type, system, code)
+
+    private fun <I : Base> collectByMetaProfile(type: KClass<I>, url: String): List<I> =
+        filterByMetaProfile(parameters.values.flatten(), type, url)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * `meta.tag` [Coding] whose [Coding.system] equals [system], passes the typed list to [builder],
+     * and stores the single result under the result's fhirType (lowercase).
+     *
+     * Non-resource objects (which carry no `meta`) are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingMetaTagWithSystem] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingMetaTagWithSystem(
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaTagSystem(type, system)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaTagWithSystem] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingMetaTagWithSystem(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaTagSystem(type, system)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaTagWithSystem] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingMetaTagWithSystem(
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaTagSystem(type, system)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingMetaTagWithSystem] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingMetaTagWithSystem(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaTagSystem(type, system)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /** Reified overload of [addFromHavingMetaTagWithSystem] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addFromHavingMetaTagWithSystem(
+        system: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingMetaTagWithSystem(I::class, system, builder)
+
+    /** Reified overload of [addAllFromHavingMetaTagWithSystem] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingMetaTagWithSystem(
+        system: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingMetaTagWithSystem(I::class, system, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * `meta.tag` [Coding] whose [Coding.code] equals [code], passes the typed list to [builder],
+     * and stores the single result under the result's fhirType (lowercase).
+     *
+     * Non-resource objects (which carry no `meta`) are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingMetaTagWithCode] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingMetaTagWithCode(
+        type: KClass<I>,
+        code: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaTagCode(type, code)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaTagWithCode] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingMetaTagWithCode(
+        name: String,
+        type: KClass<I>,
+        code: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaTagCode(type, code)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaTagWithCode] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingMetaTagWithCode(
+        type: KClass<I>,
+        code: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaTagCode(type, code)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingMetaTagWithCode] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingMetaTagWithCode(
+        name: String,
+        type: KClass<I>,
+        code: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaTagCode(type, code)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /** Reified overload of [addFromHavingMetaTagWithCode] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addFromHavingMetaTagWithCode(
+        code: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingMetaTagWithCode(I::class, code, builder)
+
+    /** Reified overload of [addAllFromHavingMetaTagWithCode] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingMetaTagWithCode(
+        code: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingMetaTagWithCode(I::class, code, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * `meta.tag` [Coding] whose [Coding.system] equals [system] **and** [Coding.code] equals [code],
+     * passes the typed list to [builder], and stores the single result under the result's fhirType (lowercase).
+     *
+     * Non-resource objects (which carry no `meta`) are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingMetaTag] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingMetaTag(
+        type: KClass<I>,
+        system: String,
+        code: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaTag(type, system, code)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaTag] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingMetaTag(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        code: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaTag(type, system, code)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaTag] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingMetaTag(
+        type: KClass<I>,
+        system: String,
+        code: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaTag(type, system, code)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingMetaTag] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingMetaTag(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        code: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaTag(type, system, code)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /** Reified overload of [addFromHavingMetaTag] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addFromHavingMetaTag(
+        system: String,
+        code: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingMetaTag(I::class, system, code, builder)
+
+    /** Reified overload of [addAllFromHavingMetaTag] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingMetaTag(
+        system: String,
+        code: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingMetaTag(I::class, system, code, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * `meta.security` [Coding] whose [Coding.system] equals [system], passes the typed list to [builder],
+     * and stores the single result under the result's fhirType (lowercase).
+     *
+     * Non-resource objects (which carry no `meta`) are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingMetaSecurityWithSystem] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingMetaSecurityWithSystem(
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaSecuritySystem(type, system)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaSecurityWithSystem] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingMetaSecurityWithSystem(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaSecuritySystem(type, system)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaSecurityWithSystem] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingMetaSecurityWithSystem(
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaSecuritySystem(type, system)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingMetaSecurityWithSystem] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingMetaSecurityWithSystem(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaSecuritySystem(type, system)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /** Reified overload of [addFromHavingMetaSecurityWithSystem] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addFromHavingMetaSecurityWithSystem(
+        system: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingMetaSecurityWithSystem(I::class, system, builder)
+
+    /** Reified overload of [addAllFromHavingMetaSecurityWithSystem] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingMetaSecurityWithSystem(
+        system: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingMetaSecurityWithSystem(I::class, system, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * `meta.security` [Coding] whose [Coding.code] equals [code], passes the typed list to [builder],
+     * and stores the single result under the result's fhirType (lowercase).
+     *
+     * Non-resource objects (which carry no `meta`) are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingMetaSecurityWithCode] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingMetaSecurityWithCode(
+        type: KClass<I>,
+        code: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaSecurityCode(type, code)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaSecurityWithCode] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingMetaSecurityWithCode(
+        name: String,
+        type: KClass<I>,
+        code: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaSecurityCode(type, code)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaSecurityWithCode] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingMetaSecurityWithCode(
+        type: KClass<I>,
+        code: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaSecurityCode(type, code)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingMetaSecurityWithCode] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingMetaSecurityWithCode(
+        name: String,
+        type: KClass<I>,
+        code: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaSecurityCode(type, code)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /** Reified overload of [addFromHavingMetaSecurityWithCode] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addFromHavingMetaSecurityWithCode(
+        code: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingMetaSecurityWithCode(I::class, code, builder)
+
+    /** Reified overload of [addAllFromHavingMetaSecurityWithCode] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingMetaSecurityWithCode(
+        code: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingMetaSecurityWithCode(I::class, code, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that have at least one
+     * `meta.security` [Coding] whose [Coding.system] equals [system] **and** [Coding.code] equals [code],
+     * passes the typed list to [builder], and stores the single result under the result's fhirType (lowercase).
+     *
+     * Non-resource objects (which carry no `meta`) are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingMetaSecurity] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingMetaSecurity(
+        type: KClass<I>,
+        system: String,
+        code: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaSecurity(type, system, code)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaSecurity] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingMetaSecurity(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        code: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaSecurity(type, system, code)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaSecurity] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingMetaSecurity(
+        type: KClass<I>,
+        system: String,
+        code: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaSecurity(type, system, code)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingMetaSecurity] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingMetaSecurity(
+        name: String,
+        type: KClass<I>,
+        system: String,
+        code: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaSecurity(type, system, code)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /** Reified overload of [addFromHavingMetaSecurity] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addFromHavingMetaSecurity(
+        system: String,
+        code: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingMetaSecurity(I::class, system, code, builder)
+
+    /** Reified overload of [addAllFromHavingMetaSecurity] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingMetaSecurity(
+        system: String,
+        code: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingMetaSecurity(I::class, system, code, builder)
+
+    /**
+     * Searches **all** accumulated parameters for instances of [type] that declare [url] in their
+     * `meta.profile` list, passes the typed list to [builder], and stores the single result under
+     * the result's fhirType (lowercase).
+     *
+     * Non-resource objects (which carry no `meta`) are excluded automatically.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     *
+     * Use [addAllFromHavingMetaProfile] when [builder] returns a `List<R>`.
+     */
+    fun <I : Base, R : Base> addFromHavingMetaProfile(
+        type: KClass<I>,
+        url: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(null) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaProfile(type, url)) }
+            storeAndCopy(null, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaProfile] but stores the result under the explicit [name]. */
+    fun <I : Base, R : Base> addFromHavingMetaProfile(
+        name: String,
+        type: KClass<I>,
+        url: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> =
+        runBuilderStep(name) {
+            val (value, duration) = measureTimedValue { builder(collectByMetaProfile(type, url)) }
+            storeAndCopy(name, value, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addFromHavingMetaProfile] but [builder] returns a `List<R>`. */
+    fun <I : Base, R : Base> addAllFromHavingMetaProfile(
+        type: KClass<I>,
+        url: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(null) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaProfile(type, url)) }
+            storeListAndCopy(null, values, duration.inWholeMilliseconds)
+        }
+
+    /** Like [addAllFromHavingMetaProfile] but stores the result list under the explicit [name]. */
+    fun <I : Base, R : Base> addAllFromHavingMetaProfile(
+        name: String,
+        type: KClass<I>,
+        url: String,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> =
+        runBuilderStep(name) {
+            val (values, duration) = measureTimedValue { builder(collectByMetaProfile(type, url)) }
+            storeListAndCopy(name, values, duration.inWholeMilliseconds)
+        }
+
+    /** Reified overload of [addFromHavingMetaProfile] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addFromHavingMetaProfile(
+        url: String,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromHavingMetaProfile(I::class, url, builder)
+
+    /** Reified overload of [addAllFromHavingMetaProfile] (unnamed output key). */
+    inline fun <reified I : Base, R : Base> addAllFromHavingMetaProfile(
+        url: String,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromHavingMetaProfile(I::class, url, builder)
+
     // Builder methods — filter all accumulated parameters by type and FHIRPath expression
 
     private fun <I : Base> collectByPath(type: KClass<I>, expression: String): List<I> =

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultMetaTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultMetaTest.kt
@@ -1,0 +1,722 @@
+package dev.ratkay.operation.r4
+
+import dev.ratkay.operation.ErrorStrategy
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.`is`
+import org.hl7.fhir.r4.model.OperationOutcome
+import org.hl7.fhir.r4.model.Patient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class OperationResultMetaTest {
+
+    // ── addFromHavingMetaTagWithSystem ────────────────────────────────────────
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem returns only resources whose tag system matches`() {
+        val withTag = patientWithTag("http://example.org/tags", "reviewed")
+        val otherSystem = patientWithTag("http://other.org/tags", "reviewed")
+        val result = OperationResult.of(listOf(withTag, otherSystem), "patients")
+            .addFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem with multiple matching resources passes all to builder`() {
+        val a = patientWithTag("http://example.org/tags", "a")
+        val b = patientWithTag("http://example.org/tags", "b")
+        val result = OperationResult.of(listOf(a, b), "patients")
+            .addFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=2", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem with no matches passes empty list to builder`() {
+        val result = OperationResult.of(patientNoMeta(), "patients")
+            .addFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem stores result under fhirType when name is null`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
+            .addFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { _ ->
+                OperationOutcome()
+            }
+
+        assertTrue(result.containsKey("operationoutcome"))
+        assertFalse(result.containsKey("patient"))
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem named overload stores result under explicit key`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
+            .addFromHavingMetaTagWithSystem("tagged", Patient::class, "http://example.org/tags") { _ ->
+                OperationOutcome()
+            }
+
+        assertTrue(result.containsKey("tagged"))
+        assertFalse(result.containsKey("operationoutcome"))
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem reified overload works without KClass argument`() {
+        val withTag = patientWithTag("http://example.org/tags", "x")
+        val result = OperationResult.of(listOf(withTag, patientNoMeta()), "patients")
+            .addFromHavingMetaTagWithSystem<Patient, OperationOutcome>("http://example.org/tags") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem records ERROR outcome when builder throws`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
+            .addFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { _ ->
+                throw RuntimeException("builder failed")
+            }
+
+        assertTrue(result.hasErrors())
+        assertThat(result.getOutcomes().first().issueFirstRep.severity, `is`(OperationOutcome.IssueSeverity.ERROR))
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem respects FAIL_FAST and skips when already errored`() {
+        var builderCalled = false
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients", ErrorStrategy.FAIL_FAST)
+            .addFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { _ ->
+                throw RuntimeException("first failure")
+            }
+            .addFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { _ ->
+                builderCalled = true
+                OperationOutcome()
+            }
+
+        assertFalse(builderCalled)
+        assertTrue(result.hasErrors())
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithSystem searches across all parameter keys`() {
+        val a = patientWithTag("http://example.org/tags", "x")
+        val b = patientWithTag("http://example.org/tags", "y")
+        val result = OperationResult.of(a, "group-a")
+            .add("group-b") { b }
+            .addFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=2", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    // ── addAllFromHavingMetaTagWithSystem ─────────────────────────────────────
+
+    @Test
+    fun `addAllFromHavingMetaTagWithSystem returns matching resources as list result`() {
+        val a = patientWithTag("http://example.org/tags", "x")
+        val b = patientWithTag("http://example.org/tags", "y")
+        val other = patientWithTag("http://other.org/tags", "x")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingMetaTagWithSystem(Patient::class, "http://example.org/tags") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    @Test
+    fun `addAllFromHavingMetaTagWithSystem named overload stores under explicit key`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
+            .addAllFromHavingMetaTagWithSystem("tagged-patients", Patient::class, "http://example.org/tags") { it }
+
+        assertTrue(result.containsKey("tagged-patients"))
+    }
+
+    @Test
+    fun `addAllFromHavingMetaTagWithSystem reified overload works`() {
+        val a = patientWithTag("http://example.org/tags", "x")
+        val result = OperationResult.of(listOf(a, patientNoMeta()), "patients")
+            .addAllFromHavingMetaTagWithSystem<Patient, Patient>("http://example.org/tags") { it }
+
+        assertThat(result.getResult(), hasSize(1))
+    }
+
+    // ── addFromHavingMetaTagWithCode ──────────────────────────────────────────
+
+    @Test
+    fun `addFromHavingMetaTagWithCode returns only resources whose tag code matches`() {
+        val target = patientWithTag("http://example.org/tags", "reviewed")
+        val other = patientWithTag("http://example.org/tags", "draft")
+        val result = OperationResult.of(listOf(target, other), "patients")
+            .addFromHavingMetaTagWithCode(Patient::class, "reviewed") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithCode with no matches passes empty list to builder`() {
+        val result = OperationResult.of(patientNoMeta(), "patients")
+            .addFromHavingMetaTagWithCode(Patient::class, "reviewed") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithCode named overload stores under explicit key`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "reviewed"), "patients")
+            .addFromHavingMetaTagWithCode("reviewed-result", Patient::class, "reviewed") { _ -> OperationOutcome() }
+
+        assertTrue(result.containsKey("reviewed-result"))
+    }
+
+    @Test
+    fun `addFromHavingMetaTagWithCode reified overload works`() {
+        val target = patientWithTag("http://example.org/tags", "reviewed")
+        val result = OperationResult.of(listOf(target, patientNoMeta()), "patients")
+            .addFromHavingMetaTagWithCode<Patient, OperationOutcome>("reviewed") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addAllFromHavingMetaTagWithCode returns matching resources as list result`() {
+        val a = patientWithTag("http://sys1.org", "reviewed")
+        val b = patientWithTag("http://sys2.org", "reviewed")
+        val other = patientWithTag("http://sys1.org", "draft")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingMetaTagWithCode(Patient::class, "reviewed") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    // ── addFromHavingMetaTag (system + code) ──────────────────────────────────
+
+    @Test
+    fun `addFromHavingMetaTag returns only resources matching both system and code`() {
+        val exact = patientWithTag("http://example.org/tags", "reviewed")
+        val wrongCode = patientWithTag("http://example.org/tags", "draft")
+        val wrongSystem = patientWithTag("http://other.org/tags", "reviewed")
+        val result = OperationResult.of(listOf(exact, wrongCode, wrongSystem), "patients")
+            .addFromHavingMetaTag(Patient::class, "http://example.org/tags", "reviewed") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTag does not match when system matches but code does not`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "draft"), "patients")
+            .addFromHavingMetaTag(Patient::class, "http://example.org/tags", "reviewed") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTag does not match when code matches but system does not`() {
+        val result = OperationResult.of(patientWithTag("http://other.org/tags", "reviewed"), "patients")
+            .addFromHavingMetaTag(Patient::class, "http://example.org/tags", "reviewed") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTag matches if any tag on resource satisfies both fields`() {
+        val multiTag = Patient().apply {
+            meta.addTag().apply { system = "http://other.org/tags"; code = "other" }
+            meta.addTag().apply { system = "http://example.org/tags"; code = "reviewed" }
+        }
+        val result = OperationResult.of(multiTag, "patients")
+            .addFromHavingMetaTag(Patient::class, "http://example.org/tags", "reviewed") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTag with no matches passes empty list to builder`() {
+        val result = OperationResult.of(patientNoMeta(), "patients")
+            .addFromHavingMetaTag(Patient::class, "http://example.org/tags", "reviewed") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTag stores result under fhirType when name is null`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "reviewed"), "patients")
+            .addFromHavingMetaTag(Patient::class, "http://example.org/tags", "reviewed") { _ -> OperationOutcome() }
+
+        assertTrue(result.containsKey("operationoutcome"))
+        assertFalse(result.containsKey("patient"))
+    }
+
+    @Test
+    fun `addFromHavingMetaTag named overload stores under explicit key`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "reviewed"), "patients")
+            .addFromHavingMetaTag("matched", Patient::class, "http://example.org/tags", "reviewed") { _ ->
+                OperationOutcome()
+            }
+
+        assertTrue(result.containsKey("matched"))
+        assertFalse(result.containsKey("operationoutcome"))
+    }
+
+    @Test
+    fun `addFromHavingMetaTag reified overload works without KClass argument`() {
+        val exact = patientWithTag("http://example.org/tags", "reviewed")
+        val result = OperationResult.of(listOf(exact, patientNoMeta()), "patients")
+            .addFromHavingMetaTag<Patient, OperationOutcome>("http://example.org/tags", "reviewed") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaTag records ERROR outcome when builder throws`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "reviewed"), "patients")
+            .addFromHavingMetaTag(Patient::class, "http://example.org/tags", "reviewed") { _ ->
+                throw RuntimeException("builder failed")
+            }
+
+        assertTrue(result.hasErrors())
+        assertThat(result.getOutcomes().first().issueFirstRep.severity, `is`(OperationOutcome.IssueSeverity.ERROR))
+    }
+
+    @Test
+    fun `addAllFromHavingMetaTag returns matching resources as list result`() {
+        val a = patientWithTag("http://example.org/tags", "reviewed")
+        val b = patientWithTag("http://example.org/tags", "reviewed")
+        val other = patientWithTag("http://example.org/tags", "draft")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingMetaTag(Patient::class, "http://example.org/tags", "reviewed") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    @Test
+    fun `addAllFromHavingMetaTag named overload stores under explicit key`() {
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "reviewed"), "patients")
+            .addAllFromHavingMetaTag("exact-matches", Patient::class, "http://example.org/tags", "reviewed") { it }
+
+        assertTrue(result.containsKey("exact-matches"))
+    }
+
+    // ── addFromHavingMetaSecurityWithSystem ───────────────────────────────────
+
+    @Test
+    fun `addFromHavingMetaSecurityWithSystem returns only resources whose security system matches`() {
+        val restricted = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val other = patientWithSecurity("http://other.org/security", "R")
+        val result = OperationResult.of(listOf(restricted, other), "patients")
+            .addFromHavingMetaSecurityWithSystem(Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurityWithSystem with no matches passes empty list to builder`() {
+        val result = OperationResult.of(patientNoMeta(), "patients")
+            .addFromHavingMetaSecurityWithSystem(Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurityWithSystem named overload stores under explicit key`() {
+        val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
+            .addFromHavingMetaSecurityWithSystem("restricted", Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode") { _ ->
+                OperationOutcome()
+            }
+
+        assertTrue(result.containsKey("restricted"))
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurityWithSystem reified overload works`() {
+        val restricted = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val result = OperationResult.of(listOf(restricted, patientNoMeta()), "patients")
+            .addFromHavingMetaSecurityWithSystem<Patient, OperationOutcome>("http://terminology.hl7.org/CodeSystem/v3-ActCode") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addAllFromHavingMetaSecurityWithSystem returns matching resources as list result`() {
+        val a = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val b = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N")
+        val other = patientWithSecurity("http://other.org/security", "R")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingMetaSecurityWithSystem(Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    // ── addFromHavingMetaSecurityWithCode ─────────────────────────────────────
+
+    @Test
+    fun `addFromHavingMetaSecurityWithCode returns only resources whose security code matches`() {
+        val restricted = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val normal = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N")
+        val result = OperationResult.of(listOf(restricted, normal), "patients")
+            .addFromHavingMetaSecurityWithCode(Patient::class, "R") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurityWithCode named overload stores under explicit key`() {
+        val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
+            .addFromHavingMetaSecurityWithCode("restricted-result", Patient::class, "R") { _ -> OperationOutcome() }
+
+        assertTrue(result.containsKey("restricted-result"))
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurityWithCode reified overload works`() {
+        val restricted = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val result = OperationResult.of(listOf(restricted, patientNoMeta()), "patients")
+            .addFromHavingMetaSecurityWithCode<Patient, OperationOutcome>("R") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addAllFromHavingMetaSecurityWithCode returns matching resources as list result`() {
+        val a = patientWithSecurity("http://sys1.org", "R")
+        val b = patientWithSecurity("http://sys2.org", "R")
+        val other = patientWithSecurity("http://sys1.org", "N")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingMetaSecurityWithCode(Patient::class, "R") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    // ── addFromHavingMetaSecurity (system + code) ─────────────────────────────
+
+    @Test
+    fun `addFromHavingMetaSecurity returns only resources matching both system and code`() {
+        val exact = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val wrongCode = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N")
+        val wrongSystem = patientWithSecurity("http://other.org/security", "R")
+        val result = OperationResult.of(listOf(exact, wrongCode, wrongSystem), "patients")
+            .addFromHavingMetaSecurity(Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode", "R") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurity does not match when system matches but code does not`() {
+        val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N"), "patients")
+            .addFromHavingMetaSecurity(Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode", "R") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurity matches if any security label on resource satisfies both fields`() {
+        val multiSec = Patient().apply {
+            meta.addSecurity().apply { system = "http://other.org/security"; code = "other" }
+            meta.addSecurity().apply { system = "http://terminology.hl7.org/CodeSystem/v3-ActCode"; code = "R" }
+        }
+        val result = OperationResult.of(multiSec, "patients")
+            .addFromHavingMetaSecurity(Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode", "R") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurity named overload stores under explicit key`() {
+        val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
+            .addFromHavingMetaSecurity("restricted", Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode", "R") { _ ->
+                OperationOutcome()
+            }
+
+        assertTrue(result.containsKey("restricted"))
+        assertFalse(result.containsKey("operationoutcome"))
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurity reified overload works`() {
+        val exact = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val result = OperationResult.of(listOf(exact, patientNoMeta()), "patients")
+            .addFromHavingMetaSecurity<Patient, OperationOutcome>("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaSecurity records ERROR outcome when builder throws`() {
+        val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
+            .addFromHavingMetaSecurity(Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode", "R") { _ ->
+                throw RuntimeException("builder failed")
+            }
+
+        assertTrue(result.hasErrors())
+        assertThat(result.getOutcomes().first().issueFirstRep.severity, `is`(OperationOutcome.IssueSeverity.ERROR))
+    }
+
+    @Test
+    fun `addAllFromHavingMetaSecurity returns matching resources as list result`() {
+        val a = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val b = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
+        val other = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingMetaSecurity(Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode", "R") { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    @Test
+    fun `addAllFromHavingMetaSecurity named overload stores under explicit key`() {
+        val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
+            .addAllFromHavingMetaSecurity("restricted-patients", Patient::class, "http://terminology.hl7.org/CodeSystem/v3-ActCode", "R") { it }
+
+        assertTrue(result.containsKey("restricted-patients"))
+    }
+
+    // ── addFromHavingMetaProfile ──────────────────────────────────────────────
+
+    @Test
+    fun `addFromHavingMetaProfile returns only resources declaring the given profile URL`() {
+        val conforming = patientWithProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")
+        val other = patientWithProfile("http://example.org/fhir/StructureDefinition/custom-patient")
+        val result = OperationResult.of(listOf(conforming, other), "patients")
+            .addFromHavingMetaProfile(Patient::class, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile with multiple matching resources passes all to builder`() {
+        val a = patientWithProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")
+        val b = patientWithProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")
+        val result = OperationResult.of(listOf(a, b), "patients")
+            .addFromHavingMetaProfile(Patient::class, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=2", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile with no matches passes empty list to builder`() {
+        val result = OperationResult.of(patientNoMeta(), "patients")
+            .addFromHavingMetaProfile(Patient::class, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertTrue(result.isSuccessful())
+        assertEquals("count=0", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile stores result under fhirType when name is null`() {
+        val result = OperationResult.of(
+            patientWithProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"), "patients"
+        )
+            .addFromHavingMetaProfile(Patient::class, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient") { _ ->
+                OperationOutcome()
+            }
+
+        assertTrue(result.containsKey("operationoutcome"))
+        assertFalse(result.containsKey("patient"))
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile named overload stores result under explicit key`() {
+        val result = OperationResult.of(
+            patientWithProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"), "patients"
+        )
+            .addFromHavingMetaProfile("us-core-result", Patient::class, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient") { _ ->
+                OperationOutcome()
+            }
+
+        assertTrue(result.containsKey("us-core-result"))
+        assertFalse(result.containsKey("operationoutcome"))
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile reified overload works without KClass argument`() {
+        val conforming = patientWithProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")
+        val result = OperationResult.of(listOf(conforming, patientNoMeta()), "patients")
+            .addFromHavingMetaProfile<Patient, OperationOutcome>("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile matches if any profile in list equals url`() {
+        val multiProfile = Patient().apply {
+            meta.addProfile("http://example.org/fhir/StructureDefinition/custom-patient")
+            meta.addProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")
+        }
+        val result = OperationResult.of(multiProfile, "patients")
+            .addFromHavingMetaProfile(Patient::class, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient") { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=1", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile records ERROR outcome when builder throws`() {
+        val result = OperationResult.of(
+            patientWithProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"), "patients"
+        )
+            .addFromHavingMetaProfile(Patient::class, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient") { _ ->
+                throw RuntimeException("builder failed")
+            }
+
+        assertTrue(result.hasErrors())
+        assertThat(result.getOutcomes().first().issueFirstRep.severity, `is`(OperationOutcome.IssueSeverity.ERROR))
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile respects FAIL_FAST and skips when already errored`() {
+        var builderCalled = false
+        val url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+        val result = OperationResult.of(patientWithProfile(url), "patients", ErrorStrategy.FAIL_FAST)
+            .addFromHavingMetaProfile(Patient::class, url) { _ ->
+                throw RuntimeException("first failure")
+            }
+            .addFromHavingMetaProfile(Patient::class, url) { _ ->
+                builderCalled = true
+                OperationOutcome()
+            }
+
+        assertFalse(builderCalled)
+        assertTrue(result.hasErrors())
+    }
+
+    @Test
+    fun `addFromHavingMetaProfile searches across all parameter keys`() {
+        val url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+        val a = patientWithProfile(url)
+        val b = patientWithProfile(url)
+        val result = OperationResult.of(a, "group-a")
+            .add("group-b") { b }
+            .addFromHavingMetaProfile(Patient::class, url) { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+
+        assertEquals("count=2", result.getResult().issueFirstRep.diagnostics)
+    }
+
+    // ── addAllFromHavingMetaProfile ───────────────────────────────────────────
+
+    @Test
+    fun `addAllFromHavingMetaProfile returns matching resources as list result`() {
+        val url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+        val a = patientWithProfile(url)
+        val b = patientWithProfile(url)
+        val other = patientWithProfile("http://example.org/fhir/StructureDefinition/other")
+        val result = OperationResult.of(listOf(a, b, other), "patients")
+            .addAllFromHavingMetaProfile(Patient::class, url) { it }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    @Test
+    fun `addAllFromHavingMetaProfile named overload stores under explicit key`() {
+        val url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+        val result = OperationResult.of(patientWithProfile(url), "patients")
+            .addAllFromHavingMetaProfile("us-core-patients", Patient::class, url) { it }
+
+        assertTrue(result.containsKey("us-core-patients"))
+    }
+
+    @Test
+    fun `addAllFromHavingMetaProfile reified overload works`() {
+        val url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+        val result = OperationResult.of(listOf(patientWithProfile(url), patientNoMeta()), "patients")
+            .addAllFromHavingMetaProfile<Patient, Patient>(url) { it }
+
+        assertThat(result.getResult(), hasSize(1))
+    }
+
+    // ── Cross-cutting ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `meta filter methods compose with subsequent pipeline steps`() {
+        val url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+        val result = OperationResult.of(listOf(patientWithProfile(url), patientNoMeta()), "patients")
+            .addFromHavingMetaProfile(Patient::class, url) { filtered ->
+                OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
+            }
+            .add("flag") { org.hl7.fhir.r4.model.StringType("done") }
+
+        assertTrue(result.isSuccessful())
+        assertTrue(result.containsKey("flag"))
+        assertTrue(result.containsKey("operationoutcome"))
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun patientWithTag(system: String, code: String) = Patient().apply {
+        meta.addTag().apply { this.system = system; this.code = code }
+    }
+
+    private fun patientWithSecurity(system: String, code: String) = Patient().apply {
+        meta.addSecurity().apply { this.system = system; this.code = code }
+    }
+
+    private fun patientWithProfile(url: String) = Patient().apply {
+        meta.addProfile(url)
+    }
+
+    private fun patientNoMeta() = Patient().apply {
+        addName().family = "NoMeta"
+    }
+}


### PR DESCRIPTION
Adds 42 new filtering overloads to OperationResult in both R4 and DSTU3.
Like identifier filtering, these operate on fields universal to every FHIR
resource via Resource.meta, making them broadly applicable without coupling
to specific resource types.

New methods:
- addFromHavingMetaTagWithSystem / WithCode / plain (+ addAll, named, reified)
- addFromHavingMetaSecurityWithSystem / WithCode / plain (+ addAll, named, reified)
- addFromHavingMetaProfile (+ addAll, named, reified)

New files: FhirMetaHelper.kt (internal helpers), OperationResultMetaTest.kt
in both R4 and DSTU3 modules.