### PR TITLE
Add FhirPath fluent expression builder to fhirmason-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1387,17 +1387,16 @@ val result = OperationResult.of(patient)
 |----------|---------|
 | Navigation | `navigate`, `union` |
 | Subsetting | `where`, `select` |
-| Collection | `first`, `last`, `tail`, `take`, `skip`, `count`, `empty`, `exists`, `all`, `allTrue`, `anyTrue`, `allFalse`, `anyFalse`, `distinct`, `isDistinct`, `subsetOf`, `supersetOf`, `children`, `descendants` |
+| Collection | `first`, `last`, `tail`, `take`, `skip`, `count`, `empty`, `exists`, `all`, `allTrue`¹, `anyTrue`¹, `allFalse`¹, `anyFalse`¹, `distinct`, `isDistinct`, `supersetOf`, `children`, `descendants` |
 | Boolean | `not`, `and`, `or`, `xor`, `implies` |
-| Equality / comparison | `eq`, `ne`, `lt`, `gt`, `le`, `ge`, `equiv`, `notEquiv`, `memberOf`, `containsValue` |
-| Type | `isType`, `asType` |
-| String | `length`, `upper`, `lower`, `trim`, `startsWith`, `endsWith`, `contains`, `matches`, `indexOf`, `substring`, `replace`, `replaceMatches`, `split`, `join` |
-| Math | `abs`, `ceiling`, `floor`, `round`, `sqrt`, `power`, `truncate` |
+| Equality / comparison | `eq`, `ne`, `lt`, `gt`, `le`, `ge`, `equiv`, `notEquiv`, `containsValue` |
+| String | `length`, `upper`¹, `lower`¹, `trim`¹, `startsWith`, `endsWith`, `contains`, `matches`, `indexOf`¹, `substring`, `replace`, `replaceMatches`¹, `split`¹, `join`¹ |
+| Math | `abs`¹, `ceiling`¹, `floor`¹, `round`¹, `sqrt`¹, `power`¹, `truncate`¹ |
 | Arithmetic | `plus`, `minus`, `times`, `dividedBy`, `div`, `mod`, `concat` |
-| Type conversion | `toBoolean`, `toInteger`, `toDecimal`, `toDate`, `toDateTime`, `toTime`, `toQuantity` |
+| Type conversion | `toBoolean`¹, `toInteger`¹, `toDecimal`, `toQuantity`¹ |
 | FHIR-specific | `extension`, `resolve` |
 
-`is` and `as` are Kotlin keywords and are exposed as `isType` / `asType`. Similarly, `in` is exposed as `memberOf`.
+¹ **R4 only.** These methods use FHIRPath 2.0 functions or math/type-conversion functions that are not registered in HAPI's DSTU3 FHIRPath 1.0 engine. They produce valid expression strings but will throw an exception when evaluated against a DSTU3 resource.
 
 **String auto-quoting.** Methods whose FHIRPath parameter is always a string literal (`startsWith`, `endsWith`, `contains`, `matches`, `indexOf`, `replace`, `replaceMatches`, `split`, `join`, `extension`) automatically wrap the argument in single quotes. Pass the plain string — no embedded quotes needed:
 ```kotlin
@@ -1412,7 +1411,6 @@ val result = OperationResult.of(patient)
 .eq(18)           // → = 18
 .lt(65.5)         // → < 65.5
 ```
-`memberOf` takes a raw FHIRPath expression (collection path or set name) and is never quoted.
 
 ### Java usage
 

--- a/README.md
+++ b/README.md
@@ -1353,23 +1353,23 @@ HAPI FHIR provides no API for constructing FHIRPath expressions programmatically
 // Absolute path
 val path = FhirPath.from("Patient")
     .navigate("name")
-    .where(FhirPath.relative().navigate("use").eq("'official'"))
+    .where(FhirPath.relative().navigate("use").eq("official"))
     .navigate("given")
     .first()
     .build()
 // → "Patient.name.where(use = 'official').given.first()"
 
 // Compose conditions with boolean operators
-val condition = FhirPath.from("active").eq("true")
+val condition = FhirPath.from("active").eq(true)
     .and(FhirPath.from("name").exists())
     .build()
 // → "(active = true) and (name.exists())"
 
 // Use with existing OperationResult FHIRPath methods
 val result = OperationResult.of(patient)
-    .guardPath(FhirPath.from("active").eq("true").build(), "Patient must be active")
+    .guardPath(FhirPath.from("active").eq(true).build(), "Patient must be active")
     .selectByPath<HumanName>(
-        FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("'official'")).first().build(),
+        FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("official")).first().build(),
         "official-name"
     )
 ```
@@ -1399,17 +1399,32 @@ val result = OperationResult.of(patient)
 
 `is` and `as` are Kotlin keywords and are exposed as `isType` / `asType`. Similarly, `in` is exposed as `memberOf`.
 
+**String auto-quoting.** Methods whose FHIRPath parameter is always a string literal (`startsWith`, `endsWith`, `contains`, `matches`, `indexOf`, `replace`, `replaceMatches`, `split`, `join`, `extension`, `hasExtension`) automatically wrap the argument in single quotes. Pass the plain string — no embedded quotes needed:
+```kotlin
+.startsWith("Sm")   // → .startsWith('Sm')
+.extension("http://example.org/ext")  // → .extension('http://example.org/ext')
+```
+
+**Typed comparison overloads.** `eq`, `ne`, `lt`, `gt`, `le`, `ge`, `equiv`, `notEquiv`, and `containsValue` provide overloads for `String` (auto-quoted), `Int`, `Double`, and (for `eq`/`ne`) `Boolean`:
+```kotlin
+.eq("official")   // → = 'official'
+.eq(true)         // → = true
+.eq(18)           // → = 18
+.lt(65.5)         // → < 65.5
+```
+`memberOf` takes a raw FHIRPath expression (collection path or set name) and is never quoted.
+
 ### Java usage
 
 ```java
 String path = FhirPath.from("Patient")
     .navigate("name")
-    .where(FhirPath.relative().navigate("use").eq("'official'"))
+    .where(FhirPath.relative().navigate("use").eq("official"))
     .navigate("given")
     .first()
     .build();
 
-result.guardPath(FhirPath.from("active").eq("true").build(), "Patient must be active");
+result.guardPath(FhirPath.from("active").eq(true).build(), "Patient must be active");
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -1386,7 +1386,7 @@ val result = OperationResult.of(patient)
 | Category | Methods |
 |----------|---------|
 | Navigation | `navigate`, `union` |
-| Subsetting | `where`, `select`, `ofType` |
+| Subsetting | `where`, `select` |
 | Collection | `first`, `last`, `tail`, `take`, `skip`, `count`, `empty`, `exists`, `all`, `allTrue`, `anyTrue`, `allFalse`, `anyFalse`, `distinct`, `isDistinct`, `subsetOf`, `supersetOf`, `children`, `descendants` |
 | Boolean | `not`, `and`, `or`, `xor`, `implies` |
 | Equality / comparison | `eq`, `ne`, `lt`, `gt`, `le`, `ge`, `equiv`, `notEquiv`, `memberOf`, `containsValue` |

--- a/README.md
+++ b/README.md
@@ -1343,6 +1343,77 @@ val result = AsyncOperationResult()
 
 ---
 
+## FhirPath Expression Builder
+
+`FhirPath` (in `fhirmason-api`, package `dev.ratkay.operation`) is a fluent, immutable builder for constructing FHIRPath expression strings. It is version-agnostic — the same class is shared by both R4 and DSTU3.
+
+HAPI FHIR provides no API for constructing FHIRPath expressions programmatically. `FhirPath` fills that gap: each step returns a new `FhirPath` instance and the final expression string is retrieved via `build()` (or `toString()`).
+
+```kotlin
+// Absolute path
+val path = FhirPath.from("Patient")
+    .navigate("name")
+    .where(FhirPath.relative().navigate("use").eq("'official'"))
+    .navigate("given")
+    .first()
+    .build()
+// → "Patient.name.where(use = 'official').given.first()"
+
+// Compose conditions with boolean operators
+val condition = FhirPath.from("active").eq("true")
+    .and(FhirPath.from("name").exists())
+    .build()
+// → "(active = true) and (name.exists())"
+
+// Use with existing OperationResult FHIRPath methods
+val result = OperationResult.of(patient)
+    .guardPath(FhirPath.from("active").eq("true").build(), "Patient must be active")
+    .selectByPath<HumanName>(
+        FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("'official'")).first().build(),
+        "official-name"
+    )
+```
+
+### Factory methods
+
+| Method | Description |
+|--------|-------------|
+| `FhirPath.from(segment)` | Start from a named root segment (resource type or first field) |
+| `FhirPath.relative()` | Start with an empty base for condition/predicate expressions used inside `where`, `all`, `exists` |
+
+### Available operations
+
+| Category | Methods |
+|----------|---------|
+| Navigation | `navigate`, `union` |
+| Subsetting | `where`, `select`, `ofType` |
+| Collection | `first`, `last`, `tail`, `take`, `skip`, `count`, `empty`, `exists`, `all`, `allTrue`, `anyTrue`, `allFalse`, `anyFalse`, `distinct`, `isDistinct`, `subsetOf`, `supersetOf`, `children`, `descendants` |
+| Boolean | `not`, `and`, `or`, `xor`, `implies` |
+| Equality / comparison | `eq`, `ne`, `lt`, `gt`, `le`, `ge`, `equiv`, `notEquiv`, `memberOf`, `containsValue` |
+| Type | `isType`, `asType` |
+| String | `length`, `upper`, `lower`, `trim`, `startsWith`, `endsWith`, `contains`, `matches`, `indexOf`, `substring`, `replace`, `replaceMatches`, `split`, `join` |
+| Math | `abs`, `ceiling`, `floor`, `round`, `sqrt`, `power`, `truncate` |
+| Arithmetic | `plus`, `minus`, `times`, `dividedBy`, `div`, `mod`, `concat` |
+| Type conversion | `toBoolean`, `toInteger`, `toDecimal`, `toDate`, `toDateTime`, `toTime`, `toQuantity` |
+| FHIR-specific | `extension`, `hasExtension`, `resolve` |
+
+`is` and `as` are Kotlin keywords and are exposed as `isType` / `asType`. Similarly, `in` is exposed as `memberOf`.
+
+### Java usage
+
+```java
+String path = FhirPath.from("Patient")
+    .navigate("name")
+    .where(FhirPath.relative().navigate("use").eq("'official'"))
+    .navigate("given")
+    .first()
+    .build();
+
+result.guardPath(FhirPath.from("active").eq("true").build(), "Patient must be active");
+```
+
+---
+
 ## Usage Examples
 
 ### 1. Simple accumulation
@@ -1576,11 +1647,14 @@ mvn clean install       # build, test, and install to local repo
 
 ```
 fhirmason-api/
-└── src/main/java/dev/ratkay/operation/
-    ├── IOperationResult.kt             # Version-agnostic interface (R4 + DSTU3 both implement)
-    ├── ErrorStrategy.kt                # FAIL_FAST / ACCUMULATE enum
-    ├── StepMetrics.kt                  # Per-step timing and outcome data
-    └── DateTimeInput.kt                # Sealed wrapper for date/time values (collapses overloads)
+├── src/main/java/dev/ratkay/operation/
+│   ├── IOperationResult.kt             # Version-agnostic interface (R4 + DSTU3 both implement)
+│   ├── ErrorStrategy.kt                # FAIL_FAST / ACCUMULATE enum
+│   ├── StepMetrics.kt                  # Per-step timing and outcome data
+│   ├── DateTimeInput.kt                # Sealed wrapper for date/time values (collapses overloads)
+│   └── FhirPath.kt                     # Fluent FHIRPath expression builder (version-agnostic)
+└── src/test/java/dev/ratkay/operation/
+    └── FhirPathTest.kt
 
 fhirmason-r4/
 └── src/

--- a/README.md
+++ b/README.md
@@ -1395,11 +1395,11 @@ val result = OperationResult.of(patient)
 | Math | `abs`, `ceiling`, `floor`, `round`, `sqrt`, `power`, `truncate` |
 | Arithmetic | `plus`, `minus`, `times`, `dividedBy`, `div`, `mod`, `concat` |
 | Type conversion | `toBoolean`, `toInteger`, `toDecimal`, `toDate`, `toDateTime`, `toTime`, `toQuantity` |
-| FHIR-specific | `extension`, `hasExtension`, `resolve` |
+| FHIR-specific | `extension`, `resolve` |
 
 `is` and `as` are Kotlin keywords and are exposed as `isType` / `asType`. Similarly, `in` is exposed as `memberOf`.
 
-**String auto-quoting.** Methods whose FHIRPath parameter is always a string literal (`startsWith`, `endsWith`, `contains`, `matches`, `indexOf`, `replace`, `replaceMatches`, `split`, `join`, `extension`, `hasExtension`) automatically wrap the argument in single quotes. Pass the plain string — no embedded quotes needed:
+**String auto-quoting.** Methods whose FHIRPath parameter is always a string literal (`startsWith`, `endsWith`, `contains`, `matches`, `indexOf`, `replace`, `replaceMatches`, `split`, `join`, `extension`) automatically wrap the argument in single quotes. Pass the plain string — no embedded quotes needed:
 ```kotlin
 .startsWith("Sm")   // → .startsWith('Sm')
 .extension("http://example.org/ext")  // → .extension('http://example.org/ext')

--- a/README.md
+++ b/README.md
@@ -1681,6 +1681,7 @@ fhirmason-r4/
         ├── OperationResultFhirErrorHandlingTest.kt
         ├── OperationResultRetryTest.kt
         ├── OperationResultFhirPathTest.kt
+        ├── FhirPathEvaluationTest.kt
         ├── OperationResultIdentifierTest.kt
         ├── OperationResultMetaTest.kt
         ├── OperationResultComplexTest.kt
@@ -1726,6 +1727,7 @@ fhirmason-dstu3/
         ├── OperationResultFhirErrorHandlingTest.kt
         ├── OperationResultRetryTest.kt
         ├── OperationResultFhirPathTest.kt
+        ├── FhirPathEvaluationTest.kt
         ├── OperationResultIdentifierTest.kt
         ├── OperationResultMetaTest.kt
         ├── OperationResultComplexTest.kt

--- a/fhirmason-api/pom.xml
+++ b/fhirmason-api/pom.xml
@@ -25,6 +25,22 @@
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-base</artifactId>
         </dependency>
+        <!-- Test -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/fhirmason-api/src/main/java/dev/ratkay/operation/FhirPath.kt
+++ b/fhirmason-api/src/main/java/dev/ratkay/operation/FhirPath.kt
@@ -15,13 +15,13 @@ package dev.ratkay.operation
  * // Absolute path
  * val path = FhirPath.from("Patient")
  *     .navigate("name")
- *     .where(FhirPath.relative().navigate("use").eq("'official'"))
+ *     .where(FhirPath.relative().navigate("use").eq("official"))
  *     .first()
  *     .build()
  * // → "Patient.name.where(use = 'official').first()"
  *
  * // Relative condition for use inside where()
- * val isActive = FhirPath.relative().navigate("active").eq("true")
+ * val isActive = FhirPath.relative().navigate("active").eq(true)
  * result.whenPath(isActive.build()) { ... }
  * ```
  *
@@ -29,7 +29,7 @@ package dev.ratkay.operation
  * ```java
  * String path = FhirPath.from("Patient")
  *     .navigate("name")
- *     .where(FhirPath.relative().navigate("use").eq("'official'"))
+ *     .where(FhirPath.relative().navigate("use").eq("official"))
  *     .first()
  *     .build();
  * ```
@@ -110,25 +110,52 @@ class FhirPath private constructor(private val expr: String) {
     fun implies(other: String): FhirPath = FhirPath("($expr) implies ($other)")
 
     // ── Equality / comparison operators ──────────────────────────────────────
+    //
+    // String overloads auto-quote: eq("official") → = 'official'
+    // Typed overloads emit the literal directly: eq(true) → = true, eq(18) → = 18
 
-    fun eq(value: String): FhirPath = FhirPath("$expr = $value")
-    fun ne(value: String): FhirPath = FhirPath("$expr != $value")
-    fun lt(value: String): FhirPath = FhirPath("$expr < $value")
-    fun gt(value: String): FhirPath = FhirPath("$expr > $value")
-    fun le(value: String): FhirPath = FhirPath("$expr <= $value")
-    fun ge(value: String): FhirPath = FhirPath("$expr >= $value")
+    fun eq(value: String): FhirPath = FhirPath("$expr = '$value'")
+    fun eq(value: Int): FhirPath = FhirPath("$expr = $value")
+    fun eq(value: Double): FhirPath = FhirPath("$expr = $value")
+    fun eq(value: Boolean): FhirPath = FhirPath("$expr = $value")
+
+    fun ne(value: String): FhirPath = FhirPath("$expr != '$value'")
+    fun ne(value: Int): FhirPath = FhirPath("$expr != $value")
+    fun ne(value: Double): FhirPath = FhirPath("$expr != $value")
+    fun ne(value: Boolean): FhirPath = FhirPath("$expr != $value")
+
+    fun lt(value: String): FhirPath = FhirPath("$expr < '$value'")
+    fun lt(value: Int): FhirPath = FhirPath("$expr < $value")
+    fun lt(value: Double): FhirPath = FhirPath("$expr < $value")
+
+    fun gt(value: String): FhirPath = FhirPath("$expr > '$value'")
+    fun gt(value: Int): FhirPath = FhirPath("$expr > $value")
+    fun gt(value: Double): FhirPath = FhirPath("$expr > $value")
+
+    fun le(value: String): FhirPath = FhirPath("$expr <= '$value'")
+    fun le(value: Int): FhirPath = FhirPath("$expr <= $value")
+    fun le(value: Double): FhirPath = FhirPath("$expr <= $value")
+
+    fun ge(value: String): FhirPath = FhirPath("$expr >= '$value'")
+    fun ge(value: Int): FhirPath = FhirPath("$expr >= $value")
+    fun ge(value: Double): FhirPath = FhirPath("$expr >= $value")
 
     /** FHIRPath equivalence (`~`): matches regardless of insignificant whitespace, case, etc. */
-    fun equiv(value: String): FhirPath = FhirPath("$expr ~ $value")
+    fun equiv(value: String): FhirPath = FhirPath("$expr ~ '$value'")
+    fun equiv(value: Int): FhirPath = FhirPath("$expr ~ $value")
+    fun equiv(value: Double): FhirPath = FhirPath("$expr ~ $value")
 
     /** FHIRPath non-equivalence (`!~`). */
-    fun notEquiv(value: String): FhirPath = FhirPath("$expr !~ $value")
+    fun notEquiv(value: String): FhirPath = FhirPath("$expr !~ '$value'")
+    fun notEquiv(value: Int): FhirPath = FhirPath("$expr !~ $value")
+    fun notEquiv(value: Double): FhirPath = FhirPath("$expr !~ $value")
 
-    /** FHIRPath `in` membership: `expr in collection`. (`in` is a Kotlin keyword, so this is named `memberOf`.) */
+    /** FHIRPath `in` membership: `expr in collection`. (`in` is a Kotlin keyword, so this is named `memberOf`.)
+     *  [collection] is a FHIRPath expression (path or set name) — not auto-quoted. */
     fun memberOf(collection: String): FhirPath = FhirPath("$expr in $collection")
 
-    /** FHIRPath `contains` membership: `expr contains value`. */
-    fun containsValue(value: String): FhirPath = FhirPath("$expr contains $value")
+    /** FHIRPath `contains` membership: `expr contains value`. [value] is auto-quoted as a string literal. */
+    fun containsValue(value: String): FhirPath = FhirPath("$expr contains '$value'")
 
     // ── Type functions ────────────────────────────────────────────────────────
 
@@ -139,22 +166,24 @@ class FhirPath private constructor(private val expr: String) {
     fun asType(type: String): FhirPath = FhirPath("$expr.as($type)")
 
     // ── String functions ──────────────────────────────────────────────────────
+    //
+    // All string-parameter functions auto-quote: startsWith("Sm") → .startsWith('Sm')
 
     fun length(): FhirPath = FhirPath("$expr.length()")
     fun upper(): FhirPath = FhirPath("$expr.upper()")
     fun lower(): FhirPath = FhirPath("$expr.lower()")
     fun trim(): FhirPath = FhirPath("$expr.trim()")
-    fun startsWith(prefix: String): FhirPath = FhirPath("$expr.startsWith($prefix)")
-    fun endsWith(suffix: String): FhirPath = FhirPath("$expr.endsWith($suffix)")
-    fun contains(substring: String): FhirPath = FhirPath("$expr.contains($substring)")
-    fun matches(regex: String): FhirPath = FhirPath("$expr.matches($regex)")
-    fun indexOf(substring: String): FhirPath = FhirPath("$expr.indexOf($substring)")
+    fun startsWith(prefix: String): FhirPath = FhirPath("$expr.startsWith('$prefix')")
+    fun endsWith(suffix: String): FhirPath = FhirPath("$expr.endsWith('$suffix')")
+    fun contains(substring: String): FhirPath = FhirPath("$expr.contains('$substring')")
+    fun matches(regex: String): FhirPath = FhirPath("$expr.matches('$regex')")
+    fun indexOf(substring: String): FhirPath = FhirPath("$expr.indexOf('$substring')")
     fun substring(start: Int): FhirPath = FhirPath("$expr.substring($start)")
     fun substring(start: Int, length: Int): FhirPath = FhirPath("$expr.substring($start, $length)")
-    fun replace(pattern: String, substitution: String): FhirPath = FhirPath("$expr.replace($pattern, $substitution)")
-    fun replaceMatches(regex: String, substitution: String): FhirPath = FhirPath("$expr.replaceMatches($regex, $substitution)")
-    fun split(separator: String): FhirPath = FhirPath("$expr.split($separator)")
-    fun join(separator: String): FhirPath = FhirPath("$expr.join($separator)")
+    fun replace(pattern: String, substitution: String): FhirPath = FhirPath("$expr.replace('$pattern', '$substitution')")
+    fun replaceMatches(regex: String, substitution: String): FhirPath = FhirPath("$expr.replaceMatches('$regex', '$substitution')")
+    fun split(separator: String): FhirPath = FhirPath("$expr.split('$separator')")
+    fun join(separator: String): FhirPath = FhirPath("$expr.join('$separator')")
 
     // ── Math functions ────────────────────────────────────────────────────────
 

--- a/fhirmason-api/src/main/java/dev/ratkay/operation/FhirPath.kt
+++ b/fhirmason-api/src/main/java/dev/ratkay/operation/FhirPath.kt
@@ -1,0 +1,209 @@
+package dev.ratkay.operation
+
+/**
+ * Fluent, immutable builder for FHIRPath expressions.
+ *
+ * Each step returns a new [FhirPath] instance; the accumulated expression string is retrieved
+ * via [build] (or [toString]).
+ *
+ * ### Factory methods
+ * - [FhirPath.from] — start from a named root segment (resource type or first field)
+ * - [FhirPath.relative] — start with an empty base for condition/predicate expressions
+ *
+ * ### Kotlin usage
+ * ```kotlin
+ * // Absolute path
+ * val path = FhirPath.from("Patient")
+ *     .navigate("name")
+ *     .where(FhirPath.relative().navigate("use").eq("'official'"))
+ *     .first()
+ *     .build()
+ * // → "Patient.name.where(use = 'official').first()"
+ *
+ * // Relative condition for use inside where()
+ * val isActive = FhirPath.relative().navigate("active").eq("true")
+ * result.whenPath(isActive.build()) { ... }
+ * ```
+ *
+ * ### Java usage
+ * ```java
+ * String path = FhirPath.from("Patient")
+ *     .navigate("name")
+ *     .where(FhirPath.relative().navigate("use").eq("'official'"))
+ *     .first()
+ *     .build();
+ * ```
+ */
+class FhirPath private constructor(private val expr: String) {
+
+    companion object {
+        /** Starts a new expression rooted at [segment] (e.g. `"Patient"` or `"name"`). */
+        @JvmStatic
+        fun from(segment: String): FhirPath = FhirPath(segment)
+
+        /** Starts an empty expression — use this to build condition strings for [where], [all], [exists], etc. */
+        @JvmStatic
+        fun relative(): FhirPath = FhirPath("")
+    }
+
+    // ── Navigation ────────────────────────────────────────────────────────────
+
+    /** Appends a navigation step: `expr.segment`. Handles an empty base from [relative] correctly. */
+    fun navigate(segment: String): FhirPath =
+        if (expr.isEmpty()) FhirPath(segment) else FhirPath("$expr.$segment")
+
+    /** Produces a union of this expression and [other]: `expr | other`. */
+    fun union(other: FhirPath): FhirPath = FhirPath("$expr | ${other.build()}")
+
+    /** Produces a union of this expression and the raw [other] string: `expr | other`. */
+    fun union(other: String): FhirPath = FhirPath("$expr | $other")
+
+    // ── Subsetting / filtering ────────────────────────────────────────────────
+
+    /** Appends a `where` filter with a raw condition string: `expr.where(condition)`. */
+    fun where(condition: String): FhirPath = FhirPath("$expr.where($condition)")
+
+    /** Appends a `where` filter with a [FhirPath] condition: `expr.where(condition)`. */
+    fun where(condition: FhirPath): FhirPath = FhirPath("$expr.where(${condition.build()})")
+
+    /** Appends a `select` projection: `expr.select(projection)`. */
+    fun select(projection: String): FhirPath = FhirPath("$expr.select($projection)")
+
+    /** Appends an `ofType` type filter: `expr.ofType(type)`. */
+    fun ofType(type: String): FhirPath = FhirPath("$expr.ofType($type)")
+
+    // ── Collection functions ──────────────────────────────────────────────────
+
+    fun first(): FhirPath = FhirPath("$expr.first()")
+    fun last(): FhirPath = FhirPath("$expr.last()")
+    fun tail(): FhirPath = FhirPath("$expr.tail()")
+    fun take(n: Int): FhirPath = FhirPath("$expr.take($n)")
+    fun skip(n: Int): FhirPath = FhirPath("$expr.skip($n)")
+    fun count(): FhirPath = FhirPath("$expr.count()")
+    fun empty(): FhirPath = FhirPath("$expr.empty()")
+    fun exists(): FhirPath = FhirPath("$expr.exists()")
+    fun exists(criteria: String): FhirPath = FhirPath("$expr.exists($criteria)")
+    fun exists(criteria: FhirPath): FhirPath = FhirPath("$expr.exists(${criteria.build()})")
+    fun all(criteria: String): FhirPath = FhirPath("$expr.all($criteria)")
+    fun all(criteria: FhirPath): FhirPath = FhirPath("$expr.all(${criteria.build()})")
+    fun allTrue(): FhirPath = FhirPath("$expr.allTrue()")
+    fun anyTrue(): FhirPath = FhirPath("$expr.anyTrue()")
+    fun allFalse(): FhirPath = FhirPath("$expr.allFalse()")
+    fun anyFalse(): FhirPath = FhirPath("$expr.anyFalse()")
+    fun distinct(): FhirPath = FhirPath("$expr.distinct()")
+    fun isDistinct(): FhirPath = FhirPath("$expr.isDistinct()")
+    fun subsetOf(other: String): FhirPath = FhirPath("$expr.subsetOf($other)")
+    fun supersetOf(other: String): FhirPath = FhirPath("$expr.supersetOf($other)")
+    fun children(): FhirPath = FhirPath("$expr.children()")
+    fun descendants(): FhirPath = FhirPath("$expr.descendants()")
+
+    // ── Boolean operators ─────────────────────────────────────────────────────
+
+    fun not(): FhirPath = FhirPath("$expr.not()")
+    fun and(other: FhirPath): FhirPath = FhirPath("($expr) and (${other.build()})")
+    fun and(other: String): FhirPath = FhirPath("($expr) and ($other)")
+    fun or(other: FhirPath): FhirPath = FhirPath("($expr) or (${other.build()})")
+    fun or(other: String): FhirPath = FhirPath("($expr) or ($other)")
+    fun xor(other: FhirPath): FhirPath = FhirPath("($expr) xor (${other.build()})")
+    fun xor(other: String): FhirPath = FhirPath("($expr) xor ($other)")
+    fun implies(other: FhirPath): FhirPath = FhirPath("($expr) implies (${other.build()})")
+    fun implies(other: String): FhirPath = FhirPath("($expr) implies ($other)")
+
+    // ── Equality / comparison operators ──────────────────────────────────────
+
+    fun eq(value: String): FhirPath = FhirPath("$expr = $value")
+    fun ne(value: String): FhirPath = FhirPath("$expr != $value")
+    fun lt(value: String): FhirPath = FhirPath("$expr < $value")
+    fun gt(value: String): FhirPath = FhirPath("$expr > $value")
+    fun le(value: String): FhirPath = FhirPath("$expr <= $value")
+    fun ge(value: String): FhirPath = FhirPath("$expr >= $value")
+
+    /** FHIRPath equivalence (`~`): matches regardless of insignificant whitespace, case, etc. */
+    fun equiv(value: String): FhirPath = FhirPath("$expr ~ $value")
+
+    /** FHIRPath non-equivalence (`!~`). */
+    fun notEquiv(value: String): FhirPath = FhirPath("$expr !~ $value")
+
+    /** FHIRPath `in` membership: `expr in collection`. (`in` is a Kotlin keyword, so this is named `memberOf`.) */
+    fun memberOf(collection: String): FhirPath = FhirPath("$expr in $collection")
+
+    /** FHIRPath `contains` membership: `expr contains value`. */
+    fun containsValue(value: String): FhirPath = FhirPath("$expr contains $value")
+
+    // ── Type functions ────────────────────────────────────────────────────────
+
+    /** FHIRPath `is` type check: `expr.is(type)`. (`is` is a Kotlin keyword, so this is named `isType`.) */
+    fun isType(type: String): FhirPath = FhirPath("$expr.is($type)")
+
+    /** FHIRPath `as` type cast: `expr.as(type)`. (`as` is a Kotlin keyword, so this is named `asType`.) */
+    fun asType(type: String): FhirPath = FhirPath("$expr.as($type)")
+
+    // ── String functions ──────────────────────────────────────────────────────
+
+    fun length(): FhirPath = FhirPath("$expr.length()")
+    fun upper(): FhirPath = FhirPath("$expr.upper()")
+    fun lower(): FhirPath = FhirPath("$expr.lower()")
+    fun trim(): FhirPath = FhirPath("$expr.trim()")
+    fun startsWith(prefix: String): FhirPath = FhirPath("$expr.startsWith($prefix)")
+    fun endsWith(suffix: String): FhirPath = FhirPath("$expr.endsWith($suffix)")
+    fun contains(substring: String): FhirPath = FhirPath("$expr.contains($substring)")
+    fun matches(regex: String): FhirPath = FhirPath("$expr.matches($regex)")
+    fun indexOf(substring: String): FhirPath = FhirPath("$expr.indexOf($substring)")
+    fun substring(start: Int): FhirPath = FhirPath("$expr.substring($start)")
+    fun substring(start: Int, length: Int): FhirPath = FhirPath("$expr.substring($start, $length)")
+    fun replace(pattern: String, substitution: String): FhirPath = FhirPath("$expr.replace($pattern, $substitution)")
+    fun replaceMatches(regex: String, substitution: String): FhirPath = FhirPath("$expr.replaceMatches($regex, $substitution)")
+    fun split(separator: String): FhirPath = FhirPath("$expr.split($separator)")
+    fun join(separator: String): FhirPath = FhirPath("$expr.join($separator)")
+
+    // ── Math functions ────────────────────────────────────────────────────────
+
+    fun abs(): FhirPath = FhirPath("$expr.abs()")
+    fun ceiling(): FhirPath = FhirPath("$expr.ceiling()")
+    fun floor(): FhirPath = FhirPath("$expr.floor()")
+    fun round(): FhirPath = FhirPath("$expr.round()")
+    fun round(precision: Int): FhirPath = FhirPath("$expr.round($precision)")
+    fun sqrt(): FhirPath = FhirPath("$expr.sqrt()")
+    fun power(exp: String): FhirPath = FhirPath("$expr.power($exp)")
+    fun truncate(): FhirPath = FhirPath("$expr.truncate()")
+
+    // ── Arithmetic operators ──────────────────────────────────────────────────
+
+    fun plus(value: String): FhirPath = FhirPath("$expr + $value")
+    fun minus(value: String): FhirPath = FhirPath("$expr - $value")
+    fun times(value: String): FhirPath = FhirPath("$expr * $value")
+    fun dividedBy(value: String): FhirPath = FhirPath("$expr / $value")
+    fun div(value: String): FhirPath = FhirPath("$expr div $value")
+    fun mod(value: String): FhirPath = FhirPath("$expr mod $value")
+
+    /** FHIRPath string concatenation (`&`): `expr & value`. */
+    fun concat(value: String): FhirPath = FhirPath("$expr & $value")
+
+    // ── Type conversion ───────────────────────────────────────────────────────
+
+    fun toBoolean(): FhirPath = FhirPath("$expr.toBoolean()")
+    fun toInteger(): FhirPath = FhirPath("$expr.toInteger()")
+    fun toDecimal(): FhirPath = FhirPath("$expr.toDecimal()")
+    fun toDate(): FhirPath = FhirPath("$expr.toDate()")
+    fun toDateTime(): FhirPath = FhirPath("$expr.toDateTime()")
+    fun toTime(): FhirPath = FhirPath("$expr.toTime()")
+    fun toQuantity(): FhirPath = FhirPath("$expr.toQuantity()")
+
+    // ── FHIR-specific ─────────────────────────────────────────────────────────
+
+    /** Navigates to the extension with [url]: `expr.extension('url')`. */
+    fun extension(url: String): FhirPath = FhirPath("$expr.extension('$url')")
+
+    /** Tests for the presence of an extension with [url]: `expr.hasExtension('url')`. */
+    fun hasExtension(url: String): FhirPath = FhirPath("$expr.hasExtension('$url')")
+
+    /** Resolves a reference to its target resource: `expr.resolve()`. */
+    fun resolve(): FhirPath = FhirPath("$expr.resolve()")
+
+    // ── Terminal ──────────────────────────────────────────────────────────────
+
+    /** Returns the accumulated FHIRPath expression string. */
+    fun build(): String = expr
+
+    override fun toString(): String = expr
+}

--- a/fhirmason-api/src/main/java/dev/ratkay/operation/FhirPath.kt
+++ b/fhirmason-api/src/main/java/dev/ratkay/operation/FhirPath.kt
@@ -69,9 +69,6 @@ class FhirPath private constructor(private val expr: String) {
     /** Appends a `select` projection: `expr.select(projection)`. */
     fun select(projection: String): FhirPath = FhirPath("$expr.select($projection)")
 
-    /** Appends an `ofType` type filter: `expr.ofType(type)`. */
-    fun ofType(type: String): FhirPath = FhirPath("$expr.ofType($type)")
-
     // ── Collection functions ──────────────────────────────────────────────────
 
     fun first(): FhirPath = FhirPath("$expr.first()")

--- a/fhirmason-api/src/main/java/dev/ratkay/operation/FhirPath.kt
+++ b/fhirmason-api/src/main/java/dev/ratkay/operation/FhirPath.kt
@@ -223,9 +223,6 @@ class FhirPath private constructor(private val expr: String) {
     /** Navigates to the extension with [url]: `expr.extension('url')`. */
     fun extension(url: String): FhirPath = FhirPath("$expr.extension('$url')")
 
-    /** Tests for the presence of an extension with [url]: `expr.hasExtension('url')`. */
-    fun hasExtension(url: String): FhirPath = FhirPath("$expr.hasExtension('$url')")
-
     /** Resolves a reference to its target resource: `expr.resolve()`. */
     fun resolve(): FhirPath = FhirPath("$expr.resolve()")
 

--- a/fhirmason-api/src/main/java/dev/ratkay/operation/FhirPath.kt
+++ b/fhirmason-api/src/main/java/dev/ratkay/operation/FhirPath.kt
@@ -89,7 +89,6 @@ class FhirPath private constructor(private val expr: String) {
     fun anyFalse(): FhirPath = FhirPath("$expr.anyFalse()")
     fun distinct(): FhirPath = FhirPath("$expr.distinct()")
     fun isDistinct(): FhirPath = FhirPath("$expr.isDistinct()")
-    fun subsetOf(other: String): FhirPath = FhirPath("$expr.subsetOf($other)")
     fun supersetOf(other: String): FhirPath = FhirPath("$expr.supersetOf($other)")
     fun children(): FhirPath = FhirPath("$expr.children()")
     fun descendants(): FhirPath = FhirPath("$expr.descendants()")
@@ -147,20 +146,8 @@ class FhirPath private constructor(private val expr: String) {
     fun notEquiv(value: Int): FhirPath = FhirPath("$expr !~ $value")
     fun notEquiv(value: Double): FhirPath = FhirPath("$expr !~ $value")
 
-    /** FHIRPath `in` membership: `expr in collection`. (`in` is a Kotlin keyword, so this is named `memberOf`.)
-     *  [collection] is a FHIRPath expression (path or set name) — not auto-quoted. */
-    fun memberOf(collection: String): FhirPath = FhirPath("$expr in $collection")
-
     /** FHIRPath `contains` membership: `expr contains value`. [value] is auto-quoted as a string literal. */
     fun containsValue(value: String): FhirPath = FhirPath("$expr contains '$value'")
-
-    // ── Type functions ────────────────────────────────────────────────────────
-
-    /** FHIRPath `is` type check: `expr.is(type)`. (`is` is a Kotlin keyword, so this is named `isType`.) */
-    fun isType(type: String): FhirPath = FhirPath("$expr.is($type)")
-
-    /** FHIRPath `as` type cast: `expr.as(type)`. (`as` is a Kotlin keyword, so this is named `asType`.) */
-    fun asType(type: String): FhirPath = FhirPath("$expr.as($type)")
 
     // ── String functions ──────────────────────────────────────────────────────
     //
@@ -210,9 +197,6 @@ class FhirPath private constructor(private val expr: String) {
     fun toBoolean(): FhirPath = FhirPath("$expr.toBoolean()")
     fun toInteger(): FhirPath = FhirPath("$expr.toInteger()")
     fun toDecimal(): FhirPath = FhirPath("$expr.toDecimal()")
-    fun toDate(): FhirPath = FhirPath("$expr.toDate()")
-    fun toDateTime(): FhirPath = FhirPath("$expr.toDateTime()")
-    fun toTime(): FhirPath = FhirPath("$expr.toTime()")
     fun toQuantity(): FhirPath = FhirPath("$expr.toQuantity()")
 
     // ── FHIR-specific ─────────────────────────────────────────────────────────

--- a/fhirmason-api/src/test/java/dev/ratkay/operation/FhirPathTest.kt
+++ b/fhirmason-api/src/test/java/dev/ratkay/operation/FhirPathTest.kt
@@ -1,0 +1,584 @@
+package dev.ratkay.operation
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+
+class FhirPathTest {
+
+    // ── Factory ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `from produces root segment`() {
+        assertThat(FhirPath.from("Patient").build(), `is`("Patient"))
+    }
+
+    @Test
+    fun `relative produces empty base`() {
+        assertThat(FhirPath.relative().build(), `is`(""))
+    }
+
+    @Test
+    fun `toString delegates to build`() {
+        val path = FhirPath.from("Patient").navigate("name")
+        assertThat(path.toString(), `is`(path.build()))
+    }
+
+    // ── Navigation ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `navigate appends dot-segment`() {
+        assertThat(FhirPath.from("Patient").navigate("name").build(), `is`("Patient.name"))
+    }
+
+    @Test
+    fun `navigate on relative base omits leading dot`() {
+        assertThat(FhirPath.relative().navigate("use").build(), `is`("use"))
+    }
+
+    @Test
+    fun `navigate chains multiple segments`() {
+        assertThat(
+            FhirPath.from("Patient").navigate("name").navigate("given").build(),
+            `is`("Patient.name.given")
+        )
+    }
+
+    @Test
+    fun `union with FhirPath produces pipe expression`() {
+        val a = FhirPath.from("name")
+        val b = FhirPath.from("identifier")
+        assertThat(a.union(b).build(), `is`("name | identifier"))
+    }
+
+    @Test
+    fun `union with string produces pipe expression`() {
+        assertThat(FhirPath.from("name").union("identifier").build(), `is`("name | identifier"))
+    }
+
+    // ── Subsetting / filtering ────────────────────────────────────────────────
+
+    @Test
+    fun `where with string condition`() {
+        assertThat(
+            FhirPath.from("name").where("use = 'official'").build(),
+            `is`("name.where(use = 'official')")
+        )
+    }
+
+    @Test
+    fun `where with FhirPath condition`() {
+        val condition = FhirPath.relative().navigate("use").eq("'official'")
+        assertThat(
+            FhirPath.from("name").where(condition).build(),
+            `is`("name.where(use = 'official')")
+        )
+    }
+
+    @Test
+    fun `select appends select projection`() {
+        assertThat(FhirPath.from("name").select("given").build(), `is`("name.select(given)"))
+    }
+
+    @Test
+    fun `ofType appends ofType call`() {
+        assertThat(FhirPath.from("value").ofType("Quantity").build(), `is`("value.ofType(Quantity)"))
+    }
+
+    // ── Collection functions ──────────────────────────────────────────────────
+
+    @Test
+    fun `first appends first()`() {
+        assertThat(FhirPath.from("name").first().build(), `is`("name.first()"))
+    }
+
+    @Test
+    fun `last appends last()`() {
+        assertThat(FhirPath.from("name").last().build(), `is`("name.last()"))
+    }
+
+    @Test
+    fun `tail appends tail()`() {
+        assertThat(FhirPath.from("name").tail().build(), `is`("name.tail()"))
+    }
+
+    @Test
+    fun `take appends take with count`() {
+        assertThat(FhirPath.from("name").take(3).build(), `is`("name.take(3)"))
+    }
+
+    @Test
+    fun `skip appends skip with count`() {
+        assertThat(FhirPath.from("name").skip(2).build(), `is`("name.skip(2)"))
+    }
+
+    @Test
+    fun `count appends count()`() {
+        assertThat(FhirPath.from("name").count().build(), `is`("name.count()"))
+    }
+
+    @Test
+    fun `empty appends empty()`() {
+        assertThat(FhirPath.from("name").empty().build(), `is`("name.empty()"))
+    }
+
+    @Test
+    fun `exists no-arg appends exists()`() {
+        assertThat(FhirPath.from("name").exists().build(), `is`("name.exists()"))
+    }
+
+    @Test
+    fun `exists with string criteria`() {
+        assertThat(FhirPath.from("name").exists("use = 'official'").build(), `is`("name.exists(use = 'official')"))
+    }
+
+    @Test
+    fun `exists with FhirPath criteria`() {
+        val criteria = FhirPath.relative().navigate("use").eq("'official'")
+        assertThat(FhirPath.from("name").exists(criteria).build(), `is`("name.exists(use = 'official')"))
+    }
+
+    @Test
+    fun `all with string criteria`() {
+        assertThat(FhirPath.from("name").all("use = 'official'").build(), `is`("name.all(use = 'official')"))
+    }
+
+    @Test
+    fun `all with FhirPath criteria`() {
+        val criteria = FhirPath.relative().navigate("use").eq("'official'")
+        assertThat(FhirPath.from("name").all(criteria).build(), `is`("name.all(use = 'official')"))
+    }
+
+    @Test
+    fun `allTrue appends allTrue()`() {
+        assertThat(FhirPath.from("active").allTrue().build(), `is`("active.allTrue()"))
+    }
+
+    @Test
+    fun `anyTrue appends anyTrue()`() {
+        assertThat(FhirPath.from("active").anyTrue().build(), `is`("active.anyTrue()"))
+    }
+
+    @Test
+    fun `allFalse appends allFalse()`() {
+        assertThat(FhirPath.from("active").allFalse().build(), `is`("active.allFalse()"))
+    }
+
+    @Test
+    fun `anyFalse appends anyFalse()`() {
+        assertThat(FhirPath.from("active").anyFalse().build(), `is`("active.anyFalse()"))
+    }
+
+    @Test
+    fun `distinct appends distinct()`() {
+        assertThat(FhirPath.from("name").distinct().build(), `is`("name.distinct()"))
+    }
+
+    @Test
+    fun `isDistinct appends isDistinct()`() {
+        assertThat(FhirPath.from("name").isDistinct().build(), `is`("name.isDistinct()"))
+    }
+
+    @Test
+    fun `subsetOf appends subsetOf call`() {
+        assertThat(FhirPath.from("a").subsetOf("b").build(), `is`("a.subsetOf(b)"))
+    }
+
+    @Test
+    fun `supersetOf appends supersetOf call`() {
+        assertThat(FhirPath.from("a").supersetOf("b").build(), `is`("a.supersetOf(b)"))
+    }
+
+    @Test
+    fun `children appends children()`() {
+        assertThat(FhirPath.from("Patient").children().build(), `is`("Patient.children()"))
+    }
+
+    @Test
+    fun `descendants appends descendants()`() {
+        assertThat(FhirPath.from("Patient").descendants().build(), `is`("Patient.descendants()"))
+    }
+
+    // ── Boolean operators ─────────────────────────────────────────────────────
+
+    @Test
+    fun `not appends not()`() {
+        assertThat(FhirPath.from("active").not().build(), `is`("active.not()"))
+    }
+
+    @Test
+    fun `and with FhirPath wraps both sides`() {
+        val left = FhirPath.from("active").eq("true")
+        val right = FhirPath.from("name").exists()
+        assertThat(left.and(right).build(), `is`("(active = true) and (name.exists())"))
+    }
+
+    @Test
+    fun `and with string wraps both sides`() {
+        assertThat(FhirPath.from("active").eq("true").and("name.exists()").build(), `is`("(active = true) and (name.exists())"))
+    }
+
+    @Test
+    fun `or with FhirPath wraps both sides`() {
+        val left = FhirPath.from("active").eq("true")
+        val right = FhirPath.from("name").exists()
+        assertThat(left.or(right).build(), `is`("(active = true) or (name.exists())"))
+    }
+
+    @Test
+    fun `or with string wraps both sides`() {
+        assertThat(FhirPath.from("active").eq("true").or("name.exists()").build(), `is`("(active = true) or (name.exists())"))
+    }
+
+    @Test
+    fun `xor with FhirPath wraps both sides`() {
+        val left = FhirPath.from("a").eq("true")
+        val right = FhirPath.from("b").eq("true")
+        assertThat(left.xor(right).build(), `is`("(a = true) xor (b = true)"))
+    }
+
+    @Test
+    fun `xor with string wraps both sides`() {
+        assertThat(FhirPath.from("a").eq("true").xor("b = true").build(), `is`("(a = true) xor (b = true)"))
+    }
+
+    @Test
+    fun `implies with FhirPath wraps both sides`() {
+        val left = FhirPath.from("active").eq("true")
+        val right = FhirPath.from("name").exists()
+        assertThat(left.implies(right).build(), `is`("(active = true) implies (name.exists())"))
+    }
+
+    @Test
+    fun `implies with string wraps both sides`() {
+        assertThat(FhirPath.from("active").eq("true").implies("name.exists()").build(), `is`("(active = true) implies (name.exists())"))
+    }
+
+    // ── Equality / comparison operators ──────────────────────────────────────
+
+    @Test
+    fun `eq produces equality expression`() {
+        assertThat(FhirPath.from("active").eq("true").build(), `is`("active = true"))
+    }
+
+    @Test
+    fun `ne produces not-equal expression`() {
+        assertThat(FhirPath.from("active").ne("true").build(), `is`("active != true"))
+    }
+
+    @Test
+    fun `lt produces less-than expression`() {
+        assertThat(FhirPath.from("age").lt("18").build(), `is`("age < 18"))
+    }
+
+    @Test
+    fun `gt produces greater-than expression`() {
+        assertThat(FhirPath.from("age").gt("18").build(), `is`("age > 18"))
+    }
+
+    @Test
+    fun `le produces less-or-equal expression`() {
+        assertThat(FhirPath.from("age").le("18").build(), `is`("age <= 18"))
+    }
+
+    @Test
+    fun `ge produces greater-or-equal expression`() {
+        assertThat(FhirPath.from("age").ge("18").build(), `is`("age >= 18"))
+    }
+
+    @Test
+    fun `equiv produces tilde expression`() {
+        assertThat(FhirPath.from("name").equiv("'Smith'").build(), `is`("name ~ 'Smith'"))
+    }
+
+    @Test
+    fun `notEquiv produces bang-tilde expression`() {
+        assertThat(FhirPath.from("name").notEquiv("'Smith'").build(), `is`("name !~ 'Smith'"))
+    }
+
+    @Test
+    fun `memberOf produces in expression`() {
+        assertThat(FhirPath.from("code").memberOf("vs").build(), `is`("code in vs"))
+    }
+
+    @Test
+    fun `containsValue produces contains expression`() {
+        assertThat(FhirPath.from("codes").containsValue("'abc'").build(), `is`("codes contains 'abc'"))
+    }
+
+    // ── Type functions ────────────────────────────────────────────────────────
+
+    @Test
+    fun `isType produces is call`() {
+        assertThat(FhirPath.from("value").isType("Quantity").build(), `is`("value.is(Quantity)"))
+    }
+
+    @Test
+    fun `asType produces as call`() {
+        assertThat(FhirPath.from("value").asType("Quantity").build(), `is`("value.as(Quantity)"))
+    }
+
+    // ── String functions ──────────────────────────────────────────────────────
+
+    @Test
+    fun `length appends length()`() {
+        assertThat(FhirPath.from("family").length().build(), `is`("family.length()"))
+    }
+
+    @Test
+    fun `upper appends upper()`() {
+        assertThat(FhirPath.from("family").upper().build(), `is`("family.upper()"))
+    }
+
+    @Test
+    fun `lower appends lower()`() {
+        assertThat(FhirPath.from("family").lower().build(), `is`("family.lower()"))
+    }
+
+    @Test
+    fun `trim appends trim()`() {
+        assertThat(FhirPath.from("family").trim().build(), `is`("family.trim()"))
+    }
+
+    @Test
+    fun `startsWith appends startsWith call`() {
+        assertThat(FhirPath.from("family").startsWith("'A'").build(), `is`("family.startsWith('A')"))
+    }
+
+    @Test
+    fun `endsWith appends endsWith call`() {
+        assertThat(FhirPath.from("family").endsWith("'son'").build(), `is`("family.endsWith('son')"))
+    }
+
+    @Test
+    fun `contains appends contains call`() {
+        assertThat(FhirPath.from("family").contains("'an'").build(), `is`("family.contains('an')"))
+    }
+
+    @Test
+    fun `matches appends matches call`() {
+        assertThat(FhirPath.from("family").matches("'[A-Z].*'").build(), `is`("family.matches('[A-Z].*')"))
+    }
+
+    @Test
+    fun `indexOf appends indexOf call`() {
+        assertThat(FhirPath.from("family").indexOf("'a'").build(), `is`("family.indexOf('a')"))
+    }
+
+    @Test
+    fun `substring with start only`() {
+        assertThat(FhirPath.from("family").substring(2).build(), `is`("family.substring(2)"))
+    }
+
+    @Test
+    fun `substring with start and length`() {
+        assertThat(FhirPath.from("family").substring(2, 4).build(), `is`("family.substring(2, 4)"))
+    }
+
+    @Test
+    fun `replace appends replace call`() {
+        assertThat(FhirPath.from("family").replace("'a'", "'b'").build(), `is`("family.replace('a', 'b')"))
+    }
+
+    @Test
+    fun `replaceMatches appends replaceMatches call`() {
+        assertThat(FhirPath.from("family").replaceMatches("'[aeiou]'", "'*'").build(), `is`("family.replaceMatches('[aeiou]', '*')"))
+    }
+
+    @Test
+    fun `split appends split call`() {
+        assertThat(FhirPath.from("csv").split("','").build(), `is`("csv.split(',')"))
+    }
+
+    @Test
+    fun `join appends join call`() {
+        assertThat(FhirPath.from("parts").join("','").build(), `is`("parts.join(',')"))
+    }
+
+    // ── Math functions ────────────────────────────────────────────────────────
+
+    @Test
+    fun `abs appends abs()`() {
+        assertThat(FhirPath.from("value").abs().build(), `is`("value.abs()"))
+    }
+
+    @Test
+    fun `ceiling appends ceiling()`() {
+        assertThat(FhirPath.from("value").ceiling().build(), `is`("value.ceiling()"))
+    }
+
+    @Test
+    fun `floor appends floor()`() {
+        assertThat(FhirPath.from("value").floor().build(), `is`("value.floor()"))
+    }
+
+    @Test
+    fun `round no-arg appends round()`() {
+        assertThat(FhirPath.from("value").round().build(), `is`("value.round()"))
+    }
+
+    @Test
+    fun `round with precision appends round with arg`() {
+        assertThat(FhirPath.from("value").round(2).build(), `is`("value.round(2)"))
+    }
+
+    @Test
+    fun `sqrt appends sqrt()`() {
+        assertThat(FhirPath.from("value").sqrt().build(), `is`("value.sqrt()"))
+    }
+
+    @Test
+    fun `power appends power call`() {
+        assertThat(FhirPath.from("value").power("2").build(), `is`("value.power(2)"))
+    }
+
+    @Test
+    fun `truncate appends truncate()`() {
+        assertThat(FhirPath.from("value").truncate().build(), `is`("value.truncate()"))
+    }
+
+    // ── Arithmetic operators ──────────────────────────────────────────────────
+
+    @Test
+    fun `plus produces addition expression`() {
+        assertThat(FhirPath.from("a").plus("b").build(), `is`("a + b"))
+    }
+
+    @Test
+    fun `minus produces subtraction expression`() {
+        assertThat(FhirPath.from("a").minus("b").build(), `is`("a - b"))
+    }
+
+    @Test
+    fun `times produces multiplication expression`() {
+        assertThat(FhirPath.from("a").times("b").build(), `is`("a * b"))
+    }
+
+    @Test
+    fun `dividedBy produces division expression`() {
+        assertThat(FhirPath.from("a").dividedBy("b").build(), `is`("a / b"))
+    }
+
+    @Test
+    fun `div produces integer division expression`() {
+        assertThat(FhirPath.from("a").div("b").build(), `is`("a div b"))
+    }
+
+    @Test
+    fun `mod produces modulo expression`() {
+        assertThat(FhirPath.from("a").mod("b").build(), `is`("a mod b"))
+    }
+
+    @Test
+    fun `concat produces ampersand expression`() {
+        assertThat(FhirPath.from("a").concat("b").build(), `is`("a & b"))
+    }
+
+    // ── Type conversion ───────────────────────────────────────────────────────
+
+    @Test
+    fun `toBoolean appends toBoolean()`() {
+        assertThat(FhirPath.from("value").toBoolean().build(), `is`("value.toBoolean()"))
+    }
+
+    @Test
+    fun `toInteger appends toInteger()`() {
+        assertThat(FhirPath.from("value").toInteger().build(), `is`("value.toInteger()"))
+    }
+
+    @Test
+    fun `toDecimal appends toDecimal()`() {
+        assertThat(FhirPath.from("value").toDecimal().build(), `is`("value.toDecimal()"))
+    }
+
+    @Test
+    fun `toDate appends toDate()`() {
+        assertThat(FhirPath.from("value").toDate().build(), `is`("value.toDate()"))
+    }
+
+    @Test
+    fun `toDateTime appends toDateTime()`() {
+        assertThat(FhirPath.from("value").toDateTime().build(), `is`("value.toDateTime()"))
+    }
+
+    @Test
+    fun `toTime appends toTime()`() {
+        assertThat(FhirPath.from("value").toTime().build(), `is`("value.toTime()"))
+    }
+
+    @Test
+    fun `toQuantity appends toQuantity()`() {
+        assertThat(FhirPath.from("value").toQuantity().build(), `is`("value.toQuantity()"))
+    }
+
+    // ── FHIR-specific ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `extension wraps url in single quotes`() {
+        assertThat(
+            FhirPath.from("Patient").extension("http://hl7.org/fhir/StructureDefinition/patient-birthPlace").build(),
+            `is`("Patient.extension('http://hl7.org/fhir/StructureDefinition/patient-birthPlace')")
+        )
+    }
+
+    @Test
+    fun `hasExtension wraps url in single quotes`() {
+        assertThat(
+            FhirPath.from("Patient").hasExtension("http://example.org/ext").build(),
+            `is`("Patient.hasExtension('http://example.org/ext')")
+        )
+    }
+
+    @Test
+    fun `resolve appends resolve()`() {
+        assertThat(FhirPath.from("subject").resolve().build(), `is`("subject.resolve()"))
+    }
+
+    // ── Compound chains ───────────────────────────────────────────────────────
+
+    @Test
+    fun `full official-name path`() {
+        val path = FhirPath.from("Patient")
+            .navigate("name")
+            .where(FhirPath.relative().navigate("use").eq("'official'"))
+            .navigate("given")
+            .first()
+            .build()
+        assertThat(path, `is`("Patient.name.where(use = 'official').given.first()"))
+    }
+
+    @Test
+    fun `compound and condition`() {
+        val active = FhirPath.from("active").eq("true")
+        val hasName = FhirPath.from("name").exists()
+        assertThat(active.and(hasName).build(), `is`("(active = true) and (name.exists())"))
+    }
+
+    @Test
+    fun `extension value path`() {
+        val path = FhirPath.from("Patient")
+            .extension("http://example.org/ext")
+            .navigate("value")
+            .build()
+        assertThat(path, `is`("Patient.extension('http://example.org/ext').value"))
+    }
+
+    @Test
+    fun `reference resolve chain`() {
+        val path = FhirPath.from("subject")
+            .resolve()
+            .navigate("birthDate")
+            .build()
+        assertThat(path, `is`("subject.resolve().birthDate"))
+    }
+
+    @Test
+    fun `immutability — reusing base produces independent paths`() {
+        val base = FhirPath.from("name")
+        val first = base.first()
+        val last = base.last()
+        assertThat(first.build(), `is`("name.first()"))
+        assertThat(last.build(), `is`("name.last()"))
+        assertThat(base.build(), `is`("name"))
+    }
+}

--- a/fhirmason-api/src/test/java/dev/ratkay/operation/FhirPathTest.kt
+++ b/fhirmason-api/src/test/java/dev/ratkay/operation/FhirPathTest.kt
@@ -175,11 +175,6 @@ class FhirPathTest {
     }
 
     @Test
-    fun `subsetOf appends subsetOf call`() {
-        assertThat(FhirPath.from("a").subsetOf("b").build(), `is`("a.subsetOf(b)"))
-    }
-
-    @Test
     fun `supersetOf appends supersetOf call`() {
         assertThat(FhirPath.from("a").supersetOf("b").build(), `is`("a.supersetOf(b)"))
     }
@@ -357,25 +352,8 @@ class FhirPathTest {
     }
 
     @Test
-    fun `memberOf produces in expression — collection is not quoted`() {
-        assertThat(FhirPath.from("code").memberOf("vs").build(), `is`("code in vs"))
-    }
-
-    @Test
     fun `containsValue auto-quotes the string value`() {
         assertThat(FhirPath.from("codes").containsValue("abc").build(), `is`("codes contains 'abc'"))
-    }
-
-    // ── Type functions ────────────────────────────────────────────────────────
-
-    @Test
-    fun `isType produces is call`() {
-        assertThat(FhirPath.from("value").isType("Quantity").build(), `is`("value.is(Quantity)"))
-    }
-
-    @Test
-    fun `asType produces as call`() {
-        assertThat(FhirPath.from("value").asType("Quantity").build(), `is`("value.as(Quantity)"))
     }
 
     // ── String functions ──────────────────────────────────────────────────────
@@ -549,21 +527,6 @@ class FhirPathTest {
     @Test
     fun `toDecimal appends toDecimal()`() {
         assertThat(FhirPath.from("value").toDecimal().build(), `is`("value.toDecimal()"))
-    }
-
-    @Test
-    fun `toDate appends toDate()`() {
-        assertThat(FhirPath.from("value").toDate().build(), `is`("value.toDate()"))
-    }
-
-    @Test
-    fun `toDateTime appends toDateTime()`() {
-        assertThat(FhirPath.from("value").toDateTime().build(), `is`("value.toDateTime()"))
-    }
-
-    @Test
-    fun `toTime appends toTime()`() {
-        assertThat(FhirPath.from("value").toTime().build(), `is`("value.toTime()"))
     }
 
     @Test

--- a/fhirmason-api/src/test/java/dev/ratkay/operation/FhirPathTest.kt
+++ b/fhirmason-api/src/test/java/dev/ratkay/operation/FhirPathTest.kt
@@ -68,7 +68,7 @@ class FhirPathTest {
 
     @Test
     fun `where with FhirPath condition`() {
-        val condition = FhirPath.relative().navigate("use").eq("'official'")
+        val condition = FhirPath.relative().navigate("use").eq("official")
         assertThat(
             FhirPath.from("name").where(condition).build(),
             `is`("name.where(use = 'official')")
@@ -134,7 +134,7 @@ class FhirPathTest {
 
     @Test
     fun `exists with FhirPath criteria`() {
-        val criteria = FhirPath.relative().navigate("use").eq("'official'")
+        val criteria = FhirPath.relative().navigate("use").eq("official")
         assertThat(FhirPath.from("name").exists(criteria).build(), `is`("name.exists(use = 'official')"))
     }
 
@@ -145,7 +145,7 @@ class FhirPathTest {
 
     @Test
     fun `all with FhirPath criteria`() {
-        val criteria = FhirPath.relative().navigate("use").eq("'official'")
+        val criteria = FhirPath.relative().navigate("use").eq("official")
         assertThat(FhirPath.from("name").all(criteria).build(), `is`("name.all(use = 'official')"))
     }
 
@@ -208,102 +208,167 @@ class FhirPathTest {
 
     @Test
     fun `and with FhirPath wraps both sides`() {
-        val left = FhirPath.from("active").eq("true")
+        val left = FhirPath.from("active").eq(true)
         val right = FhirPath.from("name").exists()
         assertThat(left.and(right).build(), `is`("(active = true) and (name.exists())"))
     }
 
     @Test
     fun `and with string wraps both sides`() {
-        assertThat(FhirPath.from("active").eq("true").and("name.exists()").build(), `is`("(active = true) and (name.exists())"))
+        assertThat(FhirPath.from("active").eq(true).and("name.exists()").build(), `is`("(active = true) and (name.exists())"))
     }
 
     @Test
     fun `or with FhirPath wraps both sides`() {
-        val left = FhirPath.from("active").eq("true")
+        val left = FhirPath.from("active").eq(true)
         val right = FhirPath.from("name").exists()
         assertThat(left.or(right).build(), `is`("(active = true) or (name.exists())"))
     }
 
     @Test
     fun `or with string wraps both sides`() {
-        assertThat(FhirPath.from("active").eq("true").or("name.exists()").build(), `is`("(active = true) or (name.exists())"))
+        assertThat(FhirPath.from("active").eq(true).or("name.exists()").build(), `is`("(active = true) or (name.exists())"))
     }
 
     @Test
     fun `xor with FhirPath wraps both sides`() {
-        val left = FhirPath.from("a").eq("true")
-        val right = FhirPath.from("b").eq("true")
+        val left = FhirPath.from("a").eq(true)
+        val right = FhirPath.from("b").eq(true)
         assertThat(left.xor(right).build(), `is`("(a = true) xor (b = true)"))
     }
 
     @Test
     fun `xor with string wraps both sides`() {
-        assertThat(FhirPath.from("a").eq("true").xor("b = true").build(), `is`("(a = true) xor (b = true)"))
+        assertThat(FhirPath.from("a").eq(true).xor("b = true").build(), `is`("(a = true) xor (b = true)"))
     }
 
     @Test
     fun `implies with FhirPath wraps both sides`() {
-        val left = FhirPath.from("active").eq("true")
+        val left = FhirPath.from("active").eq(true)
         val right = FhirPath.from("name").exists()
         assertThat(left.implies(right).build(), `is`("(active = true) implies (name.exists())"))
     }
 
     @Test
     fun `implies with string wraps both sides`() {
-        assertThat(FhirPath.from("active").eq("true").implies("name.exists()").build(), `is`("(active = true) implies (name.exists())"))
+        assertThat(FhirPath.from("active").eq(true).implies("name.exists()").build(), `is`("(active = true) implies (name.exists())"))
     }
 
     // ── Equality / comparison operators ──────────────────────────────────────
 
     @Test
-    fun `eq produces equality expression`() {
-        assertThat(FhirPath.from("active").eq("true").build(), `is`("active = true"))
+    fun `eq with String auto-quotes the value`() {
+        assertThat(FhirPath.from("use").eq("official").build(), `is`("use = 'official'"))
     }
 
     @Test
-    fun `ne produces not-equal expression`() {
-        assertThat(FhirPath.from("active").ne("true").build(), `is`("active != true"))
+    fun `eq with Boolean emits literal`() {
+        assertThat(FhirPath.from("active").eq(true).build(), `is`("active = true"))
     }
 
     @Test
-    fun `lt produces less-than expression`() {
-        assertThat(FhirPath.from("age").lt("18").build(), `is`("age < 18"))
+    fun `eq with Int emits literal`() {
+        assertThat(FhirPath.from("count").eq(5).build(), `is`("count = 5"))
     }
 
     @Test
-    fun `gt produces greater-than expression`() {
-        assertThat(FhirPath.from("age").gt("18").build(), `is`("age > 18"))
+    fun `eq with Double emits literal`() {
+        assertThat(FhirPath.from("score").eq(3.14).build(), `is`("score = 3.14"))
     }
 
     @Test
-    fun `le produces less-or-equal expression`() {
-        assertThat(FhirPath.from("age").le("18").build(), `is`("age <= 18"))
+    fun `ne with String auto-quotes the value`() {
+        assertThat(FhirPath.from("use").ne("official").build(), `is`("use != 'official'"))
     }
 
     @Test
-    fun `ge produces greater-or-equal expression`() {
-        assertThat(FhirPath.from("age").ge("18").build(), `is`("age >= 18"))
+    fun `ne with Boolean emits literal`() {
+        assertThat(FhirPath.from("active").ne(false).build(), `is`("active != false"))
     }
 
     @Test
-    fun `equiv produces tilde expression`() {
-        assertThat(FhirPath.from("name").equiv("'Smith'").build(), `is`("name ~ 'Smith'"))
+    fun `ne with Int emits literal`() {
+        assertThat(FhirPath.from("age").ne(0).build(), `is`("age != 0"))
     }
 
     @Test
-    fun `notEquiv produces bang-tilde expression`() {
-        assertThat(FhirPath.from("name").notEquiv("'Smith'").build(), `is`("name !~ 'Smith'"))
+    fun `lt with Int emits literal`() {
+        assertThat(FhirPath.from("age").lt(18).build(), `is`("age < 18"))
     }
 
     @Test
-    fun `memberOf produces in expression`() {
+    fun `lt with Double emits literal`() {
+        assertThat(FhirPath.from("score").lt(9.5).build(), `is`("score < 9.5"))
+    }
+
+    @Test
+    fun `lt with String auto-quotes`() {
+        assertThat(FhirPath.from("name").lt("M").build(), `is`("name < 'M'"))
+    }
+
+    @Test
+    fun `gt with Int emits literal`() {
+        assertThat(FhirPath.from("age").gt(65).build(), `is`("age > 65"))
+    }
+
+    @Test
+    fun `gt with Double emits literal`() {
+        assertThat(FhirPath.from("score").gt(0.5).build(), `is`("score > 0.5"))
+    }
+
+    @Test
+    fun `gt with String auto-quotes`() {
+        assertThat(FhirPath.from("name").gt("M").build(), `is`("name > 'M'"))
+    }
+
+    @Test
+    fun `le with Int emits literal`() {
+        assertThat(FhirPath.from("age").le(17).build(), `is`("age <= 17"))
+    }
+
+    @Test
+    fun `le with Double emits literal`() {
+        assertThat(FhirPath.from("score").le(1.0).build(), `is`("score <= 1.0"))
+    }
+
+    @Test
+    fun `ge with Int emits literal`() {
+        assertThat(FhirPath.from("age").ge(18).build(), `is`("age >= 18"))
+    }
+
+    @Test
+    fun `ge with Double emits literal`() {
+        assertThat(FhirPath.from("score").ge(0.0).build(), `is`("score >= 0.0"))
+    }
+
+    @Test
+    fun `equiv produces tilde expression with auto-quoted string`() {
+        assertThat(FhirPath.from("name").equiv("Smith").build(), `is`("name ~ 'Smith'"))
+    }
+
+    @Test
+    fun `equiv with Int emits literal`() {
+        assertThat(FhirPath.from("value").equiv(42).build(), `is`("value ~ 42"))
+    }
+
+    @Test
+    fun `notEquiv produces bang-tilde expression with auto-quoted string`() {
+        assertThat(FhirPath.from("name").notEquiv("Smith").build(), `is`("name !~ 'Smith'"))
+    }
+
+    @Test
+    fun `notEquiv with Int emits literal`() {
+        assertThat(FhirPath.from("value").notEquiv(0).build(), `is`("value !~ 0"))
+    }
+
+    @Test
+    fun `memberOf produces in expression — collection is not quoted`() {
         assertThat(FhirPath.from("code").memberOf("vs").build(), `is`("code in vs"))
     }
 
     @Test
-    fun `containsValue produces contains expression`() {
-        assertThat(FhirPath.from("codes").containsValue("'abc'").build(), `is`("codes contains 'abc'"))
+    fun `containsValue auto-quotes the string value`() {
+        assertThat(FhirPath.from("codes").containsValue("abc").build(), `is`("codes contains 'abc'"))
     }
 
     // ── Type functions ────────────────────────────────────────────────────────
@@ -341,28 +406,28 @@ class FhirPathTest {
     }
 
     @Test
-    fun `startsWith appends startsWith call`() {
-        assertThat(FhirPath.from("family").startsWith("'A'").build(), `is`("family.startsWith('A')"))
+    fun `startsWith auto-quotes prefix`() {
+        assertThat(FhirPath.from("family").startsWith("A").build(), `is`("family.startsWith('A')"))
     }
 
     @Test
-    fun `endsWith appends endsWith call`() {
-        assertThat(FhirPath.from("family").endsWith("'son'").build(), `is`("family.endsWith('son')"))
+    fun `endsWith auto-quotes suffix`() {
+        assertThat(FhirPath.from("family").endsWith("son").build(), `is`("family.endsWith('son')"))
     }
 
     @Test
-    fun `contains appends contains call`() {
-        assertThat(FhirPath.from("family").contains("'an'").build(), `is`("family.contains('an')"))
+    fun `contains auto-quotes substring`() {
+        assertThat(FhirPath.from("family").contains("an").build(), `is`("family.contains('an')"))
     }
 
     @Test
-    fun `matches appends matches call`() {
-        assertThat(FhirPath.from("family").matches("'[A-Z].*'").build(), `is`("family.matches('[A-Z].*')"))
+    fun `matches auto-quotes regex`() {
+        assertThat(FhirPath.from("family").matches("[A-Z].*").build(), `is`("family.matches('[A-Z].*')"))
     }
 
     @Test
-    fun `indexOf appends indexOf call`() {
-        assertThat(FhirPath.from("family").indexOf("'a'").build(), `is`("family.indexOf('a')"))
+    fun `indexOf auto-quotes substring`() {
+        assertThat(FhirPath.from("family").indexOf("a").build(), `is`("family.indexOf('a')"))
     }
 
     @Test
@@ -376,23 +441,23 @@ class FhirPathTest {
     }
 
     @Test
-    fun `replace appends replace call`() {
-        assertThat(FhirPath.from("family").replace("'a'", "'b'").build(), `is`("family.replace('a', 'b')"))
+    fun `replace auto-quotes pattern and substitution`() {
+        assertThat(FhirPath.from("family").replace("a", "b").build(), `is`("family.replace('a', 'b')"))
     }
 
     @Test
-    fun `replaceMatches appends replaceMatches call`() {
-        assertThat(FhirPath.from("family").replaceMatches("'[aeiou]'", "'*'").build(), `is`("family.replaceMatches('[aeiou]', '*')"))
+    fun `replaceMatches auto-quotes regex and substitution`() {
+        assertThat(FhirPath.from("family").replaceMatches("[aeiou]", "*").build(), `is`("family.replaceMatches('[aeiou]', '*')"))
     }
 
     @Test
-    fun `split appends split call`() {
-        assertThat(FhirPath.from("csv").split("','").build(), `is`("csv.split(',')"))
+    fun `split auto-quotes separator`() {
+        assertThat(FhirPath.from("csv").split(",").build(), `is`("csv.split(',')"))
     }
 
     @Test
-    fun `join appends join call`() {
-        assertThat(FhirPath.from("parts").join("','").build(), `is`("parts.join(',')"))
+    fun `join auto-quotes separator`() {
+        assertThat(FhirPath.from("parts").join(",").build(), `is`("parts.join(',')"))
     }
 
     // ── Math functions ────────────────────────────────────────────────────────
@@ -540,7 +605,7 @@ class FhirPathTest {
     fun `full official-name path`() {
         val path = FhirPath.from("Patient")
             .navigate("name")
-            .where(FhirPath.relative().navigate("use").eq("'official'"))
+            .where(FhirPath.relative().navigate("use").eq("official"))
             .navigate("given")
             .first()
             .build()
@@ -549,7 +614,7 @@ class FhirPathTest {
 
     @Test
     fun `compound and condition`() {
-        val active = FhirPath.from("active").eq("true")
+        val active = FhirPath.from("active").eq(true)
         val hasName = FhirPath.from("name").exists()
         assertThat(active.and(hasName).build(), `is`("(active = true) and (name.exists())"))
     }

--- a/fhirmason-api/src/test/java/dev/ratkay/operation/FhirPathTest.kt
+++ b/fhirmason-api/src/test/java/dev/ratkay/operation/FhirPathTest.kt
@@ -587,14 +587,6 @@ class FhirPathTest {
     }
 
     @Test
-    fun `hasExtension wraps url in single quotes`() {
-        assertThat(
-            FhirPath.from("Patient").hasExtension("http://example.org/ext").build(),
-            `is`("Patient.hasExtension('http://example.org/ext')")
-        )
-    }
-
-    @Test
     fun `resolve appends resolve()`() {
         assertThat(FhirPath.from("subject").resolve().build(), `is`("subject.resolve()"))
     }

--- a/fhirmason-api/src/test/java/dev/ratkay/operation/FhirPathTest.kt
+++ b/fhirmason-api/src/test/java/dev/ratkay/operation/FhirPathTest.kt
@@ -80,11 +80,6 @@ class FhirPathTest {
         assertThat(FhirPath.from("name").select("given").build(), `is`("name.select(given)"))
     }
 
-    @Test
-    fun `ofType appends ofType call`() {
-        assertThat(FhirPath.from("value").ofType("Quantity").build(), `is`("value.ofType(Quantity)"))
-    }
-
     // ── Collection functions ──────────────────────────────────────────────────
 
     @Test

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/FhirPathEvaluationTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/FhirPathEvaluationTest.kt
@@ -1,0 +1,405 @@
+package dev.ratkay.operation.dstu3
+
+import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.fhirpath.IFhirPath
+import dev.ratkay.operation.FhirPath
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.`is`
+import org.hl7.fhir.dstu3.model.BooleanType
+import org.hl7.fhir.dstu3.model.ContactPoint
+import org.hl7.fhir.dstu3.model.HumanName
+import org.hl7.fhir.dstu3.model.IntegerType
+import org.hl7.fhir.dstu3.model.Patient
+import org.hl7.fhir.dstu3.model.StringType
+import org.hl7.fhir.instance.model.api.IBase
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Validates that expressions produced by [FhirPath] are accepted and evaluated correctly by
+ * HAPI's DSTU3 FHIRPath engine. A test failure here means the builder produced an invalid or
+ * incorrectly structured expression string — not just a wrong expected value.
+ */
+class FhirPathEvaluationTest {
+
+    companion object {
+        private val engine: IFhirPath = FhirContext.forDstu3Cached().newFhirPath()
+    }
+
+    private fun <T : IBase> evaluateFirst(resource: IBase, path: FhirPath, type: Class<T>): T? =
+        engine.evaluateFirst(resource, path.build(), type).orElse(null)
+
+    private fun <T : IBase> evaluate(resource: IBase, path: FhirPath, type: Class<T>): List<T> =
+        engine.evaluate(resource, path.build(), type)
+
+    private fun matches(resource: IBase, path: FhirPath): Boolean {
+        val results = engine.evaluate(resource, path.build(), IBase::class.java)
+        if (results.isEmpty()) return false
+        val first = results.first()
+        return if (first is BooleanType) first.booleanValue() else true
+    }
+
+    // ── where + navigate ──────────────────────────────────────────────────────
+
+    @Test
+    fun `where with FhirPath condition extracts official family name`() {
+        val patient = Patient().apply {
+            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith" }
+            addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
+        }
+        val path = FhirPath.from("name")
+            .where(FhirPath.relative().navigate("use").eq("'official'"))
+            .navigate("family")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(1))
+        assertThat(results[0].value, `is`("Smith"))
+    }
+
+    @Test
+    fun `chained where and first extracts first given name from official name`() {
+        val patient = Patient().apply {
+            addName().apply {
+                use = HumanName.NameUse.OFFICIAL
+                family = "Smith"
+                addGiven("John")
+                addGiven("William")
+            }
+            addName().apply { use = HumanName.NameUse.NICKNAME; addGiven("Johnny") }
+        }
+        val path = FhirPath.from("name")
+            .where(FhirPath.relative().navigate("use").eq("'official'"))
+            .navigate("given")
+            .first()
+
+        val result = evaluateFirst(patient, path, StringType::class.java)
+        assertThat(result?.value, `is`("John"))
+    }
+
+    @Test
+    fun `and condition filters names that have both official use and a family`() {
+        val patient = Patient().apply {
+            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith" }
+            addName().apply { use = HumanName.NameUse.OFFICIAL }     // no family
+            addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
+        }
+        val condition = FhirPath.relative().navigate("use").eq("'official'")
+            .and(FhirPath.relative().navigate("family").exists())
+        val path = FhirPath.from("name").where(condition).navigate("family")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(1))
+        assertThat(results[0].value, `is`("Smith"))
+    }
+
+    @Test
+    fun `or condition finds both phone and email telecom values`() {
+        val patient = Patient().apply {
+            addTelecom().apply { system = ContactPoint.ContactPointSystem.PHONE; value = "555-1234" }
+            addTelecom().apply { system = ContactPoint.ContactPointSystem.EMAIL; value = "j@example.org" }
+            addTelecom().apply { system = ContactPoint.ContactPointSystem.FAX; value = "555-0000" }
+        }
+        val phoneOrEmail = FhirPath.relative().navigate("system").eq("'phone'")
+            .or(FhirPath.relative().navigate("system").eq("'email'"))
+        val path = FhirPath.from("telecom").where(phoneOrEmail).navigate("value")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    @Test
+    fun `identifier where system extracts MRN value`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { system = "http://example.org/mrn"; value = "MRN-001" }
+            addIdentifier().apply { system = "http://example.org/ssn"; value = "123-45-6789" }
+        }
+        val path = FhirPath.from("identifier")
+            .where(FhirPath.relative().navigate("system").eq("'http://example.org/mrn'"))
+            .navigate("value")
+
+        val result = evaluateFirst(patient, path, StringType::class.java)
+        assertThat(result?.value, `is`("MRN-001"))
+    }
+
+    @Test
+    fun `and on identifier filters by system and value prefix`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { system = "http://example.org/mrn"; value = "MRN-001" }
+            addIdentifier().apply { system = "http://example.org/mrn"; value = "OLD-001" }
+            addIdentifier().apply { system = "http://example.org/ssn"; value = "MRN-999" }
+        }
+        val condition = FhirPath.relative().navigate("system").eq("'http://example.org/mrn'")
+            .and(FhirPath.relative().navigate("value").startsWith("'MRN-'"))
+        val path = FhirPath.from("identifier").where(condition).navigate("value")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(1))
+        assertThat(results[0].value, `is`("MRN-001"))
+    }
+
+    // ── count / exists / all ──────────────────────────────────────────────────
+
+    @Test
+    fun `count of filtered list returns correct total`() {
+        val patient = Patient().apply {
+            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith" }
+            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Jones" }
+            addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
+        }
+        val path = FhirPath.from("name")
+            .where(FhirPath.relative().navigate("use").eq("'official'"))
+            .count()
+
+        val result = evaluateFirst(patient, path, IntegerType::class.java)
+        assertThat(result?.value, `is`(2))
+    }
+
+    @Test
+    fun `where then exists detects presence of matching element`() {
+        val patient = Patient().apply {
+            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith" }
+            addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
+        }
+        val path = FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("'official'")).exists()
+        assertTrue(matches(patient, path))
+    }
+
+    @Test
+    fun `where then exists is false when no element matches`() {
+        val patient = Patient().apply {
+            addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
+        }
+        val path = FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("'official'")).exists()
+        assertFalse(matches(patient, path))
+    }
+
+    @Test
+    fun `all with FhirPath criteria returns true when every identifier has a system`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { system = "http://example.org/mrn"; value = "12345" }
+            addIdentifier().apply { system = "http://example.org/ssn"; value = "999-99-9999" }
+        }
+        assertTrue(matches(patient, FhirPath.from("identifier").all(FhirPath.relative().navigate("system").exists())))
+    }
+
+    @Test
+    fun `all with FhirPath criteria returns false when an identifier lacks a system`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { system = "http://example.org/mrn"; value = "12345" }
+            addIdentifier().apply { value = "orphan" }
+        }
+        assertFalse(matches(patient, FhirPath.from("identifier").all(FhirPath.relative().navigate("system").exists())))
+    }
+
+    // ── string functions (DSTU3 FHIRPath 1.0 subset) ─────────────────────────
+
+    @Test
+    fun `length returns character count of family name`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").length(), IntegerType::class.java)
+        assertThat(result?.value, `is`(5))
+    }
+
+    @Test
+    fun `substring extracts characters from family name`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").substring(1, 3), StringType::class.java)
+        assertThat(result?.value, `is`("mit"))
+    }
+
+    @Test
+    fun `startsWith in where condition filters names by prefix`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Jones" }
+            addName().apply { family = "Smithfield" }
+        }
+        val path = FhirPath.from("name")
+            .where(FhirPath.relative().navigate("family").startsWith("'Sm'"))
+            .navigate("family")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    @Test
+    fun `endsWith in where condition filters names by suffix`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Jones" }
+            addName().apply { family = "Griffith" }
+        }
+        val path = FhirPath.from("name")
+            .where(FhirPath.relative().navigate("family").endsWith("'ith'"))
+            .navigate("family")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    // ── string function: matches regex ───────────────────────────────────────
+
+    @Test
+    fun `matches regex in where condition filters identifiers by value pattern`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { system = "http://example.org/id"; value = "MRN-001" }
+            addIdentifier().apply { system = "http://example.org/id"; value = "ABC-001" }
+            addIdentifier().apply { system = "http://example.org/id"; value = "MRN-099" }
+        }
+        val path = FhirPath.from("identifier")
+            .where(FhirPath.relative().navigate("value").matches("'MRN-[0-9]+'"))
+            .navigate("value")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    // ── select projection ─────────────────────────────────────────────────────
+
+    @Test
+    fun `select projects a field from every element of a collection`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith"; addGiven("John") }
+            addName().apply { family = "Jones"; addGiven("Jane") }
+        }
+        val results = evaluate(patient, FhirPath.from("name").select("family"), StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    // ── multi-term boolean chain ──────────────────────────────────────────────
+
+    @Test
+    fun `or-then-and three-term condition filters with correct precedence`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { system = "http://a.org"; value = "active-mrn" }
+            addIdentifier().apply { system = "http://b.org"; value = "passive-mrn" }
+            addIdentifier().apply { system = "http://c.org"; value = "something-else" }
+        }
+        val sysA = FhirPath.relative().navigate("system").eq("'http://a.org'")
+        val sysB = FhirPath.relative().navigate("system").eq("'http://b.org'")
+        val endsWithMrn = FhirPath.relative().navigate("value").endsWith("'-mrn'")
+        val path = FhirPath.from("identifier")
+            .where(sysA.or(sysB).and(endsWithMrn))
+            .navigate("value")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    // ── FHIR-specific: extension ──────────────────────────────────────────────
+
+    @Test
+    fun `extension function navigates to named extension value`() {
+        val patient = Patient().apply {
+            addExtension("http://example.org/color", StringType("blue"))
+        }
+        val path = FhirPath.from("Patient")
+            .extension("http://example.org/color")
+            .navigate("value")
+
+        val result = evaluateFirst(patient, path, StringType::class.java)
+        assertThat(result?.value, `is`("blue"))
+    }
+
+    @Test
+    fun `extension where url detects presence of a named extension`() {
+        val patient = Patient().apply {
+            addExtension("http://example.org/color", StringType("blue"))
+        }
+        val path = FhirPath.from("extension")
+            .where(FhirPath.relative().navigate("url").eq("'http://example.org/color'"))
+            .exists()
+        assertTrue(matches(patient, path))
+    }
+
+    @Test
+    fun `extension where url is false when extension is absent`() {
+        val path = FhirPath.from("extension")
+            .where(FhirPath.relative().navigate("url").eq("'http://example.org/color'"))
+            .exists()
+        assertFalse(matches(Patient(), path))
+    }
+
+    // ── boolean operators ─────────────────────────────────────────────────────
+
+    @Test
+    fun `not negates truthy active flag`() {
+        val patient = Patient().apply { active = true }
+        assertFalse(matches(patient, FhirPath.from("active").not()))
+    }
+
+    @Test
+    fun `not negates falsy active flag`() {
+        val patient = Patient().apply { active = false }
+        assertTrue(matches(patient, FhirPath.from("active").not()))
+    }
+
+    @Test
+    fun `and of two satisfied conditions is true`() {
+        val patient = Patient().apply {
+            active = true
+            addName().apply { family = "Smith" }
+        }
+        val path = FhirPath.from("active").eq("true")
+            .and(FhirPath.from("name").exists())
+        assertTrue(matches(patient, path))
+    }
+
+    @Test
+    fun `and short-circuits when second condition is false`() {
+        val patient = Patient().apply { active = true }
+        val path = FhirPath.from("active").eq("true")
+            .and(FhirPath.from("name").exists())
+        assertFalse(matches(patient, path))
+    }
+
+    // ── distinct / isDistinct ─────────────────────────────────────────────────
+
+    @Test
+    fun `distinct removes duplicate family names`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Jones" }
+        }
+        val results = evaluate(patient, FhirPath.from("name").navigate("family").distinct(), StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    @Test
+    fun `isDistinct returns true when all family names are unique`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Jones" }
+        }
+        assertTrue(matches(patient, FhirPath.from("name").navigate("family").isDistinct()))
+    }
+
+    @Test
+    fun `isDistinct returns false when duplicates exist`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Smith" }
+        }
+        assertFalse(matches(patient, FhirPath.from("name").navigate("family").isDistinct()))
+    }
+
+    // ── immutability under evaluation ─────────────────────────────────────────
+
+    @Test
+    fun `reusing a base FhirPath produces independent evaluated results`() {
+        val patient = Patient().apply {
+            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith"; addGiven("John") }
+        }
+        val base = FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("'official'"))
+
+        val family = evaluateFirst(patient, base.navigate("family"), StringType::class.java)
+        val given = evaluateFirst(patient, base.navigate("given").first(), StringType::class.java)
+
+        assertThat(family?.value, `is`("Smith"))
+        assertThat(given?.value, `is`("John"))
+        assertThat(base.build(), `is`("name.where(use = 'official')"))
+    }
+}

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/FhirPathEvaluationTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/FhirPathEvaluationTest.kt
@@ -8,6 +8,7 @@ import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.`is`
 import org.hl7.fhir.dstu3.model.BooleanType
 import org.hl7.fhir.dstu3.model.ContactPoint
+import org.hl7.fhir.dstu3.model.DecimalType
 import org.hl7.fhir.dstu3.model.HumanName
 import org.hl7.fhir.dstu3.model.IntegerType
 import org.hl7.fhir.dstu3.model.Patient
@@ -21,6 +22,9 @@ import org.junit.jupiter.api.Test
  * Validates that expressions produced by [FhirPath] are accepted and evaluated correctly by
  * HAPI's DSTU3 FHIRPath engine. A test failure here means the builder produced an invalid or
  * incorrectly structured expression string — not just a wrong expected value.
+ *
+ * Note: DSTU3 uses FHIRPath 1.0. Functions exclusive to FHIRPath 2.0 (lower, upper, trim,
+ * indexOf, split, join, replaceMatches) are not tested here.
  */
 class FhirPathEvaluationTest {
 
@@ -41,7 +45,7 @@ class FhirPathEvaluationTest {
         return if (first is BooleanType) first.booleanValue() else true
     }
 
-    // ── where + navigate ──────────────────────────────────────────────────────
+    // ── navigate ──────────────────────────────────────────────────────────────
 
     @Test
     fun `where with FhirPath condition extracts official family name`() {
@@ -139,6 +143,77 @@ class FhirPathEvaluationTest {
         assertThat(results[0].value, `is`("MRN-001"))
     }
 
+    // ── union ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `union combines two collections`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addIdentifier().apply { value = "ID-1" }
+        }
+        val results = evaluate(patient, FhirPath.from("name").union(FhirPath.from("identifier")), IBase::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    // ── collection: first, last, tail, take, skip, count, empty ──────────────
+
+    @Test
+    fun `last returns the last element`() {
+        val patient = Patient().apply {
+            addName().apply { family = "First" }
+            addName().apply { family = "Last" }
+        }
+        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").last(), StringType::class.java)
+        assertThat(result?.value, `is`("Last"))
+    }
+
+    @Test
+    fun `tail returns all but first element`() {
+        val patient = Patient().apply {
+            addName().apply { family = "First" }
+            addName().apply { family = "Second" }
+            addName().apply { family = "Third" }
+        }
+        val results = evaluate(patient, FhirPath.from("name").navigate("family").tail(), StringType::class.java)
+        assertThat(results, hasSize(2))
+        assertThat(results[0].value, `is`("Second"))
+    }
+
+    @Test
+    fun `take returns the first n elements`() {
+        val patient = Patient().apply {
+            addName().apply { family = "A" }
+            addName().apply { family = "B" }
+            addName().apply { family = "C" }
+        }
+        val results = evaluate(patient, FhirPath.from("name").navigate("family").take(2), StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    @Test
+    fun `skip omits the first n elements`() {
+        val patient = Patient().apply {
+            addName().apply { family = "A" }
+            addName().apply { family = "B" }
+            addName().apply { family = "C" }
+        }
+        val results = evaluate(patient, FhirPath.from("name").navigate("family").skip(1), StringType::class.java)
+        assertThat(results, hasSize(2))
+        assertThat(results[0].value, `is`("B"))
+    }
+
+    @Test
+    fun `empty returns true when collection is empty`() {
+        val patient = Patient()
+        assertTrue(matches(patient, FhirPath.from("name").empty()))
+    }
+
+    @Test
+    fun `empty returns false when collection has elements`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        assertFalse(matches(patient, FhirPath.from("name").empty()))
+    }
+
     // ── count / exists / all ──────────────────────────────────────────────────
 
     @Test
@@ -175,6 +250,8 @@ class FhirPathEvaluationTest {
         assertFalse(matches(patient, path))
     }
 
+    // exists(criteria) is not supported by HAPI's DSTU3 FHIRPath 1.0 engine (0 parameters only).
+
     @Test
     fun `all with FhirPath criteria returns true when every identifier has a system`() {
         val patient = Patient().apply {
@@ -193,133 +270,39 @@ class FhirPathEvaluationTest {
         assertFalse(matches(patient, FhirPath.from("identifier").all(FhirPath.relative().navigate("system").exists())))
     }
 
-    // ── string functions (DSTU3 FHIRPath 1.0 subset) ─────────────────────────
+    // allTrue/anyTrue/allFalse/anyFalse are not supported by HAPI's DSTU3 FHIRPath 1.0 engine.
+
+    // ── collection: supersetOf ───────────────────────────────────────────────
 
     @Test
-    fun `length returns character count of family name`() {
-        val patient = Patient().apply { addName().apply { family = "Smith" } }
-        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").length(), IntegerType::class.java)
-        assertThat(result?.value, `is`(5))
-    }
-
-    @Test
-    fun `substring extracts characters from family name`() {
-        val patient = Patient().apply { addName().apply { family = "Smith" } }
-        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").substring(1, 3), StringType::class.java)
-        assertThat(result?.value, `is`("mit"))
-    }
-
-    @Test
-    fun `startsWith in where condition filters names by prefix`() {
+    fun `supersetOf returns true when collection contains the other`() {
         val patient = Patient().apply {
-            addName().apply { family = "Smith" }
-            addName().apply { family = "Jones" }
-            addName().apply { family = "Smithfield" }
-        }
-        val path = FhirPath.from("name")
-            .where(FhirPath.relative().navigate("family").startsWith("Sm"))
-            .navigate("family")
-
-        val results = evaluate(patient, path, StringType::class.java)
-        assertThat(results, hasSize(2))
-    }
-
-    @Test
-    fun `endsWith in where condition filters names by suffix`() {
-        val patient = Patient().apply {
-            addName().apply { family = "Smith" }
-            addName().apply { family = "Jones" }
-            addName().apply { family = "Griffith" }
-        }
-        val path = FhirPath.from("name")
-            .where(FhirPath.relative().navigate("family").endsWith("ith"))
-            .navigate("family")
-
-        val results = evaluate(patient, path, StringType::class.java)
-        assertThat(results, hasSize(2))
-    }
-
-    // ── string function: matches regex ───────────────────────────────────────
-
-    @Test
-    fun `matches regex in where condition filters identifiers by value pattern`() {
-        val patient = Patient().apply {
-            addIdentifier().apply { system = "http://example.org/id"; value = "MRN-001" }
-            addIdentifier().apply { system = "http://example.org/id"; value = "ABC-001" }
-            addIdentifier().apply { system = "http://example.org/id"; value = "MRN-099" }
+            addIdentifier().apply { system = "http://a.org"; value = "1" }
+            addIdentifier().apply { system = "http://b.org"; value = "2" }
         }
         val path = FhirPath.from("identifier")
-            .where(FhirPath.relative().navigate("value").matches("MRN-[0-9]+"))
-            .navigate("value")
-
-        val results = evaluate(patient, path, StringType::class.java)
-        assertThat(results, hasSize(2))
-    }
-
-    // ── select projection ─────────────────────────────────────────────────────
-
-    @Test
-    fun `select projects a field from every element of a collection`() {
-        val patient = Patient().apply {
-            addName().apply { family = "Smith"; addGiven("John") }
-            addName().apply { family = "Jones"; addGiven("Jane") }
-        }
-        val results = evaluate(patient, FhirPath.from("name").select("family"), StringType::class.java)
-        assertThat(results, hasSize(2))
-    }
-
-    // ── multi-term boolean chain ──────────────────────────────────────────────
-
-    @Test
-    fun `or-then-and three-term condition filters with correct precedence`() {
-        val patient = Patient().apply {
-            addIdentifier().apply { system = "http://a.org"; value = "active-mrn" }
-            addIdentifier().apply { system = "http://b.org"; value = "passive-mrn" }
-            addIdentifier().apply { system = "http://c.org"; value = "something-else" }
-        }
-        val sysA = FhirPath.relative().navigate("system").eq("http://a.org")
-        val sysB = FhirPath.relative().navigate("system").eq("http://b.org")
-        val endsWithMrn = FhirPath.relative().navigate("value").endsWith("-mrn")
-        val path = FhirPath.from("identifier")
-            .where(sysA.or(sysB).and(endsWithMrn))
-            .navigate("value")
-
-        val results = evaluate(patient, path, StringType::class.java)
-        assertThat(results, hasSize(2))
-    }
-
-    // ── FHIR-specific: extension ──────────────────────────────────────────────
-
-    @Test
-    fun `extension function navigates to named extension value`() {
-        val patient = Patient().apply {
-            addExtension("http://example.org/color", StringType("blue"))
-        }
-        val path = FhirPath.from("Patient")
-            .extension("http://example.org/color")
-            .navigate("value")
-
-        val result = evaluateFirst(patient, path, StringType::class.java)
-        assertThat(result?.value, `is`("blue"))
-    }
-
-    @Test
-    fun `extension where url detects presence of a named extension`() {
-        val patient = Patient().apply {
-            addExtension("http://example.org/color", StringType("blue"))
-        }
-        val path = FhirPath.from("extension")
-            .where(FhirPath.relative().navigate("url").eq("http://example.org/color"))
-            .exists()
+            .supersetOf("identifier.where(system = 'http://a.org')")
         assertTrue(matches(patient, path))
     }
 
+    // ── collection: children, descendants ─────────────────────────────────────
+
     @Test
-    fun `extension where url is false when extension is absent`() {
-        val path = FhirPath.from("extension")
-            .where(FhirPath.relative().navigate("url").eq("http://example.org/color"))
-            .exists()
-        assertFalse(matches(Patient(), path))
+    fun `children returns immediate child elements`() {
+        val patient = Patient().apply {
+            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith"; addGiven("John") }
+        }
+        val results = evaluate(patient, FhirPath.from("name").first().children(), IBase::class.java)
+        assertTrue(results.isNotEmpty())
+    }
+
+    @Test
+    fun `descendants returns all nested child elements`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+        }
+        val results = evaluate(patient, FhirPath.from("name").descendants(), IBase::class.java)
+        assertTrue(results.isNotEmpty())
     }
 
     // ── boolean operators ─────────────────────────────────────────────────────
@@ -355,6 +338,231 @@ class FhirPathEvaluationTest {
         assertFalse(matches(patient, path))
     }
 
+    @Test
+    fun `xor returns true when exactly one condition holds`() {
+        val patient = Patient().apply { active = true }
+        val path = FhirPath.from("active").eq(true)
+            .xor(FhirPath.from("name").exists())
+        assertTrue(matches(patient, path))
+    }
+
+    @Test
+    fun `implies returns true when antecedent is false`() {
+        val patient = Patient().apply { active = false }
+        val path = FhirPath.from("active").eq(true)
+            .implies(FhirPath.from("name").exists())
+        assertTrue(matches(patient, path))
+    }
+
+    // ── equality / comparison operators ──────────────────────────────────────
+
+    @Test
+    fun `ne filters out the matching name`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Jones" }
+        }
+        val results = evaluate(patient,
+            FhirPath.from("name").where(FhirPath.relative().navigate("family").ne("Smith")).navigate("family"),
+            StringType::class.java)
+        assertThat(results, hasSize(1))
+        assertThat(results[0].value, `is`("Jones"))
+    }
+
+    @Test
+    fun `lt filters names with family lexicographically before threshold`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Adams" }
+            addName().apply { family = "Smith" }
+        }
+        val results = evaluate(patient,
+            FhirPath.from("name").where(FhirPath.relative().navigate("family").lt("M")).navigate("family"),
+            StringType::class.java)
+        assertThat(results, hasSize(1))
+        assertThat(results[0].value, `is`("Adams"))
+    }
+
+    @Test
+    fun `gt filters names with family lexicographically after threshold`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Adams" }
+            addName().apply { family = "Smith" }
+        }
+        val results = evaluate(patient,
+            FhirPath.from("name").where(FhirPath.relative().navigate("family").gt("M")).navigate("family"),
+            StringType::class.java)
+        assertThat(results, hasSize(1))
+        assertThat(results[0].value, `is`("Smith"))
+    }
+
+    @Test
+    fun `le filters names up to and including threshold`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Adams" }
+            addName().apply { family = "Smith" }
+        }
+        val results = evaluate(patient,
+            FhirPath.from("name").where(FhirPath.relative().navigate("family").le("Smith")).navigate("family"),
+            StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    @Test
+    fun `ge filters names from threshold upward`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Adams" }
+            addName().apply { family = "Smith" }
+        }
+        val results = evaluate(patient,
+            FhirPath.from("name").where(FhirPath.relative().navigate("family").ge("Smith")).navigate("family"),
+            StringType::class.java)
+        assertThat(results, hasSize(1))
+        assertThat(results[0].value, `is`("Smith"))
+    }
+
+    @Test
+    fun `equiv matches strings case-insensitively`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        assertTrue(matches(patient, FhirPath.from("name").navigate("family").first().equiv("smith")))
+    }
+
+    @Test
+    fun `notEquiv returns true for different values`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        assertTrue(matches(patient, FhirPath.from("name").navigate("family").first().notEquiv("jones")))
+    }
+
+    @Test
+    fun `containsValue returns true when collection contains the item`() {
+        val patient = Patient().apply {
+            addName().apply { addGiven("John"); addGiven("William") }
+        }
+        assertTrue(matches(patient, FhirPath.from("name").navigate("given").containsValue("John")))
+    }
+
+    // ── string functions (DSTU3 FHIRPath 1.0 subset) ─────────────────────────
+    // Note: lower, upper, trim, indexOf, split, join, replaceMatches are FHIRPath 2.0 only
+
+    @Test
+    fun `length returns character count of family name`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").length(), IntegerType::class.java)
+        assertThat(result?.value, `is`(5))
+    }
+
+    @Test
+    fun `substring extracts characters from family name`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").substring(1, 3), StringType::class.java)
+        assertThat(result?.value, `is`("mit"))
+    }
+
+    @Test
+    fun `substring with only start returns rest of string`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").substring(2), StringType::class.java)
+        assertThat(result?.value, `is`("ith"))
+    }
+
+    @Test
+    fun `startsWith in where condition filters names by prefix`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Jones" }
+            addName().apply { family = "Smithfield" }
+        }
+        val path = FhirPath.from("name")
+            .where(FhirPath.relative().navigate("family").startsWith("Sm"))
+            .navigate("family")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    @Test
+    fun `endsWith in where condition filters names by suffix`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Jones" }
+            addName().apply { family = "Griffith" }
+        }
+        val path = FhirPath.from("name")
+            .where(FhirPath.relative().navigate("family").endsWith("ith"))
+            .navigate("family")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    @Test
+    fun `contains detects substring in family name`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smithfield" }
+            addName().apply { family = "Jones" }
+        }
+        val results = evaluate(patient,
+            FhirPath.from("name").where(FhirPath.relative().navigate("family").contains("mith")).navigate("family"),
+            StringType::class.java)
+        assertThat(results, hasSize(1))
+        assertThat(results[0].value, `is`("Smithfield"))
+    }
+
+    @Test
+    fun `matches regex in where condition filters identifiers by value pattern`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { system = "http://example.org/id"; value = "MRN-001" }
+            addIdentifier().apply { system = "http://example.org/id"; value = "ABC-001" }
+            addIdentifier().apply { system = "http://example.org/id"; value = "MRN-099" }
+        }
+        val path = FhirPath.from("identifier")
+            .where(FhirPath.relative().navigate("value").matches("MRN-[0-9]+"))
+            .navigate("value")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    @Test
+    fun `replace substitutes a pattern in a string`() {
+        val patient = Patient().apply { addName().apply { family = "Smith-Jones" } }
+        val result = evaluateFirst(patient,
+            FhirPath.from("name").navigate("family").replace("-", " "),
+            StringType::class.java)
+        assertThat(result?.value, `is`("Smith Jones"))
+    }
+
+    // ── select projection ─────────────────────────────────────────────────────
+
+    @Test
+    fun `select projects a field from every element of a collection`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith"; addGiven("John") }
+            addName().apply { family = "Jones"; addGiven("Jane") }
+        }
+        val results = evaluate(patient, FhirPath.from("name").select("family"), StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    // ── multi-term boolean chain ──────────────────────────────────────────────
+
+    @Test
+    fun `or-then-and three-term condition filters with correct precedence`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { system = "http://a.org"; value = "active-mrn" }
+            addIdentifier().apply { system = "http://b.org"; value = "passive-mrn" }
+            addIdentifier().apply { system = "http://c.org"; value = "something-else" }
+        }
+        val sysA = FhirPath.relative().navigate("system").eq("http://a.org")
+        val sysB = FhirPath.relative().navigate("system").eq("http://b.org")
+        val endsWithMrn = FhirPath.relative().navigate("value").endsWith("-mrn")
+        val path = FhirPath.from("identifier")
+            .where(sysA.or(sysB).and(endsWithMrn))
+            .navigate("value")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
     // ── distinct / isDistinct ─────────────────────────────────────────────────
 
     @Test
@@ -384,6 +592,117 @@ class FhirPathEvaluationTest {
             addName().apply { family = "Smith" }
         }
         assertFalse(matches(patient, FhirPath.from("name").navigate("family").isDistinct()))
+    }
+
+    // Math functions (abs, ceiling, floor, round, sqrt, truncate, power) are not supported
+    // by HAPI's DSTU3 FHIRPath 1.0 engine. Use R4 for expressions requiring math functions.
+
+    // ── arithmetic operators ──────────────────────────────────────────────────
+
+    @Test
+    fun `plus adds integer to count`() {
+        val patient = Patient().apply { addName(); addName() }
+        val result = evaluateFirst(patient, FhirPath.from("name").count().plus("1"), IntegerType::class.java)
+        assertThat(result?.value, `is`(3))
+    }
+
+    @Test
+    fun `minus subtracts integer from count`() {
+        val patient = Patient().apply { addName(); addName(); addName() }
+        val result = evaluateFirst(patient, FhirPath.from("name").count().minus("1"), IntegerType::class.java)
+        assertThat(result?.value, `is`(2))
+    }
+
+    @Test
+    fun `times multiplies count by integer`() {
+        val patient = Patient().apply { addName(); addName() }
+        val result = evaluateFirst(patient, FhirPath.from("name").count().times("3"), IntegerType::class.java)
+        assertThat(result?.value, `is`(6))
+    }
+
+    @Test
+    fun `dividedBy divides count`() {
+        val patient = Patient().apply { addName(); addName(); addName(); addName() }
+        val result = evaluateFirst(patient, FhirPath.from("name").count().dividedBy("2"), DecimalType::class.java)
+        assertThat(result?.value?.toDouble(), `is`(2.0))
+    }
+
+    @Test
+    fun `div performs integer division`() {
+        val patient = Patient().apply { addName(); addName(); addName() }
+        val result = evaluateFirst(patient, FhirPath.from("name").count().div("2"), IntegerType::class.java)
+        assertThat(result?.value, `is`(1))
+    }
+
+    @Test
+    fun `mod returns remainder`() {
+        val patient = Patient().apply { addName(); addName(); addName() }
+        val result = evaluateFirst(patient, FhirPath.from("name").count().mod("2"), IntegerType::class.java)
+        assertThat(result?.value, `is`(1))
+    }
+
+    @Test
+    fun `concat joins strings with ampersand`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        val result = evaluateFirst(patient,
+            FhirPath.from("name").navigate("family").first().concat("' Jr.'"),
+            StringType::class.java)
+        assertThat(result?.value, `is`("Smith Jr."))
+    }
+
+    // ── type conversion ───────────────────────────────────────────────────────
+    // toBoolean, toInteger, toQuantity are not supported by HAPI's DSTU3 FHIRPath 1.0 engine.
+
+    @Test
+    fun `toDecimal converts an integer to decimal`() {
+        val patient = Patient().apply { addName(); addName() }
+        val result = evaluateFirst(patient, FhirPath.from("name").count().toDecimal(), DecimalType::class.java)
+        assertThat(result?.value?.toDouble(), `is`(2.0))
+    }
+
+    // ── FHIR-specific ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `extension navigates to a named extension value`() {
+        val patient = Patient().apply {
+            addExtension("http://example.org/color", StringType("blue"))
+        }
+        val path = FhirPath.from("Patient")
+            .extension("http://example.org/color")
+            .navigate("value")
+
+        val result = evaluateFirst(patient, path, StringType::class.java)
+        assertThat(result?.value, `is`("blue"))
+    }
+
+    @Test
+    fun `extension where url detects presence of a named extension`() {
+        val patient = Patient().apply {
+            addExtension("http://example.org/color", StringType("blue"))
+        }
+        val path = FhirPath.from("extension")
+            .where(FhirPath.relative().navigate("url").eq("http://example.org/color"))
+            .exists()
+        assertTrue(matches(patient, path))
+    }
+
+    @Test
+    fun `extension where url is false when extension is absent`() {
+        val path = FhirPath.from("extension")
+            .where(FhirPath.relative().navigate("url").eq("http://example.org/color"))
+            .exists()
+        assertFalse(matches(Patient(), path))
+    }
+
+    @Test
+    fun `resolve returns empty collection without server resolver`() {
+        val patient = Patient().apply {
+            addGeneralPractitioner().reference = "Practitioner/123"
+        }
+        val results = evaluate(patient,
+            FhirPath.from("generalPractitioner").resolve(),
+            IBase::class.java)
+        assertTrue(results.isEmpty())
     }
 
     // ── immutability under evaluation ─────────────────────────────────────────

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/FhirPathEvaluationTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/FhirPathEvaluationTest.kt
@@ -50,7 +50,7 @@ class FhirPathEvaluationTest {
             addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
         }
         val path = FhirPath.from("name")
-            .where(FhirPath.relative().navigate("use").eq("'official'"))
+            .where(FhirPath.relative().navigate("use").eq("official"))
             .navigate("family")
 
         val results = evaluate(patient, path, StringType::class.java)
@@ -70,7 +70,7 @@ class FhirPathEvaluationTest {
             addName().apply { use = HumanName.NameUse.NICKNAME; addGiven("Johnny") }
         }
         val path = FhirPath.from("name")
-            .where(FhirPath.relative().navigate("use").eq("'official'"))
+            .where(FhirPath.relative().navigate("use").eq("official"))
             .navigate("given")
             .first()
 
@@ -85,7 +85,7 @@ class FhirPathEvaluationTest {
             addName().apply { use = HumanName.NameUse.OFFICIAL }     // no family
             addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
         }
-        val condition = FhirPath.relative().navigate("use").eq("'official'")
+        val condition = FhirPath.relative().navigate("use").eq("official")
             .and(FhirPath.relative().navigate("family").exists())
         val path = FhirPath.from("name").where(condition).navigate("family")
 
@@ -101,8 +101,8 @@ class FhirPathEvaluationTest {
             addTelecom().apply { system = ContactPoint.ContactPointSystem.EMAIL; value = "j@example.org" }
             addTelecom().apply { system = ContactPoint.ContactPointSystem.FAX; value = "555-0000" }
         }
-        val phoneOrEmail = FhirPath.relative().navigate("system").eq("'phone'")
-            .or(FhirPath.relative().navigate("system").eq("'email'"))
+        val phoneOrEmail = FhirPath.relative().navigate("system").eq("phone")
+            .or(FhirPath.relative().navigate("system").eq("email"))
         val path = FhirPath.from("telecom").where(phoneOrEmail).navigate("value")
 
         val results = evaluate(patient, path, StringType::class.java)
@@ -116,7 +116,7 @@ class FhirPathEvaluationTest {
             addIdentifier().apply { system = "http://example.org/ssn"; value = "123-45-6789" }
         }
         val path = FhirPath.from("identifier")
-            .where(FhirPath.relative().navigate("system").eq("'http://example.org/mrn'"))
+            .where(FhirPath.relative().navigate("system").eq("http://example.org/mrn"))
             .navigate("value")
 
         val result = evaluateFirst(patient, path, StringType::class.java)
@@ -130,8 +130,8 @@ class FhirPathEvaluationTest {
             addIdentifier().apply { system = "http://example.org/mrn"; value = "OLD-001" }
             addIdentifier().apply { system = "http://example.org/ssn"; value = "MRN-999" }
         }
-        val condition = FhirPath.relative().navigate("system").eq("'http://example.org/mrn'")
-            .and(FhirPath.relative().navigate("value").startsWith("'MRN-'"))
+        val condition = FhirPath.relative().navigate("system").eq("http://example.org/mrn")
+            .and(FhirPath.relative().navigate("value").startsWith("MRN-"))
         val path = FhirPath.from("identifier").where(condition).navigate("value")
 
         val results = evaluate(patient, path, StringType::class.java)
@@ -149,7 +149,7 @@ class FhirPathEvaluationTest {
             addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
         }
         val path = FhirPath.from("name")
-            .where(FhirPath.relative().navigate("use").eq("'official'"))
+            .where(FhirPath.relative().navigate("use").eq("official"))
             .count()
 
         val result = evaluateFirst(patient, path, IntegerType::class.java)
@@ -162,7 +162,7 @@ class FhirPathEvaluationTest {
             addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith" }
             addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
         }
-        val path = FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("'official'")).exists()
+        val path = FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("official")).exists()
         assertTrue(matches(patient, path))
     }
 
@@ -171,7 +171,7 @@ class FhirPathEvaluationTest {
         val patient = Patient().apply {
             addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
         }
-        val path = FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("'official'")).exists()
+        val path = FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("official")).exists()
         assertFalse(matches(patient, path))
     }
 
@@ -217,7 +217,7 @@ class FhirPathEvaluationTest {
             addName().apply { family = "Smithfield" }
         }
         val path = FhirPath.from("name")
-            .where(FhirPath.relative().navigate("family").startsWith("'Sm'"))
+            .where(FhirPath.relative().navigate("family").startsWith("Sm"))
             .navigate("family")
 
         val results = evaluate(patient, path, StringType::class.java)
@@ -232,7 +232,7 @@ class FhirPathEvaluationTest {
             addName().apply { family = "Griffith" }
         }
         val path = FhirPath.from("name")
-            .where(FhirPath.relative().navigate("family").endsWith("'ith'"))
+            .where(FhirPath.relative().navigate("family").endsWith("ith"))
             .navigate("family")
 
         val results = evaluate(patient, path, StringType::class.java)
@@ -249,7 +249,7 @@ class FhirPathEvaluationTest {
             addIdentifier().apply { system = "http://example.org/id"; value = "MRN-099" }
         }
         val path = FhirPath.from("identifier")
-            .where(FhirPath.relative().navigate("value").matches("'MRN-[0-9]+'"))
+            .where(FhirPath.relative().navigate("value").matches("MRN-[0-9]+"))
             .navigate("value")
 
         val results = evaluate(patient, path, StringType::class.java)
@@ -277,9 +277,9 @@ class FhirPathEvaluationTest {
             addIdentifier().apply { system = "http://b.org"; value = "passive-mrn" }
             addIdentifier().apply { system = "http://c.org"; value = "something-else" }
         }
-        val sysA = FhirPath.relative().navigate("system").eq("'http://a.org'")
-        val sysB = FhirPath.relative().navigate("system").eq("'http://b.org'")
-        val endsWithMrn = FhirPath.relative().navigate("value").endsWith("'-mrn'")
+        val sysA = FhirPath.relative().navigate("system").eq("http://a.org")
+        val sysB = FhirPath.relative().navigate("system").eq("http://b.org")
+        val endsWithMrn = FhirPath.relative().navigate("value").endsWith("-mrn")
         val path = FhirPath.from("identifier")
             .where(sysA.or(sysB).and(endsWithMrn))
             .navigate("value")
@@ -309,7 +309,7 @@ class FhirPathEvaluationTest {
             addExtension("http://example.org/color", StringType("blue"))
         }
         val path = FhirPath.from("extension")
-            .where(FhirPath.relative().navigate("url").eq("'http://example.org/color'"))
+            .where(FhirPath.relative().navigate("url").eq("http://example.org/color"))
             .exists()
         assertTrue(matches(patient, path))
     }
@@ -317,7 +317,7 @@ class FhirPathEvaluationTest {
     @Test
     fun `extension where url is false when extension is absent`() {
         val path = FhirPath.from("extension")
-            .where(FhirPath.relative().navigate("url").eq("'http://example.org/color'"))
+            .where(FhirPath.relative().navigate("url").eq("http://example.org/color"))
             .exists()
         assertFalse(matches(Patient(), path))
     }
@@ -342,7 +342,7 @@ class FhirPathEvaluationTest {
             active = true
             addName().apply { family = "Smith" }
         }
-        val path = FhirPath.from("active").eq("true")
+        val path = FhirPath.from("active").eq(true)
             .and(FhirPath.from("name").exists())
         assertTrue(matches(patient, path))
     }
@@ -350,7 +350,7 @@ class FhirPathEvaluationTest {
     @Test
     fun `and short-circuits when second condition is false`() {
         val patient = Patient().apply { active = true }
-        val path = FhirPath.from("active").eq("true")
+        val path = FhirPath.from("active").eq(true)
             .and(FhirPath.from("name").exists())
         assertFalse(matches(patient, path))
     }
@@ -393,7 +393,7 @@ class FhirPathEvaluationTest {
         val patient = Patient().apply {
             addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith"; addGiven("John") }
         }
-        val base = FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("'official'"))
+        val base = FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("official"))
 
         val family = evaluateFirst(patient, base.navigate("family"), StringType::class.java)
         val given = evaluateFirst(patient, base.navigate("given").first(), StringType::class.java)

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/FhirPathEvaluationTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/FhirPathEvaluationTest.kt
@@ -50,7 +50,7 @@ class FhirPathEvaluationTest {
             addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
         }
         val path = FhirPath.from("name")
-            .where(FhirPath.relative().navigate("use").eq("'official'"))
+            .where(FhirPath.relative().navigate("use").eq("official"))
             .navigate("family")
 
         val results = evaluate(patient, path, StringType::class.java)
@@ -70,7 +70,7 @@ class FhirPathEvaluationTest {
             addName().apply { use = HumanName.NameUse.NICKNAME; addGiven("Johnny") }
         }
         val path = FhirPath.from("name")
-            .where(FhirPath.relative().navigate("use").eq("'official'"))
+            .where(FhirPath.relative().navigate("use").eq("official"))
             .navigate("given")
             .first()
 
@@ -85,7 +85,7 @@ class FhirPathEvaluationTest {
             addName().apply { use = HumanName.NameUse.OFFICIAL }     // no family
             addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
         }
-        val condition = FhirPath.relative().navigate("use").eq("'official'")
+        val condition = FhirPath.relative().navigate("use").eq("official")
             .and(FhirPath.relative().navigate("family").exists())
         val path = FhirPath.from("name").where(condition).navigate("family")
 
@@ -101,8 +101,8 @@ class FhirPathEvaluationTest {
             addTelecom().apply { system = ContactPoint.ContactPointSystem.EMAIL; value = "j@example.org" }
             addTelecom().apply { system = ContactPoint.ContactPointSystem.FAX; value = "555-0000" }
         }
-        val phoneOrEmail = FhirPath.relative().navigate("system").eq("'phone'")
-            .or(FhirPath.relative().navigate("system").eq("'email'"))
+        val phoneOrEmail = FhirPath.relative().navigate("system").eq("phone")
+            .or(FhirPath.relative().navigate("system").eq("email"))
         val path = FhirPath.from("telecom").where(phoneOrEmail).navigate("value")
 
         val results = evaluate(patient, path, StringType::class.java)
@@ -116,7 +116,7 @@ class FhirPathEvaluationTest {
             addIdentifier().apply { system = "http://example.org/ssn"; value = "123-45-6789" }
         }
         val path = FhirPath.from("identifier")
-            .where(FhirPath.relative().navigate("system").eq("'http://example.org/mrn'"))
+            .where(FhirPath.relative().navigate("system").eq("http://example.org/mrn"))
             .navigate("value")
 
         val result = evaluateFirst(patient, path, StringType::class.java)
@@ -130,8 +130,8 @@ class FhirPathEvaluationTest {
             addIdentifier().apply { system = "http://example.org/mrn"; value = "OLD-001" }
             addIdentifier().apply { system = "http://example.org/ssn"; value = "MRN-999" }
         }
-        val condition = FhirPath.relative().navigate("system").eq("'http://example.org/mrn'")
-            .and(FhirPath.relative().navigate("value").startsWith("'MRN-'"))
+        val condition = FhirPath.relative().navigate("system").eq("http://example.org/mrn")
+            .and(FhirPath.relative().navigate("value").startsWith("MRN-"))
         val path = FhirPath.from("identifier").where(condition).navigate("value")
 
         val results = evaluate(patient, path, StringType::class.java)
@@ -149,7 +149,7 @@ class FhirPathEvaluationTest {
             addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
         }
         val path = FhirPath.from("name")
-            .where(FhirPath.relative().navigate("use").eq("'official'"))
+            .where(FhirPath.relative().navigate("use").eq("official"))
             .count()
 
         val result = evaluateFirst(patient, path, IntegerType::class.java)
@@ -162,7 +162,7 @@ class FhirPathEvaluationTest {
             addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith" }
             addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
         }
-        assertTrue(matches(patient, FhirPath.from("name").exists(FhirPath.relative().navigate("use").eq("'official'"))))
+        assertTrue(matches(patient, FhirPath.from("name").exists(FhirPath.relative().navigate("use").eq("official"))))
     }
 
     @Test
@@ -170,7 +170,7 @@ class FhirPathEvaluationTest {
         val patient = Patient().apply {
             addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
         }
-        assertFalse(matches(patient, FhirPath.from("name").exists(FhirPath.relative().navigate("use").eq("'official'"))))
+        assertFalse(matches(patient, FhirPath.from("name").exists(FhirPath.relative().navigate("use").eq("official"))))
     }
 
     @Test
@@ -222,7 +222,7 @@ class FhirPathEvaluationTest {
             addName().apply { family = "Smithfield" }
         }
         val path = FhirPath.from("name")
-            .where(FhirPath.relative().navigate("family").startsWith("'Sm'"))
+            .where(FhirPath.relative().navigate("family").startsWith("Sm"))
             .navigate("family")
 
         val results = evaluate(patient, path, StringType::class.java)
@@ -236,7 +236,7 @@ class FhirPathEvaluationTest {
             addName().apply { family = "Jones" }
         }
         val path = FhirPath.from("name")
-            .where(FhirPath.relative().navigate("family").upper().eq("'SMITH'"))
+            .where(FhirPath.relative().navigate("family").upper().eq("SMITH"))
             .navigate("family")
 
         val results = evaluate(patient, path, StringType::class.java)
@@ -254,7 +254,7 @@ class FhirPathEvaluationTest {
             addIdentifier().apply { system = "http://example.org/id"; value = "MRN-099" }
         }
         val path = FhirPath.from("identifier")
-            .where(FhirPath.relative().navigate("value").matches("'MRN-[0-9]+'"))
+            .where(FhirPath.relative().navigate("value").matches("MRN-[0-9]+"))
             .navigate("value")
 
         val results = evaluate(patient, path, StringType::class.java)
@@ -282,9 +282,9 @@ class FhirPathEvaluationTest {
             addIdentifier().apply { system = "http://b.org"; value = "passive-mrn" }
             addIdentifier().apply { system = "http://c.org"; value = "something-else" }
         }
-        val sysA = FhirPath.relative().navigate("system").eq("'http://a.org'")
-        val sysB = FhirPath.relative().navigate("system").eq("'http://b.org'")
-        val endsWithMrn = FhirPath.relative().navigate("value").endsWith("'-mrn'")
+        val sysA = FhirPath.relative().navigate("system").eq("http://a.org")
+        val sysB = FhirPath.relative().navigate("system").eq("http://b.org")
+        val endsWithMrn = FhirPath.relative().navigate("value").endsWith("-mrn")
         val path = FhirPath.from("identifier")
             .where(sysA.or(sysB).and(endsWithMrn))
             .navigate("value")
@@ -314,7 +314,7 @@ class FhirPathEvaluationTest {
             addExtension("http://example.org/color", StringType("blue"))
         }
         val path = FhirPath.from("extension")
-            .where(FhirPath.relative().navigate("url").eq("'http://example.org/color'"))
+            .where(FhirPath.relative().navigate("url").eq("http://example.org/color"))
             .exists()
         assertTrue(matches(patient, path))
     }
@@ -322,7 +322,7 @@ class FhirPathEvaluationTest {
     @Test
     fun `extension where url is false when extension is absent`() {
         val path = FhirPath.from("extension")
-            .where(FhirPath.relative().navigate("url").eq("'http://example.org/color'"))
+            .where(FhirPath.relative().navigate("url").eq("http://example.org/color"))
             .exists()
         assertFalse(matches(Patient(), path))
     }
@@ -347,7 +347,7 @@ class FhirPathEvaluationTest {
             active = true
             addName().apply { family = "Smith" }
         }
-        val path = FhirPath.from("active").eq("true")
+        val path = FhirPath.from("active").eq(true)
             .and(FhirPath.from("name").exists())
         assertTrue(matches(patient, path))
     }
@@ -355,7 +355,7 @@ class FhirPathEvaluationTest {
     @Test
     fun `and short-circuits when second condition is false`() {
         val patient = Patient().apply { active = true }
-        val path = FhirPath.from("active").eq("true")
+        val path = FhirPath.from("active").eq(true)
             .and(FhirPath.from("name").exists())
         assertFalse(matches(patient, path))
     }
@@ -398,7 +398,7 @@ class FhirPathEvaluationTest {
         val patient = Patient().apply {
             addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith"; addGiven("John") }
         }
-        val base = FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("'official'"))
+        val base = FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("official"))
 
         val family = evaluateFirst(patient, base.navigate("family"), StringType::class.java)
         val given = evaluateFirst(patient, base.navigate("given").first(), StringType::class.java)

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/FhirPathEvaluationTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/FhirPathEvaluationTest.kt
@@ -9,13 +9,19 @@ import org.hamcrest.Matchers.`is`
 import org.hl7.fhir.instance.model.api.IBase
 import org.hl7.fhir.r4.model.BooleanType
 import org.hl7.fhir.r4.model.ContactPoint
+import org.hl7.fhir.r4.model.DecimalType
 import org.hl7.fhir.r4.model.HumanName
 import org.hl7.fhir.r4.model.IntegerType
+import org.hl7.fhir.r4.model.Observation
 import org.hl7.fhir.r4.model.Patient
+import org.hl7.fhir.r4.model.Quantity
+import org.hl7.fhir.r4.model.Reference
 import org.hl7.fhir.r4.model.StringType
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 
 /**
  * Validates that expressions produced by [FhirPath] are accepted and evaluated correctly by
@@ -41,7 +47,10 @@ class FhirPathEvaluationTest {
         return if (first is BooleanType) first.booleanValue() else true
     }
 
-    // ── where + navigate ──────────────────────────────────────────────────────
+    private fun obsWithQuantity(v: Double): Observation =
+        Observation().also { it.value = Quantity().setValue(BigDecimal.valueOf(v)) }
+
+    // ── navigate ──────────────────────────────────────────────────────────────
 
     @Test
     fun `where with FhirPath condition extracts official family name`() {
@@ -49,318 +58,159 @@ class FhirPathEvaluationTest {
             addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith" }
             addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
         }
-        val path = FhirPath.from("name")
+        val results = evaluate(patient, FhirPath.from("name")
             .where(FhirPath.relative().navigate("use").eq("official"))
-            .navigate("family")
-
-        val results = evaluate(patient, path, StringType::class.java)
+            .navigate("family"), StringType::class.java)
         assertThat(results, hasSize(1))
         assertThat(results[0].value, `is`("Smith"))
     }
 
     @Test
-    fun `chained where and first extracts first given name from official name`() {
+    fun `union combines two field collections into one`() {
         val patient = Patient().apply {
-            addName().apply {
-                use = HumanName.NameUse.OFFICIAL
-                family = "Smith"
-                addGiven("John")
-                addGiven("William")
-            }
-            addName().apply { use = HumanName.NameUse.NICKNAME; addGiven("Johnny") }
+            addName().apply { addGiven("John"); family = "Smith" }
         }
-        val path = FhirPath.from("name")
-            .where(FhirPath.relative().navigate("use").eq("official"))
-            .navigate("given")
-            .first()
-
-        val result = evaluateFirst(patient, path, StringType::class.java)
-        assertThat(result?.value, `is`("John"))
-    }
-
-    @Test
-    fun `and condition filters names that have both official use and a family`() {
-        val patient = Patient().apply {
-            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith" }
-            addName().apply { use = HumanName.NameUse.OFFICIAL }     // no family
-            addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
-        }
-        val condition = FhirPath.relative().navigate("use").eq("official")
-            .and(FhirPath.relative().navigate("family").exists())
-        val path = FhirPath.from("name").where(condition).navigate("family")
-
-        val results = evaluate(patient, path, StringType::class.java)
-        assertThat(results, hasSize(1))
-        assertThat(results[0].value, `is`("Smith"))
-    }
-
-    @Test
-    fun `or condition finds both phone and email telecom values`() {
-        val patient = Patient().apply {
-            addTelecom().apply { system = ContactPoint.ContactPointSystem.PHONE; value = "555-1234" }
-            addTelecom().apply { system = ContactPoint.ContactPointSystem.EMAIL; value = "j@example.org" }
-            addTelecom().apply { system = ContactPoint.ContactPointSystem.FAX; value = "555-0000" }
-        }
-        val phoneOrEmail = FhirPath.relative().navigate("system").eq("phone")
-            .or(FhirPath.relative().navigate("system").eq("email"))
-        val path = FhirPath.from("telecom").where(phoneOrEmail).navigate("value")
-
+        val path = FhirPath.from("name").navigate("given")
+            .union(FhirPath.from("name").navigate("family"))
         val results = evaluate(patient, path, StringType::class.java)
         assertThat(results, hasSize(2))
     }
 
-    @Test
-    fun `identifier where system extracts MRN value`() {
-        val patient = Patient().apply {
-            addIdentifier().apply { system = "http://example.org/mrn"; value = "MRN-001" }
-            addIdentifier().apply { system = "http://example.org/ssn"; value = "123-45-6789" }
-        }
-        val path = FhirPath.from("identifier")
-            .where(FhirPath.relative().navigate("system").eq("http://example.org/mrn"))
-            .navigate("value")
+    // ── collection: first, last, tail, take, skip ─────────────────────────────
 
-        val result = evaluateFirst(patient, path, StringType::class.java)
-        assertThat(result?.value, `is`("MRN-001"))
+    @Test
+    fun `first returns the first element`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Alpha" }
+            addName().apply { family = "Beta" }
+        }
+        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").first(), StringType::class.java)
+        assertThat(result?.value, `is`("Alpha"))
     }
 
     @Test
-    fun `and on identifier filters by system and value prefix`() {
+    fun `last returns the final element`() {
         val patient = Patient().apply {
-            addIdentifier().apply { system = "http://example.org/mrn"; value = "MRN-001" }
-            addIdentifier().apply { system = "http://example.org/mrn"; value = "OLD-001" }
-            addIdentifier().apply { system = "http://example.org/ssn"; value = "MRN-999" }
+            addName().apply { family = "Alpha" }
+            addName().apply { family = "Beta" }
+            addName().apply { family = "Gamma" }
         }
-        val condition = FhirPath.relative().navigate("system").eq("http://example.org/mrn")
-            .and(FhirPath.relative().navigate("value").startsWith("MRN-"))
-        val path = FhirPath.from("identifier").where(condition).navigate("value")
-
-        val results = evaluate(patient, path, StringType::class.java)
-        assertThat(results, hasSize(1))
-        assertThat(results[0].value, `is`("MRN-001"))
+        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").last(), StringType::class.java)
+        assertThat(result?.value, `is`("Gamma"))
     }
 
-    // ── count / exists / all ──────────────────────────────────────────────────
+    @Test
+    fun `tail returns all but the first element`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Alpha" }
+            addName().apply { family = "Beta" }
+            addName().apply { family = "Gamma" }
+        }
+        val results = evaluate(patient, FhirPath.from("name").navigate("family").tail(), StringType::class.java)
+        assertThat(results, hasSize(2))
+        assertThat(results[0].value, `is`("Beta"))
+    }
 
     @Test
-    fun `count of filtered list returns correct total`() {
+    fun `take returns the first n elements`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Alpha" }
+            addName().apply { family = "Beta" }
+            addName().apply { family = "Gamma" }
+        }
+        val results = evaluate(patient, FhirPath.from("name").navigate("family").take(2), StringType::class.java)
+        assertThat(results, hasSize(2))
+        assertThat(results[0].value, `is`("Alpha"))
+    }
+
+    @Test
+    fun `skip omits the first n elements`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Alpha" }
+            addName().apply { family = "Beta" }
+            addName().apply { family = "Gamma" }
+        }
+        val results = evaluate(patient, FhirPath.from("name").navigate("family").skip(1), StringType::class.java)
+        assertThat(results, hasSize(2))
+        assertThat(results[0].value, `is`("Beta"))
+    }
+
+    // ── collection: count, empty, exists, all ─────────────────────────────────
+
+    @Test
+    fun `count returns the number of elements`() {
         val patient = Patient().apply {
             addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith" }
             addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Jones" }
             addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
         }
-        val path = FhirPath.from("name")
-            .where(FhirPath.relative().navigate("use").eq("official"))
-            .count()
-
-        val result = evaluateFirst(patient, path, IntegerType::class.java)
+        val result = evaluateFirst(patient,
+            FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("official")).count(),
+            IntegerType::class.java)
         assertThat(result?.value, `is`(2))
+    }
+
+    @Test
+    fun `empty returns true when collection is empty`() {
+        assertTrue(matches(Patient(), FhirPath.from("name").empty()))
+    }
+
+    @Test
+    fun `empty returns false when collection has elements`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        assertFalse(matches(patient, FhirPath.from("name").empty()))
     }
 
     @Test
     fun `exists with FhirPath criteria detects matching element`() {
         val patient = Patient().apply {
-            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith" }
-            addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
+            addName().apply { use = HumanName.NameUse.OFFICIAL }
         }
         assertTrue(matches(patient, FhirPath.from("name").exists(FhirPath.relative().navigate("use").eq("official"))))
     }
 
     @Test
-    fun `exists with FhirPath criteria is false when no element matches`() {
+    fun `all with FhirPath criteria is true when every element matches`() {
         val patient = Patient().apply {
-            addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
-        }
-        assertFalse(matches(patient, FhirPath.from("name").exists(FhirPath.relative().navigate("use").eq("official"))))
-    }
-
-    @Test
-    fun `all with FhirPath criteria returns true when every identifier has a system`() {
-        val patient = Patient().apply {
-            addIdentifier().apply { system = "http://example.org/mrn"; value = "12345" }
-            addIdentifier().apply { system = "http://example.org/ssn"; value = "999-99-9999" }
+            addIdentifier().apply { system = "http://example.org/mrn"; value = "1" }
+            addIdentifier().apply { system = "http://example.org/ssn"; value = "2" }
         }
         assertTrue(matches(patient, FhirPath.from("identifier").all(FhirPath.relative().navigate("system").exists())))
     }
 
-    @Test
-    fun `all with FhirPath criteria returns false when an identifier lacks a system`() {
-        val patient = Patient().apply {
-            addIdentifier().apply { system = "http://example.org/mrn"; value = "12345" }
-            addIdentifier().apply { value = "orphan" }
-        }
-        assertFalse(matches(patient, FhirPath.from("identifier").all(FhirPath.relative().navigate("system").exists())))
-    }
-
-    // ── string functions ──────────────────────────────────────────────────────
+    // ── collection: allTrue, anyTrue, allFalse, anyFalse ─────────────────────
 
     @Test
-    fun `lower converts family name to lowercase`() {
-        val patient = Patient().apply { addName().apply { family = "SMITH" } }
-        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").lower(), StringType::class.java)
-        assertThat(result?.value, `is`("smith"))
-    }
-
-    @Test
-    fun `upper converts family name to uppercase`() {
-        val patient = Patient().apply { addName().apply { family = "smith" } }
-        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").upper(), StringType::class.java)
-        assertThat(result?.value, `is`("SMITH"))
-    }
-
-    @Test
-    fun `length returns character count of family name`() {
-        val patient = Patient().apply { addName().apply { family = "Smith" } }
-        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").length(), IntegerType::class.java)
-        assertThat(result?.value, `is`(5))
-    }
-
-    @Test
-    fun `startsWith in where condition filters names by prefix`() {
-        val patient = Patient().apply {
-            addName().apply { family = "Smith" }
-            addName().apply { family = "Jones" }
-            addName().apply { family = "Smithfield" }
-        }
-        val path = FhirPath.from("name")
-            .where(FhirPath.relative().navigate("family").startsWith("Sm"))
-            .navigate("family")
-
-        val results = evaluate(patient, path, StringType::class.java)
-        assertThat(results, hasSize(2))
-    }
-
-    @Test
-    fun `upper in where condition enables case-insensitive family match`() {
-        val patient = Patient().apply {
-            addName().apply { family = "smith" }
-            addName().apply { family = "Jones" }
-        }
-        val path = FhirPath.from("name")
-            .where(FhirPath.relative().navigate("family").upper().eq("SMITH"))
-            .navigate("family")
-
-        val results = evaluate(patient, path, StringType::class.java)
-        assertThat(results, hasSize(1))
-        assertThat(results[0].value, `is`("smith"))
-    }
-
-    // ── string function: matches regex ───────────────────────────────────────
-
-    @Test
-    fun `matches regex in where condition filters identifiers by value pattern`() {
-        val patient = Patient().apply {
-            addIdentifier().apply { system = "http://example.org/id"; value = "MRN-001" }
-            addIdentifier().apply { system = "http://example.org/id"; value = "ABC-001" }
-            addIdentifier().apply { system = "http://example.org/id"; value = "MRN-099" }
-        }
-        val path = FhirPath.from("identifier")
-            .where(FhirPath.relative().navigate("value").matches("MRN-[0-9]+"))
-            .navigate("value")
-
-        val results = evaluate(patient, path, StringType::class.java)
-        assertThat(results, hasSize(2))
-    }
-
-    // ── select projection ─────────────────────────────────────────────────────
-
-    @Test
-    fun `select projects a field from every element of a collection`() {
-        val patient = Patient().apply {
-            addName().apply { family = "Smith"; addGiven("John") }
-            addName().apply { family = "Jones"; addGiven("Jane") }
-        }
-        val results = evaluate(patient, FhirPath.from("name").select("family"), StringType::class.java)
-        assertThat(results, hasSize(2))
-    }
-
-    // ── multi-term boolean chain ──────────────────────────────────────────────
-
-    @Test
-    fun `or-then-and three-term condition filters with correct precedence`() {
-        val patient = Patient().apply {
-            addIdentifier().apply { system = "http://a.org"; value = "active-mrn" }
-            addIdentifier().apply { system = "http://b.org"; value = "passive-mrn" }
-            addIdentifier().apply { system = "http://c.org"; value = "something-else" }
-        }
-        val sysA = FhirPath.relative().navigate("system").eq("http://a.org")
-        val sysB = FhirPath.relative().navigate("system").eq("http://b.org")
-        val endsWithMrn = FhirPath.relative().navigate("value").endsWith("-mrn")
-        val path = FhirPath.from("identifier")
-            .where(sysA.or(sysB).and(endsWithMrn))
-            .navigate("value")
-
-        val results = evaluate(patient, path, StringType::class.java)
-        assertThat(results, hasSize(2))
-    }
-
-    // ── FHIR-specific: extension ──────────────────────────────────────────────
-
-    @Test
-    fun `extension function navigates to named extension value`() {
-        val patient = Patient().apply {
-            addExtension("http://example.org/color", StringType("blue"))
-        }
-        val path = FhirPath.from("Patient")
-            .extension("http://example.org/color")
-            .navigate("value")
-
-        val result = evaluateFirst(patient, path, StringType::class.java)
-        assertThat(result?.value, `is`("blue"))
-    }
-
-    @Test
-    fun `extension where url detects presence of a named extension`() {
-        val patient = Patient().apply {
-            addExtension("http://example.org/color", StringType("blue"))
-        }
-        val path = FhirPath.from("extension")
-            .where(FhirPath.relative().navigate("url").eq("http://example.org/color"))
-            .exists()
-        assertTrue(matches(patient, path))
-    }
-
-    @Test
-    fun `extension where url is false when extension is absent`() {
-        val path = FhirPath.from("extension")
-            .where(FhirPath.relative().navigate("url").eq("http://example.org/color"))
-            .exists()
-        assertFalse(matches(Patient(), path))
-    }
-
-    // ── boolean operators ─────────────────────────────────────────────────────
-
-    @Test
-    fun `not negates truthy active flag`() {
+    fun `allTrue returns true when all items are true`() {
         val patient = Patient().apply { active = true }
-        assertFalse(matches(patient, FhirPath.from("active").not()))
+        assertTrue(matches(patient, FhirPath.from("active").allTrue()))
     }
 
     @Test
-    fun `not negates falsy active flag`() {
+    fun `allTrue returns false when an item is false`() {
         val patient = Patient().apply { active = false }
-        assertTrue(matches(patient, FhirPath.from("active").not()))
+        assertFalse(matches(patient, FhirPath.from("active").allTrue()))
     }
 
     @Test
-    fun `and of two satisfied conditions is true`() {
-        val patient = Patient().apply {
-            active = true
-            addName().apply { family = "Smith" }
-        }
-        val path = FhirPath.from("active").eq(true)
-            .and(FhirPath.from("name").exists())
-        assertTrue(matches(patient, path))
-    }
-
-    @Test
-    fun `and short-circuits when second condition is false`() {
+    fun `anyTrue returns true when at least one item is true`() {
         val patient = Patient().apply { active = true }
-        val path = FhirPath.from("active").eq(true)
-            .and(FhirPath.from("name").exists())
-        assertFalse(matches(patient, path))
+        assertTrue(matches(patient, FhirPath.from("active").anyTrue()))
     }
 
-    // ── distinct / isDistinct ─────────────────────────────────────────────────
+    @Test
+    fun `allFalse returns true when all items are false`() {
+        val patient = Patient().apply { active = false }
+        assertTrue(matches(patient, FhirPath.from("active").allFalse()))
+    }
+
+    @Test
+    fun `anyFalse returns true when at least one item is false`() {
+        val patient = Patient().apply { active = false }
+        assertTrue(matches(patient, FhirPath.from("active").anyFalse()))
+    }
+
+    // ── collection: distinct, isDistinct ─────────────────────────────────────
 
     @Test
     fun `distinct removes duplicate family names`() {
@@ -374,7 +224,7 @@ class FhirPathEvaluationTest {
     }
 
     @Test
-    fun `isDistinct returns true when all family names are unique`() {
+    fun `isDistinct returns true when all elements are unique`() {
         val patient = Patient().apply {
             addName().apply { family = "Smith" }
             addName().apply { family = "Jones" }
@@ -391,7 +241,529 @@ class FhirPathEvaluationTest {
         assertFalse(matches(patient, FhirPath.from("name").navigate("family").isDistinct()))
     }
 
-    // ── immutability under evaluation ─────────────────────────────────────────
+    // ── collection: supersetOf ───────────────────────────────────────────────
+
+    @Test
+    fun `supersetOf returns true when collection contains the other`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { system = "http://a.org"; value = "1" }
+            addIdentifier().apply { system = "http://b.org"; value = "2" }
+        }
+        val path = FhirPath.from("identifier")
+            .supersetOf("identifier.where(system = 'http://a.org')")
+        assertTrue(matches(patient, path))
+    }
+
+    // ── collection: children, descendants ─────────────────────────────────────
+
+    @Test
+    fun `children returns immediate child elements`() {
+        val patient = Patient().apply {
+            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith"; addGiven("John") }
+        }
+        val results = evaluate(patient, FhirPath.from("name").first().children(), IBase::class.java)
+        assertTrue(results.isNotEmpty())
+    }
+
+    @Test
+    fun `descendants returns all nested elements`() {
+        val patient = Patient().apply {
+            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith"; addGiven("John") }
+        }
+        val results = evaluate(patient, FhirPath.from("name").first().descendants(), IBase::class.java)
+        assertTrue(results.isNotEmpty())
+    }
+
+    // ── boolean: not, and, or, xor, implies ──────────────────────────────────
+
+    @Test
+    fun `not negates a true value`() {
+        val patient = Patient().apply { active = true }
+        assertFalse(matches(patient, FhirPath.from("active").not()))
+    }
+
+    @Test
+    fun `and of two true conditions is true`() {
+        val patient = Patient().apply { active = true; addName().apply { family = "Smith" } }
+        assertTrue(matches(patient, FhirPath.from("active").eq(true).and(FhirPath.from("name").exists())))
+    }
+
+    @Test
+    fun `or of one true and one false is true`() {
+        val patient = Patient().apply {
+            addTelecom().apply { system = ContactPoint.ContactPointSystem.PHONE; value = "555-1234" }
+        }
+        val path = FhirPath.relative().navigate("system").eq("phone")
+            .or(FhirPath.relative().navigate("system").eq("email"))
+        assertTrue(matches(patient, FhirPath.from("telecom").where(path).exists()))
+    }
+
+    @Test
+    fun `xor returns true when exactly one operand is true`() {
+        val patient = Patient().apply { active = true; addName().apply { family = "Smith" } }
+        // active=true, name.empty()=false → true xor false = true
+        assertTrue(matches(patient, FhirPath.from("active").xor(FhirPath.from("name").empty())))
+    }
+
+    @Test
+    fun `xor returns false when both operands are true`() {
+        val patient = Patient().apply { active = true; addName().apply { family = "Smith" } }
+        // active=true, name.exists()=true → true xor true = false
+        assertFalse(matches(patient, FhirPath.from("active").xor(FhirPath.from("name").exists())))
+    }
+
+    @Test
+    fun `implies returns true when antecedent is true and consequent is true`() {
+        val patient = Patient().apply { active = true; addName().apply { family = "Smith" } }
+        assertTrue(matches(patient, FhirPath.from("active").implies(FhirPath.from("name").exists())))
+    }
+
+    @Test
+    fun `implies returns false when antecedent is true and consequent is false`() {
+        val patient = Patient().apply { active = true }
+        assertFalse(matches(patient, FhirPath.from("active").implies(FhirPath.from("name").exists())))
+    }
+
+    // ── comparison: eq, ne, lt, gt, le, ge ───────────────────────────────────
+
+    @Test
+    fun `eq with Int compares integer values`() {
+        val patient = Patient().apply { addName(); addName() }
+        assertTrue(matches(patient, FhirPath.from("name").count().eq(2)))
+    }
+
+    @Test
+    fun `eq with Double compares decimal values`() {
+        assertTrue(matches(obsWithQuantity(3.0), FhirPath.from("value").navigate("value").eq(3.0)))
+    }
+
+    @Test
+    fun `ne with String compares string values`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        assertTrue(matches(patient, FhirPath.from("name").navigate("family").first().ne("Jones")))
+    }
+
+    @Test
+    fun `ne with Boolean compares boolean values`() {
+        val patient = Patient().apply { active = true }
+        assertTrue(matches(patient, FhirPath.from("active").ne(false)))
+    }
+
+    @Test
+    fun `ne with Int compares integer values`() {
+        val patient = Patient().apply { addName(); addName() }
+        assertTrue(matches(patient, FhirPath.from("name").count().ne(0)))
+    }
+
+    @Test
+    fun `lt with Int returns true when left is less`() {
+        val patient = Patient().apply { addName(); addName() }
+        assertTrue(matches(patient, FhirPath.from("name").count().lt(5)))
+    }
+
+    @Test
+    fun `lt with Double returns true when left is less`() {
+        assertTrue(matches(obsWithQuantity(3.14), FhirPath.from("value").navigate("value").lt(4.0)))
+    }
+
+    @Test
+    fun `gt with Int returns true when left is greater`() {
+        val patient = Patient().apply { addName(); addName() }
+        assertTrue(matches(patient, FhirPath.from("name").count().gt(1)))
+    }
+
+    @Test
+    fun `gt with Double returns true when left is greater`() {
+        assertTrue(matches(obsWithQuantity(3.14), FhirPath.from("value").navigate("value").gt(3.0)))
+    }
+
+    @Test
+    fun `le with Int returns true when equal`() {
+        val patient = Patient().apply { addName(); addName() }
+        assertTrue(matches(patient, FhirPath.from("name").count().le(2)))
+    }
+
+    @Test
+    fun `ge with Int returns true when equal`() {
+        val patient = Patient().apply { addName(); addName() }
+        assertTrue(matches(patient, FhirPath.from("name").count().ge(2)))
+    }
+
+    // ── comparison: equiv, notEquiv, memberOf, containsValue ─────────────────
+
+    @Test
+    fun `equiv matches strings case-insensitively`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        assertTrue(matches(patient, FhirPath.from("name").navigate("family").first().equiv("smith")))
+    }
+
+    @Test
+    fun `notEquiv returns true for different values`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        assertTrue(matches(patient, FhirPath.from("name").navigate("family").first().notEquiv("jones")))
+    }
+
+    @Test
+    fun `containsValue returns true when collection contains the item`() {
+        val patient = Patient().apply {
+            addName().apply { addGiven("John"); addGiven("William") }
+        }
+        assertTrue(matches(patient, FhirPath.from("name").navigate("given").containsValue("John")))
+    }
+
+    // ── string functions ──────────────────────────────────────────────────────
+
+    @Test
+    fun `lower converts to lowercase`() {
+        val patient = Patient().apply { addName().apply { family = "SMITH" } }
+        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").lower(), StringType::class.java)
+        assertThat(result?.value, `is`("smith"))
+    }
+
+    @Test
+    fun `upper converts to uppercase`() {
+        val patient = Patient().apply { addName().apply { family = "smith" } }
+        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").upper(), StringType::class.java)
+        assertThat(result?.value, `is`("SMITH"))
+    }
+
+    @Test
+    fun `length returns character count`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").length(), IntegerType::class.java)
+        assertThat(result?.value, `is`(5))
+    }
+
+    @Test
+    fun `trim removes leading and trailing whitespace`() {
+        val patient = Patient().apply { addName().apply { family = "  Smith  " } }
+        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").trim(), StringType::class.java)
+        assertThat(result?.value, `is`("Smith"))
+    }
+
+    @Test
+    fun `startsWith filters names by prefix`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Jones" }
+            addName().apply { family = "Smithfield" }
+        }
+        val results = evaluate(patient,
+            FhirPath.from("name").where(FhirPath.relative().navigate("family").startsWith("Sm")).navigate("family"),
+            StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    @Test
+    fun `endsWith filters names by suffix`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Jones" }
+        }
+        val results = evaluate(patient,
+            FhirPath.from("name").where(FhirPath.relative().navigate("family").endsWith("ith")).navigate("family"),
+            StringType::class.java)
+        assertThat(results, hasSize(1))
+        assertThat(results[0].value, `is`("Smith"))
+    }
+
+    @Test
+    fun `contains filters names containing a substring`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Jones" }
+        }
+        val results = evaluate(patient,
+            FhirPath.from("name").where(FhirPath.relative().navigate("family").contains("mit")).navigate("family"),
+            StringType::class.java)
+        assertThat(results, hasSize(1))
+    }
+
+    @Test
+    fun `matches filters by regex`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { value = "MRN-001" }
+            addIdentifier().apply { value = "ABC-001" }
+        }
+        val results = evaluate(patient,
+            FhirPath.from("identifier").where(FhirPath.relative().navigate("value").matches("MRN-[0-9]+")).navigate("value"),
+            StringType::class.java)
+        assertThat(results, hasSize(1))
+    }
+
+    @Test
+    fun `indexOf returns position of substring`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        val result = evaluateFirst(patient,
+            FhirPath.from("name").navigate("family").indexOf("mit"),
+            IntegerType::class.java)
+        assertThat(result?.value, `is`(1))
+    }
+
+    @Test
+    fun `substring extracts characters by start and length`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        val result = evaluateFirst(patient,
+            FhirPath.from("name").navigate("family").substring(1, 3),
+            StringType::class.java)
+        assertThat(result?.value, `is`("mit"))
+    }
+
+    @Test
+    fun `replace substitutes pattern with substitution`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        val result = evaluateFirst(patient,
+            FhirPath.from("name").navigate("family").replace("Smith", "Jones"),
+            StringType::class.java)
+        assertThat(result?.value, `is`("Jones"))
+    }
+
+    @Test
+    fun `replaceMatches substitutes regex matches`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        val result = evaluateFirst(patient,
+            FhirPath.from("name").navigate("family").replaceMatches("[aeiou]", "*"),
+            StringType::class.java)
+        assertThat(result?.value, `is`("Sm*th"))
+    }
+
+    @Test
+    fun `split divides a string into a collection`() {
+        val patient = Patient().apply { addName().apply { family = "Van.Der.Berg" } }
+        val results = evaluate(patient,
+            FhirPath.from("name").navigate("family").split("."),
+            StringType::class.java)
+        assertThat(results, hasSize(3))
+    }
+
+    @Test
+    fun `join concatenates a collection with a separator`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Jones" }
+        }
+        val result = evaluateFirst(patient,
+            FhirPath.from("name").navigate("family").join(", "),
+            StringType::class.java)
+        assertThat(result?.value, `is`("Smith, Jones"))
+    }
+
+    // ── math functions ────────────────────────────────────────────────────────
+
+    @Test
+    fun `abs returns absolute value`() {
+        val result = evaluateFirst(obsWithQuantity(-4.5),
+            FhirPath.from("value").navigate("value").abs(),
+            DecimalType::class.java)
+        assertThat(result?.value?.toDouble(), `is`(4.5))
+    }
+
+    @Test
+    fun `ceiling rounds up to nearest integer`() {
+        val result = evaluateFirst(obsWithQuantity(3.2),
+            FhirPath.from("value").navigate("value").ceiling(),
+            IntegerType::class.java)
+        assertThat(result?.value, `is`(4))
+    }
+
+    @Test
+    fun `floor rounds down to nearest integer`() {
+        val result = evaluateFirst(obsWithQuantity(3.7),
+            FhirPath.from("value").navigate("value").floor(),
+            IntegerType::class.java)
+        assertThat(result?.value, `is`(3))
+    }
+
+    @Test
+    fun `round rounds to nearest integer`() {
+        val result = evaluateFirst(obsWithQuantity(3.5),
+            FhirPath.from("value").navigate("value").round(),
+            DecimalType::class.java)
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `round with precision rounds to given decimal places`() {
+        val result = evaluateFirst(obsWithQuantity(3.14159),
+            FhirPath.from("value").navigate("value").round(2),
+            DecimalType::class.java)
+        assertThat(result?.value?.toDouble(), `is`(3.14))
+    }
+
+    @Test
+    fun `sqrt returns square root`() {
+        val result = evaluateFirst(obsWithQuantity(4.0),
+            FhirPath.from("value").navigate("value").sqrt(),
+            DecimalType::class.java)
+        assertThat(result?.value?.toDouble(), `is`(2.0))
+    }
+
+    @Test
+    fun `power raises to exponent`() {
+        val result = evaluateFirst(obsWithQuantity(3.0),
+            FhirPath.from("value").navigate("value").power("2"),
+            DecimalType::class.java)
+        assertThat(result?.value?.toDouble(), `is`(9.0))
+    }
+
+    @Test
+    fun `truncate removes fractional part`() {
+        val result = evaluateFirst(obsWithQuantity(3.9),
+            FhirPath.from("value").navigate("value").truncate(),
+            IntegerType::class.java)
+        assertThat(result?.value, `is`(3))
+    }
+
+    // ── arithmetic operators ──────────────────────────────────────────────────
+
+    @Test
+    fun `plus adds a value`() {
+        val patient = Patient().apply { addName(); addName() }
+        val result = evaluateFirst(patient, FhirPath.from("name").count().plus("1"), IntegerType::class.java)
+        assertThat(result?.value, `is`(3))
+    }
+
+    @Test
+    fun `minus subtracts a value`() {
+        val patient = Patient().apply { addName(); addName() }
+        val result = evaluateFirst(patient, FhirPath.from("name").count().minus("1"), IntegerType::class.java)
+        assertThat(result?.value, `is`(1))
+    }
+
+    @Test
+    fun `times multiplies a value`() {
+        val patient = Patient().apply { addName(); addName() }
+        val result = evaluateFirst(patient, FhirPath.from("name").count().times("3"), IntegerType::class.java)
+        assertThat(result?.value, `is`(6))
+    }
+
+    @Test
+    fun `dividedBy divides producing a decimal`() {
+        val patient = Patient().apply { addName(); addName() }
+        val result = evaluateFirst(patient, FhirPath.from("name").count().dividedBy("4"), DecimalType::class.java)
+        assertThat(result?.value?.toDouble(), `is`(0.5))
+    }
+
+    @Test
+    fun `div performs integer division`() {
+        val patient = Patient().apply { addName(); addName() }
+        val result = evaluateFirst(patient, FhirPath.from("name").count().div("2"), IntegerType::class.java)
+        assertThat(result?.value, `is`(1))
+    }
+
+    @Test
+    fun `mod returns remainder`() {
+        val patient = Patient().apply { addName(); addName(); addName() }
+        val result = evaluateFirst(patient, FhirPath.from("name").count().mod("2"), IntegerType::class.java)
+        assertThat(result?.value, `is`(1))
+    }
+
+    @Test
+    fun `concat joins strings with ampersand`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        val result = evaluateFirst(patient,
+            FhirPath.from("name").navigate("family").first().concat("' Jr.'"),
+            StringType::class.java)
+        assertThat(result?.value, `is`("Smith Jr."))
+    }
+
+    // ── type conversion ───────────────────────────────────────────────────────
+
+    @Test
+    fun `toBoolean converts a boolean value`() {
+        val patient = Patient().apply { active = true }
+        val result = evaluateFirst(patient, FhirPath.from("active").toBoolean(), BooleanType::class.java)
+        assertTrue(result!!.booleanValue())
+    }
+
+    @Test
+    fun `toInteger converts boolean true to 1`() {
+        val patient = Patient().apply { active = true }
+        val result = evaluateFirst(patient, FhirPath.from("active").toInteger(), IntegerType::class.java)
+        assertThat(result?.value, `is`(1))
+    }
+
+    @Test
+    fun `toDecimal converts an integer to decimal`() {
+        val patient = Patient().apply { addName(); addName() }
+        val result = evaluateFirst(patient, FhirPath.from("name").count().toDecimal(), DecimalType::class.java)
+        assertThat(result?.value?.toDouble(), `is`(2.0))
+    }
+
+    @Test
+    fun `toQuantity converts an integer to a Quantity`() {
+        val patient = Patient().apply { addName(); addName() }
+        val result = evaluateFirst(patient, FhirPath.from("name").count().toQuantity(), Quantity::class.java)
+        assertNotNull(result)
+    }
+
+    // ── FHIR-specific ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `extension navigates to a named extension value`() {
+        val patient = Patient().apply {
+            addExtension("http://example.org/color", StringType("blue"))
+        }
+        val result = evaluateFirst(patient,
+            FhirPath.from("Patient").extension("http://example.org/color").navigate("value"),
+            StringType::class.java)
+        assertThat(result?.value, `is`("blue"))
+    }
+
+    @Test
+    fun `extension where url detects presence of extension`() {
+        val patient = Patient().apply { addExtension("http://example.org/color", StringType("blue")) }
+        assertTrue(matches(patient,
+            FhirPath.from("extension").where(FhirPath.relative().navigate("url").eq("http://example.org/color")).exists()))
+    }
+
+    @Test
+    fun `resolve on a reference without a resolver returns empty collection`() {
+        val patient = Patient().apply { managingOrganization = Reference("Organization/123") }
+        val results = evaluate(patient, FhirPath.from("managingOrganization").resolve(), IBase::class.java)
+        assertTrue(results.isEmpty())
+    }
+
+    // ── select projection ─────────────────────────────────────────────────────
+
+    @Test
+    fun `select projects a field from every element`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Jones" }
+        }
+        val results = evaluate(patient, FhirPath.from("name").select("family"), StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    // ── complex chains ────────────────────────────────────────────────────────
+
+    @Test
+    fun `chained where and first extracts first given name from official name`() {
+        val patient = Patient().apply {
+            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith"; addGiven("John"); addGiven("William") }
+            addName().apply { use = HumanName.NameUse.NICKNAME; addGiven("Johnny") }
+        }
+        val result = evaluateFirst(patient,
+            FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("official")).navigate("given").first(),
+            StringType::class.java)
+        assertThat(result?.value, `is`("John"))
+    }
+
+    @Test
+    fun `or-then-and three-term condition filters with correct precedence`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { system = "http://a.org"; value = "active-mrn" }
+            addIdentifier().apply { system = "http://b.org"; value = "passive-mrn" }
+            addIdentifier().apply { system = "http://c.org"; value = "something-else" }
+        }
+        val path = FhirPath.from("identifier")
+            .where(FhirPath.relative().navigate("system").eq("http://a.org")
+                .or(FhirPath.relative().navigate("system").eq("http://b.org"))
+                .and(FhirPath.relative().navigate("value").endsWith("-mrn")))
+            .navigate("value")
+        assertThat(evaluate(patient, path, StringType::class.java), hasSize(2))
+    }
 
     @Test
     fun `reusing a base FhirPath produces independent evaluated results`() {
@@ -399,10 +771,8 @@ class FhirPathEvaluationTest {
             addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith"; addGiven("John") }
         }
         val base = FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("official"))
-
         val family = evaluateFirst(patient, base.navigate("family"), StringType::class.java)
         val given = evaluateFirst(patient, base.navigate("given").first(), StringType::class.java)
-
         assertThat(family?.value, `is`("Smith"))
         assertThat(given?.value, `is`("John"))
         assertThat(base.build(), `is`("name.where(use = 'official')"))

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/FhirPathEvaluationTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/FhirPathEvaluationTest.kt
@@ -1,0 +1,410 @@
+package dev.ratkay.operation.r4
+
+import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.fhirpath.IFhirPath
+import dev.ratkay.operation.FhirPath
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.`is`
+import org.hl7.fhir.instance.model.api.IBase
+import org.hl7.fhir.r4.model.BooleanType
+import org.hl7.fhir.r4.model.ContactPoint
+import org.hl7.fhir.r4.model.HumanName
+import org.hl7.fhir.r4.model.IntegerType
+import org.hl7.fhir.r4.model.Patient
+import org.hl7.fhir.r4.model.StringType
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Validates that expressions produced by [FhirPath] are accepted and evaluated correctly by
+ * HAPI's FHIRPath engine. A test failure here means the builder produced an invalid or
+ * incorrectly structured expression string — not just a wrong expected value.
+ */
+class FhirPathEvaluationTest {
+
+    companion object {
+        private val engine: IFhirPath = FhirContext.forR4Cached().newFhirPath()
+    }
+
+    private fun <T : IBase> evaluateFirst(resource: IBase, path: FhirPath, type: Class<T>): T? =
+        engine.evaluateFirst(resource, path.build(), type).orElse(null)
+
+    private fun <T : IBase> evaluate(resource: IBase, path: FhirPath, type: Class<T>): List<T> =
+        engine.evaluate(resource, path.build(), type)
+
+    private fun matches(resource: IBase, path: FhirPath): Boolean {
+        val results = engine.evaluate(resource, path.build(), IBase::class.java)
+        if (results.isEmpty()) return false
+        val first = results.first()
+        return if (first is BooleanType) first.booleanValue() else true
+    }
+
+    // ── where + navigate ──────────────────────────────────────────────────────
+
+    @Test
+    fun `where with FhirPath condition extracts official family name`() {
+        val patient = Patient().apply {
+            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith" }
+            addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
+        }
+        val path = FhirPath.from("name")
+            .where(FhirPath.relative().navigate("use").eq("'official'"))
+            .navigate("family")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(1))
+        assertThat(results[0].value, `is`("Smith"))
+    }
+
+    @Test
+    fun `chained where and first extracts first given name from official name`() {
+        val patient = Patient().apply {
+            addName().apply {
+                use = HumanName.NameUse.OFFICIAL
+                family = "Smith"
+                addGiven("John")
+                addGiven("William")
+            }
+            addName().apply { use = HumanName.NameUse.NICKNAME; addGiven("Johnny") }
+        }
+        val path = FhirPath.from("name")
+            .where(FhirPath.relative().navigate("use").eq("'official'"))
+            .navigate("given")
+            .first()
+
+        val result = evaluateFirst(patient, path, StringType::class.java)
+        assertThat(result?.value, `is`("John"))
+    }
+
+    @Test
+    fun `and condition filters names that have both official use and a family`() {
+        val patient = Patient().apply {
+            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith" }
+            addName().apply { use = HumanName.NameUse.OFFICIAL }     // no family
+            addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
+        }
+        val condition = FhirPath.relative().navigate("use").eq("'official'")
+            .and(FhirPath.relative().navigate("family").exists())
+        val path = FhirPath.from("name").where(condition).navigate("family")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(1))
+        assertThat(results[0].value, `is`("Smith"))
+    }
+
+    @Test
+    fun `or condition finds both phone and email telecom values`() {
+        val patient = Patient().apply {
+            addTelecom().apply { system = ContactPoint.ContactPointSystem.PHONE; value = "555-1234" }
+            addTelecom().apply { system = ContactPoint.ContactPointSystem.EMAIL; value = "j@example.org" }
+            addTelecom().apply { system = ContactPoint.ContactPointSystem.FAX; value = "555-0000" }
+        }
+        val phoneOrEmail = FhirPath.relative().navigate("system").eq("'phone'")
+            .or(FhirPath.relative().navigate("system").eq("'email'"))
+        val path = FhirPath.from("telecom").where(phoneOrEmail).navigate("value")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    @Test
+    fun `identifier where system extracts MRN value`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { system = "http://example.org/mrn"; value = "MRN-001" }
+            addIdentifier().apply { system = "http://example.org/ssn"; value = "123-45-6789" }
+        }
+        val path = FhirPath.from("identifier")
+            .where(FhirPath.relative().navigate("system").eq("'http://example.org/mrn'"))
+            .navigate("value")
+
+        val result = evaluateFirst(patient, path, StringType::class.java)
+        assertThat(result?.value, `is`("MRN-001"))
+    }
+
+    @Test
+    fun `and on identifier filters by system and value prefix`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { system = "http://example.org/mrn"; value = "MRN-001" }
+            addIdentifier().apply { system = "http://example.org/mrn"; value = "OLD-001" }
+            addIdentifier().apply { system = "http://example.org/ssn"; value = "MRN-999" }
+        }
+        val condition = FhirPath.relative().navigate("system").eq("'http://example.org/mrn'")
+            .and(FhirPath.relative().navigate("value").startsWith("'MRN-'"))
+        val path = FhirPath.from("identifier").where(condition).navigate("value")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(1))
+        assertThat(results[0].value, `is`("MRN-001"))
+    }
+
+    // ── count / exists / all ──────────────────────────────────────────────────
+
+    @Test
+    fun `count of filtered list returns correct total`() {
+        val patient = Patient().apply {
+            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith" }
+            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Jones" }
+            addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
+        }
+        val path = FhirPath.from("name")
+            .where(FhirPath.relative().navigate("use").eq("'official'"))
+            .count()
+
+        val result = evaluateFirst(patient, path, IntegerType::class.java)
+        assertThat(result?.value, `is`(2))
+    }
+
+    @Test
+    fun `exists with FhirPath criteria detects matching element`() {
+        val patient = Patient().apply {
+            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith" }
+            addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
+        }
+        assertTrue(matches(patient, FhirPath.from("name").exists(FhirPath.relative().navigate("use").eq("'official'"))))
+    }
+
+    @Test
+    fun `exists with FhirPath criteria is false when no element matches`() {
+        val patient = Patient().apply {
+            addName().apply { use = HumanName.NameUse.NICKNAME; family = "Smitty" }
+        }
+        assertFalse(matches(patient, FhirPath.from("name").exists(FhirPath.relative().navigate("use").eq("'official'"))))
+    }
+
+    @Test
+    fun `all with FhirPath criteria returns true when every identifier has a system`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { system = "http://example.org/mrn"; value = "12345" }
+            addIdentifier().apply { system = "http://example.org/ssn"; value = "999-99-9999" }
+        }
+        assertTrue(matches(patient, FhirPath.from("identifier").all(FhirPath.relative().navigate("system").exists())))
+    }
+
+    @Test
+    fun `all with FhirPath criteria returns false when an identifier lacks a system`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { system = "http://example.org/mrn"; value = "12345" }
+            addIdentifier().apply { value = "orphan" }
+        }
+        assertFalse(matches(patient, FhirPath.from("identifier").all(FhirPath.relative().navigate("system").exists())))
+    }
+
+    // ── string functions ──────────────────────────────────────────────────────
+
+    @Test
+    fun `lower converts family name to lowercase`() {
+        val patient = Patient().apply { addName().apply { family = "SMITH" } }
+        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").lower(), StringType::class.java)
+        assertThat(result?.value, `is`("smith"))
+    }
+
+    @Test
+    fun `upper converts family name to uppercase`() {
+        val patient = Patient().apply { addName().apply { family = "smith" } }
+        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").upper(), StringType::class.java)
+        assertThat(result?.value, `is`("SMITH"))
+    }
+
+    @Test
+    fun `length returns character count of family name`() {
+        val patient = Patient().apply { addName().apply { family = "Smith" } }
+        val result = evaluateFirst(patient, FhirPath.from("name").navigate("family").length(), IntegerType::class.java)
+        assertThat(result?.value, `is`(5))
+    }
+
+    @Test
+    fun `startsWith in where condition filters names by prefix`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Jones" }
+            addName().apply { family = "Smithfield" }
+        }
+        val path = FhirPath.from("name")
+            .where(FhirPath.relative().navigate("family").startsWith("'Sm'"))
+            .navigate("family")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    @Test
+    fun `upper in where condition enables case-insensitive family match`() {
+        val patient = Patient().apply {
+            addName().apply { family = "smith" }
+            addName().apply { family = "Jones" }
+        }
+        val path = FhirPath.from("name")
+            .where(FhirPath.relative().navigate("family").upper().eq("'SMITH'"))
+            .navigate("family")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(1))
+        assertThat(results[0].value, `is`("smith"))
+    }
+
+    // ── string function: matches regex ───────────────────────────────────────
+
+    @Test
+    fun `matches regex in where condition filters identifiers by value pattern`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { system = "http://example.org/id"; value = "MRN-001" }
+            addIdentifier().apply { system = "http://example.org/id"; value = "ABC-001" }
+            addIdentifier().apply { system = "http://example.org/id"; value = "MRN-099" }
+        }
+        val path = FhirPath.from("identifier")
+            .where(FhirPath.relative().navigate("value").matches("'MRN-[0-9]+'"))
+            .navigate("value")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    // ── select projection ─────────────────────────────────────────────────────
+
+    @Test
+    fun `select projects a field from every element of a collection`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith"; addGiven("John") }
+            addName().apply { family = "Jones"; addGiven("Jane") }
+        }
+        val results = evaluate(patient, FhirPath.from("name").select("family"), StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    // ── multi-term boolean chain ──────────────────────────────────────────────
+
+    @Test
+    fun `or-then-and three-term condition filters with correct precedence`() {
+        val patient = Patient().apply {
+            addIdentifier().apply { system = "http://a.org"; value = "active-mrn" }
+            addIdentifier().apply { system = "http://b.org"; value = "passive-mrn" }
+            addIdentifier().apply { system = "http://c.org"; value = "something-else" }
+        }
+        val sysA = FhirPath.relative().navigate("system").eq("'http://a.org'")
+        val sysB = FhirPath.relative().navigate("system").eq("'http://b.org'")
+        val endsWithMrn = FhirPath.relative().navigate("value").endsWith("'-mrn'")
+        val path = FhirPath.from("identifier")
+            .where(sysA.or(sysB).and(endsWithMrn))
+            .navigate("value")
+
+        val results = evaluate(patient, path, StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    // ── FHIR-specific: extension ──────────────────────────────────────────────
+
+    @Test
+    fun `extension function navigates to named extension value`() {
+        val patient = Patient().apply {
+            addExtension("http://example.org/color", StringType("blue"))
+        }
+        val path = FhirPath.from("Patient")
+            .extension("http://example.org/color")
+            .navigate("value")
+
+        val result = evaluateFirst(patient, path, StringType::class.java)
+        assertThat(result?.value, `is`("blue"))
+    }
+
+    @Test
+    fun `extension where url detects presence of a named extension`() {
+        val patient = Patient().apply {
+            addExtension("http://example.org/color", StringType("blue"))
+        }
+        val path = FhirPath.from("extension")
+            .where(FhirPath.relative().navigate("url").eq("'http://example.org/color'"))
+            .exists()
+        assertTrue(matches(patient, path))
+    }
+
+    @Test
+    fun `extension where url is false when extension is absent`() {
+        val path = FhirPath.from("extension")
+            .where(FhirPath.relative().navigate("url").eq("'http://example.org/color'"))
+            .exists()
+        assertFalse(matches(Patient(), path))
+    }
+
+    // ── boolean operators ─────────────────────────────────────────────────────
+
+    @Test
+    fun `not negates truthy active flag`() {
+        val patient = Patient().apply { active = true }
+        assertFalse(matches(patient, FhirPath.from("active").not()))
+    }
+
+    @Test
+    fun `not negates falsy active flag`() {
+        val patient = Patient().apply { active = false }
+        assertTrue(matches(patient, FhirPath.from("active").not()))
+    }
+
+    @Test
+    fun `and of two satisfied conditions is true`() {
+        val patient = Patient().apply {
+            active = true
+            addName().apply { family = "Smith" }
+        }
+        val path = FhirPath.from("active").eq("true")
+            .and(FhirPath.from("name").exists())
+        assertTrue(matches(patient, path))
+    }
+
+    @Test
+    fun `and short-circuits when second condition is false`() {
+        val patient = Patient().apply { active = true }
+        val path = FhirPath.from("active").eq("true")
+            .and(FhirPath.from("name").exists())
+        assertFalse(matches(patient, path))
+    }
+
+    // ── distinct / isDistinct ─────────────────────────────────────────────────
+
+    @Test
+    fun `distinct removes duplicate family names`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Jones" }
+        }
+        val results = evaluate(patient, FhirPath.from("name").navigate("family").distinct(), StringType::class.java)
+        assertThat(results, hasSize(2))
+    }
+
+    @Test
+    fun `isDistinct returns true when all family names are unique`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Jones" }
+        }
+        assertTrue(matches(patient, FhirPath.from("name").navigate("family").isDistinct()))
+    }
+
+    @Test
+    fun `isDistinct returns false when duplicates exist`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith" }
+            addName().apply { family = "Smith" }
+        }
+        assertFalse(matches(patient, FhirPath.from("name").navigate("family").isDistinct()))
+    }
+
+    // ── immutability under evaluation ─────────────────────────────────────────
+
+    @Test
+    fun `reusing a base FhirPath produces independent evaluated results`() {
+        val patient = Patient().apply {
+            addName().apply { use = HumanName.NameUse.OFFICIAL; family = "Smith"; addGiven("John") }
+        }
+        val base = FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("'official'"))
+
+        val family = evaluateFirst(patient, base.navigate("family"), StringType::class.java)
+        val given = evaluateFirst(patient, base.navigate("given").first(), StringType::class.java)
+
+        assertThat(family?.value, `is`("Smith"))
+        assertThat(given?.value, `is`("John"))
+        assertThat(base.build(), `is`("name.where(use = 'official')"))
+    }
+}


### PR DESCRIPTION
Introduces FhirPath, an immutable builder for constructing FHIRPath expression strings programmatically. HAPI FHIR has no such API — it only evaluates expressions from strings. FhirPath fills the gap with a fluent chain (navigate, where, eq, and/or, extension, resolve, …) that terminates with build() returning the complete expression string.

Placed in fhirmason-api so a single class is shared by both R4 and DSTU3. 100 unit tests verify every method and compound chains.