### PR TITLE
Add FhirPath overloads to all FHIRPath string-based pipeline methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,12 @@ val result6 = OperationResult.of(resources, "resources")
 
 | Method | Returns | Default key |
 |---|---|---|
-| `addFromMatching(name?, type, expression) { list -> R }` | `OperationResult<R>` | `type` simple name (lowercase) |
-| `addAllFromMatching(name?, type, expression) { list -> List<R> }` | `OperationResult<List<R>>` | `type` simple name (lowercase) |
+| `addFromMatching(name?, type, expression: String) { list -> R }` | `OperationResult<R>` | `type` simple name (lowercase) |
+| `addFromMatching(name?, type, expression: FhirPath) { list -> R }` | `OperationResult<R>` | `type` simple name (lowercase) |
+| `addAllFromMatching(name?, type, expression: String) { list -> List<R> }` | `OperationResult<List<R>>` | `type` simple name (lowercase) |
+| `addAllFromMatching(name?, type, expression: FhirPath) { list -> List<R> }` | `OperationResult<List<R>>` | `type` simple name (lowercase) |
 
-Both methods have reified Kotlin overloads (omit `type`) and generate `@JvmOverloads` for Java callers. Error handling follows Pattern A: malformed expressions produce an ERROR `OperationOutcome` and skip the head.
+Each method has a `String`-expression variant and a `FhirPath`-expression variant (the `FhirPath` overload calls `.build()` and delegates). Both variants have reified Kotlin overloads (omit `type`) and generate `@JvmOverloads` for Java callers. Error handling follows Pattern A: malformed expressions produce an ERROR `OperationOutcome` and skip the head.
 
 ```kotlin
 // Keep only active patients, then build a summary
@@ -726,20 +728,36 @@ Three FHIRPath-aware methods complement the existing conditional API. All expres
 
 | Method | Head requirement | Behaviour |
 |---|---|---|
-| `whenPath(expression) { ... }` | Must be a `Base`; silent skip if null/non-Base | Runs block and merges parameters when expression is truthy; WARNING on malformed expression |
-| `guardPath(expression, message)` | Must be a `Base`; WARNING if null/non-Base | Records WARNING `OperationOutcome` with `message` when expression is `false`; WARNING on malformed expression |
-| `selectByPath(type, expression, name?)` | Must be a `Base`; ERROR if null/non-Base | Evaluates expression, promotes first matching result of `type` to the new pipeline head, stores under `name`; ERROR if no match found |
+| `whenPath(expression: String) { ... }` | Must be a `Base`; silent skip if null/non-Base | Runs block and merges parameters when expression is truthy; WARNING on malformed expression |
+| `whenPath(expression: FhirPath) { ... }` | Must be a `Base`; silent skip if null/non-Base | `FhirPath` overload — calls `.build()` and delegates |
+| `guardPath(expression: String, message)` | Must be a `Base`; WARNING if null/non-Base | Records WARNING `OperationOutcome` with `message` when expression is `false`; WARNING on malformed expression |
+| `guardPath(expression: FhirPath, message)` | Must be a `Base`; WARNING if null/non-Base | `FhirPath` overload — calls `.build()` and delegates |
+| `selectByPath(type, expression: String, name?)` | Must be a `Base`; ERROR if null/non-Base | Evaluates expression, promotes first matching result of `type` to the new pipeline head, stores under `name`; ERROR if no match found |
+| `selectByPath(type, expression: FhirPath, name?)` | Must be a `Base`; ERROR if null/non-Base | `FhirPath` overload — calls `.build()` and delegates |
 
 ```kotlin
+val activeGuard = FhirPath.relative().navigate("active").eq(true)
+val mpiFilter   = FhirPath.relative().navigate("identifier")
+                      .where(FhirPath.relative().navigate("system").eq("http://example.org/mpi"))
+                      .exists()
+val officialName = FhirPath.relative().navigate("name")
+                      .where(FhirPath.relative().navigate("use").eq("official"))
+                      .first()
+
 val result = OperationResult.of(patient)
-    .guardPath("active = true", "Patient must be active")
-    .whenPath("identifier.where(system='http://example.org/mpi').exists()") {
+    .guardPath(activeGuard, "Patient must be active")
+    .whenPath(mpiFilter) {
         add("mpi-flag") { StringType("enrolled") }
     }
+    .selectByPath<HumanName>(officialName, "official-name")
+
+// String expressions still work unchanged:
+val result2 = OperationResult.of(patient)
+    .guardPath("active = true", "Patient must be active")
     .selectByPath<HumanName>("name.where(use='official').first()", "official-name")
 ```
 
-`selectByPath` has a reified Kotlin overload (`selectByPath<HumanName>("name.first()")`). Error handling for `whenPath` and `guardPath` follows Pattern B (head preserved); `selectByPath` follows Pattern A (head skipped on failure).
+`selectByPath` has a reified Kotlin overload (`selectByPath<HumanName>("name.first()")` and `selectByPath<HumanName>(FhirPath.relative().navigate("name").first())`). Error handling for `whenPath` and `guardPath` follows Pattern B (head preserved); `selectByPath` follows Pattern A (head skipped on failure).
 
 #### Convenience lookups
 
@@ -1365,13 +1383,20 @@ val condition = FhirPath.from("active").eq(true)
     .build()
 // → "(active = true) and (name.exists())"
 
-// Use with existing OperationResult FHIRPath methods
+// Use with OperationResult FHIRPath methods — pass a FhirPath directly (no .build() needed)
+val activeGuard = FhirPath.relative().navigate("active").eq(true)
+val officialName = FhirPath.relative().navigate("name")
+    .where(FhirPath.relative().navigate("use").eq("official"))
+    .first()
+
 val result = OperationResult.of(patient)
+    .guardPath(activeGuard, "Patient must be active")
+    .selectByPath<HumanName>(officialName, "official-name")
+
+// String expressions still work — .build() is only needed when calling methods
+// that accept only a String:
+val result2 = OperationResult.of(patient)
     .guardPath(FhirPath.from("active").eq(true).build(), "Patient must be active")
-    .selectByPath<HumanName>(
-        FhirPath.from("name").where(FhirPath.relative().navigate("use").eq("official")).first().build(),
-        "official-name"
-    )
 ```
 
 ### Factory methods
@@ -1422,6 +1447,11 @@ String path = FhirPath.from("Patient")
     .first()
     .build();
 
+// Pass a FhirPath directly — no .build() needed:
+result.guardPath(FhirPath.from("active").eq(true), "Patient must be active");
+result.selectByPath(HumanName.class, FhirPath.relative().navigate("name").first(), "official-name");
+
+// String expressions still work unchanged:
 result.guardPath(FhirPath.from("active").eq(true).build(), "Patient must be active");
 ```
 

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
@@ -23,6 +23,7 @@ import org.hl7.fhir.dstu3.model.Type
 import org.hl7.fhir.dstu3.model.UriType
 import dev.ratkay.operation.DateTimeInput
 import dev.ratkay.operation.ErrorStrategy
+import dev.ratkay.operation.FhirPath
 import dev.ratkay.operation.IOperationResult
 import dev.ratkay.operation.StepMetrics
 import org.slf4j.LoggerFactory
@@ -341,6 +342,15 @@ class OperationResult<T> private constructor(
         }
     }
 
+    /** [FhirPath] overload of [addFromMatching] — builds the expression and delegates. */
+    @JvmOverloads
+    fun <I : Base, R : Base> addFromMatching(
+        name: String? = null,
+        type: KClass<I>,
+        expression: FhirPath,
+        builder: (List<I>) -> R
+    ): OperationResult<R> = addFromMatching(name, type, expression.build(), builder)
+
     /**
      * Like [addFromMatching] but [builder] returns a `List<R>`.
      * When [name] is `null`, the output key defaults to the first element's [Base.fhirType]
@@ -359,6 +369,15 @@ class OperationResult<T> private constructor(
         }
     }
 
+    /** [FhirPath] overload of [addAllFromMatching] — builds the expression and delegates. */
+    @JvmOverloads
+    fun <I : Base, R : Base> addAllFromMatching(
+        name: String? = null,
+        type: KClass<I>,
+        expression: FhirPath,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromMatching(name, type, expression.build(), builder)
+
     /** Reified overload of [addFromMatching] — no [KClass] argument needed at call sites. */
     inline fun <reified I : Base, R : Base> addFromMatching(
         name: String? = null,
@@ -366,12 +385,26 @@ class OperationResult<T> private constructor(
         noinline builder: (List<I>) -> R
     ): OperationResult<R> = addFromMatching(name, I::class, expression, builder)
 
+    /** [FhirPath] reified overload of [addFromMatching]. */
+    inline fun <reified I : Base, R : Base> addFromMatching(
+        name: String? = null,
+        expression: FhirPath,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromMatching(name, I::class, expression.build(), builder)
+
     /** Reified overload of [addAllFromMatching] — no [KClass] argument needed at call sites. */
     inline fun <reified I : Base, R : Base> addAllFromMatching(
         name: String? = null,
         expression: String,
         noinline builder: (List<I>) -> List<R>
     ): OperationResult<List<R>> = addAllFromMatching(name, I::class, expression, builder)
+
+    /** [FhirPath] reified overload of [addAllFromMatching]. */
+    inline fun <reified I : Base, R : Base> addAllFromMatching(
+        name: String? = null,
+        expression: FhirPath,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromMatching(name, I::class, expression.build(), builder)
 
     // Builder methods - single item
 
@@ -1063,6 +1096,10 @@ class OperationResult<T> private constructor(
         )
     }
 
+    /** [FhirPath] overload of [whenPath] — builds the expression and delegates. */
+    fun whenPath(expression: FhirPath, block: OperationResult<T>.() -> OperationResult<*>): OperationResult<T> =
+        whenPath(expression.build(), block)
+
     /**
      * Returns this result unchanged when [expression] evaluates to `true` against the current
      * head value.
@@ -1112,6 +1149,10 @@ class OperationResult<T> private constructor(
         }
     }
 
+    /** [FhirPath] overload of [guardPath] — builds the expression and delegates. */
+    fun guardPath(expression: FhirPath, message: String): OperationResult<T> =
+        guardPath(expression.build(), message)
+
     // ── FHIRPath extraction ───────────────────────────────────────────────
 
     /**
@@ -1143,9 +1184,18 @@ class OperationResult<T> private constructor(
         }
     }
 
+    /** [FhirPath] overload of [selectByPath] — builds the expression and delegates. */
+    @JvmOverloads
+    fun <R : Base> selectByPath(type: KClass<R>, expression: FhirPath, name: String? = null): OperationResult<R> =
+        selectByPath(type, expression.build(), name)
+
     /** Reified overload of [selectByPath] — no [KClass] argument needed at call sites. */
     inline fun <reified R : Base> selectByPath(expression: String, name: String? = null): OperationResult<R> =
         selectByPath(R::class, expression, name)
+
+    /** [FhirPath] reified overload of [selectByPath]. */
+    inline fun <reified R : Base> selectByPath(expression: FhirPath, name: String? = null): OperationResult<R> =
+        selectByPath(R::class, expression.build(), name)
 
     /** Returns the first value stored under [name], or `null` if the key is absent or empty. */
     fun takeFirst(name: String): Base? = parameters[name]?.firstOrNull()

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFhirPathTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFhirPathTest.kt
@@ -1,6 +1,7 @@
 package dev.ratkay.operation.dstu3
 
 import dev.ratkay.operation.ErrorStrategy
+import dev.ratkay.operation.FhirPath
 
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.empty
@@ -346,5 +347,138 @@ class OperationResultFhirPathTest {
 
         assertTrue(result.isSuccessful())
         assertEquals("Smith", result.getResult().value)
+    }
+
+    // ── FhirPath builder overloads ────────────────────────────────────────
+
+    @Test
+    fun `addFromMatching accepts FhirPath expression`() {
+        val activePatient = Patient().apply { active = true; setId("p1") }
+        val inactivePatient = Patient().apply { active = false; setId("p2") }
+        val expression = FhirPath.relative().navigate("active").eq(true)
+
+        val result = OperationResult.of(activePatient)
+            .add { inactivePatient }
+            .addFromMatching<Patient, StringType>("result", Patient::class, expression) { matches ->
+                assertThat(matches, hasSize(1))
+                assertThat(matches[0].idPart, `is`("p1"))
+                StringType("found")
+            }
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getAll("result"), hasSize(1))
+    }
+
+    @Test
+    fun `addFromMatching reified accepts FhirPath expression`() {
+        val patient = Patient().apply { active = true }
+        val expression = FhirPath.relative().navigate("active").eq(true)
+
+        val result = OperationResult.of(patient)
+            .addFromMatching<Patient, StringType>(expression = expression) { StringType("ok") }
+
+        assertThat(result.getAll("string"), hasSize(1))
+    }
+
+    @Test
+    fun `addAllFromMatching accepts FhirPath expression`() {
+        val p1 = Patient().apply { active = true; setId("p1") }
+        val p2 = Patient().apply { active = true; setId("p2") }
+        val expression = FhirPath.relative().navigate("active").eq(true)
+
+        val result = OperationResult.of(p1)
+            .add { p2 }
+            .addAllFromMatching("active", Patient::class, expression) { it }
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getAll("active"), hasSize(2))
+    }
+
+    @Test
+    fun `addAllFromMatching reified accepts FhirPath expression`() {
+        val patient = Patient().apply { active = true }
+        val expression = FhirPath.relative().navigate("active").eq(true)
+
+        val result = OperationResult.of(patient)
+            .addAllFromMatching<Patient, Patient>(expression = expression) { it }
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getResult(), hasSize(1))
+    }
+
+    @Test
+    fun `whenPath accepts FhirPath expression`() {
+        val patient = Patient().apply { active = true }
+        val expression = FhirPath.relative().navigate("active").eq(true)
+
+        val result = OperationResult.of(patient)
+            .whenPath(expression) { add("flag") { StringType("ran") } }
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getAll("flag"), hasSize(1))
+    }
+
+    @Test
+    fun `whenPath with FhirPath skips block when expression is false`() {
+        val patient = Patient().apply { active = false }
+        val expression = FhirPath.relative().navigate("active").eq(true)
+
+        val result = OperationResult.of(patient)
+            .whenPath(expression) { add("flag") { StringType("should-not-run") } }
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getAll("flag"), empty())
+    }
+
+    @Test
+    fun `guardPath accepts FhirPath expression`() {
+        val patient = Patient().apply { active = true }
+        val expression = FhirPath.relative().navigate("active").eq(true)
+
+        val result = OperationResult.of(patient)
+            .guardPath(expression, "Patient must be active")
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getOutcomes(), empty())
+    }
+
+    @Test
+    fun `guardPath with FhirPath records WARNING when expression is false`() {
+        val patient = Patient().apply { active = false }
+        val expression = FhirPath.relative().navigate("active").eq(true)
+
+        val result = OperationResult.of(patient)
+            .guardPath(expression, "Patient must be active")
+
+        assertTrue(result.hasErrors())
+        assertEquals(OperationOutcome.IssueSeverity.WARNING, result.getOutcomes().first().issueFirstRep.severity)
+    }
+
+    @Test
+    fun `selectByPath KClass accepts FhirPath expression`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith"; addGiven("John") }
+        }
+        val expression = FhirPath.relative().navigate("name").first()
+
+        val result = OperationResult.of(patient)
+            .selectByPath(HumanName::class, expression)
+
+        assertTrue(result.isSuccessful())
+        assertEquals("Smith", result.getResult().family)
+    }
+
+    @Test
+    fun `selectByPath reified accepts FhirPath expression`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Jones" }
+        }
+        val expression = FhirPath.relative().navigate("name").first()
+
+        val result = OperationResult.of(patient)
+            .selectByPath<HumanName>(expression)
+
+        assertTrue(result.isSuccessful())
+        assertEquals("Jones", result.getResult().family)
     }
 }

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -2,6 +2,7 @@ package dev.ratkay.operation.r4
 
 import dev.ratkay.operation.DateTimeInput
 import dev.ratkay.operation.ErrorStrategy
+import dev.ratkay.operation.FhirPath
 import dev.ratkay.operation.IOperationResult
 import dev.ratkay.operation.StepMetrics
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException
@@ -344,6 +345,15 @@ class OperationResult<T> private constructor(
         }
     }
 
+    /** [FhirPath] overload of [addFromMatching] — builds the expression and delegates. */
+    @JvmOverloads
+    fun <I : Base, R : Base> addFromMatching(
+        name: String? = null,
+        type: KClass<I>,
+        expression: FhirPath,
+        builder: (List<I>) -> R
+    ): OperationResult<R> = addFromMatching(name, type, expression.build(), builder)
+
     /**
      * Like [addFromMatching] but [builder] returns a `List<R>`.
      * When [name] is `null`, the output key defaults to the first element's [Base.fhirType]
@@ -362,6 +372,15 @@ class OperationResult<T> private constructor(
         }
     }
 
+    /** [FhirPath] overload of [addAllFromMatching] — builds the expression and delegates. */
+    @JvmOverloads
+    fun <I : Base, R : Base> addAllFromMatching(
+        name: String? = null,
+        type: KClass<I>,
+        expression: FhirPath,
+        builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromMatching(name, type, expression.build(), builder)
+
     /** Reified overload of [addFromMatching] — no [KClass] argument needed at call sites. */
     inline fun <reified I : Base, R : Base> addFromMatching(
         name: String? = null,
@@ -369,12 +388,26 @@ class OperationResult<T> private constructor(
         noinline builder: (List<I>) -> R
     ): OperationResult<R> = addFromMatching(name, I::class, expression, builder)
 
+    /** [FhirPath] reified overload of [addFromMatching]. */
+    inline fun <reified I : Base, R : Base> addFromMatching(
+        name: String? = null,
+        expression: FhirPath,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromMatching(name, I::class, expression.build(), builder)
+
     /** Reified overload of [addAllFromMatching] — no [KClass] argument needed at call sites. */
     inline fun <reified I : Base, R : Base> addAllFromMatching(
         name: String? = null,
         expression: String,
         noinline builder: (List<I>) -> List<R>
     ): OperationResult<List<R>> = addAllFromMatching(name, I::class, expression, builder)
+
+    /** [FhirPath] reified overload of [addAllFromMatching]. */
+    inline fun <reified I : Base, R : Base> addAllFromMatching(
+        name: String? = null,
+        expression: FhirPath,
+        noinline builder: (List<I>) -> List<R>
+    ): OperationResult<List<R>> = addAllFromMatching(name, I::class, expression.build(), builder)
 
     // Builder methods - single item
 
@@ -1068,6 +1101,10 @@ class OperationResult<T> private constructor(
         )
     }
 
+    /** [FhirPath] overload of [whenPath] — builds the expression and delegates. */
+    fun whenPath(expression: FhirPath, block: OperationResult<T>.() -> OperationResult<*>): OperationResult<T> =
+        whenPath(expression.build(), block)
+
     /**
      * Returns this result unchanged when [expression] evaluates to `true` against the current
      * head value.
@@ -1117,6 +1154,10 @@ class OperationResult<T> private constructor(
         }
     }
 
+    /** [FhirPath] overload of [guardPath] — builds the expression and delegates. */
+    fun guardPath(expression: FhirPath, message: String): OperationResult<T> =
+        guardPath(expression.build(), message)
+
     // ── FHIRPath extraction ───────────────────────────────────────────────
 
     /**
@@ -1148,9 +1189,18 @@ class OperationResult<T> private constructor(
         }
     }
 
+    /** [FhirPath] overload of [selectByPath] — builds the expression and delegates. */
+    @JvmOverloads
+    fun <R : Base> selectByPath(type: KClass<R>, expression: FhirPath, name: String? = null): OperationResult<R> =
+        selectByPath(type, expression.build(), name)
+
     /** Reified overload of [selectByPath] — no [KClass] argument needed at call sites. */
     inline fun <reified R : Base> selectByPath(expression: String, name: String? = null): OperationResult<R> =
         selectByPath(R::class, expression, name)
+
+    /** [FhirPath] reified overload of [selectByPath]. */
+    inline fun <reified R : Base> selectByPath(expression: FhirPath, name: String? = null): OperationResult<R> =
+        selectByPath(R::class, expression.build(), name)
 
     /** Returns the first value stored under [name], or `null` if the key is absent or empty. */
     fun takeFirst(name: String): Base? = parameters[name]?.firstOrNull()

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFhirPathTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFhirPathTest.kt
@@ -1,6 +1,7 @@
 package dev.ratkay.operation.r4
 
 import dev.ratkay.operation.ErrorStrategy
+import dev.ratkay.operation.FhirPath
 
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.empty
@@ -346,5 +347,138 @@ class OperationResultFhirPathTest {
 
         assertTrue(result.isSuccessful())
         assertEquals("Smith", result.getResult().value)
+    }
+
+    // ── FhirPath builder overloads ────────────────────────────────────────
+
+    @Test
+    fun `addFromMatching accepts FhirPath expression`() {
+        val activePatient = Patient().apply { active = true; setId("p1") }
+        val inactivePatient = Patient().apply { active = false; setId("p2") }
+        val expression = FhirPath.relative().navigate("active").eq(true)
+
+        val result = OperationResult.of(activePatient)
+            .add { inactivePatient }
+            .addFromMatching<Patient, StringType>("result", Patient::class, expression) { matches ->
+                assertThat(matches, hasSize(1))
+                assertThat(matches[0].idPart, `is`("p1"))
+                StringType("found")
+            }
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getAll("result"), hasSize(1))
+    }
+
+    @Test
+    fun `addFromMatching reified accepts FhirPath expression`() {
+        val patient = Patient().apply { active = true }
+        val expression = FhirPath.relative().navigate("active").eq(true)
+
+        val result = OperationResult.of(patient)
+            .addFromMatching<Patient, StringType>(expression = expression) { StringType("ok") }
+
+        assertThat(result.getAll("string"), hasSize(1))
+    }
+
+    @Test
+    fun `addAllFromMatching accepts FhirPath expression`() {
+        val p1 = Patient().apply { active = true; setId("p1") }
+        val p2 = Patient().apply { active = true; setId("p2") }
+        val expression = FhirPath.relative().navigate("active").eq(true)
+
+        val result = OperationResult.of(p1)
+            .add { p2 }
+            .addAllFromMatching("active", Patient::class, expression) { it }
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getAll("active"), hasSize(2))
+    }
+
+    @Test
+    fun `addAllFromMatching reified accepts FhirPath expression`() {
+        val patient = Patient().apply { active = true }
+        val expression = FhirPath.relative().navigate("active").eq(true)
+
+        val result = OperationResult.of(patient)
+            .addAllFromMatching<Patient, Patient>(expression = expression) { it }
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getResult(), hasSize(1))
+    }
+
+    @Test
+    fun `whenPath accepts FhirPath expression`() {
+        val patient = Patient().apply { active = true }
+        val expression = FhirPath.relative().navigate("active").eq(true)
+
+        val result = OperationResult.of(patient)
+            .whenPath(expression) { add("flag") { StringType("ran") } }
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getAll("flag"), hasSize(1))
+    }
+
+    @Test
+    fun `whenPath with FhirPath skips block when expression is false`() {
+        val patient = Patient().apply { active = false }
+        val expression = FhirPath.relative().navigate("active").eq(true)
+
+        val result = OperationResult.of(patient)
+            .whenPath(expression) { add("flag") { StringType("should-not-run") } }
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getAll("flag"), empty())
+    }
+
+    @Test
+    fun `guardPath accepts FhirPath expression`() {
+        val patient = Patient().apply { active = true }
+        val expression = FhirPath.relative().navigate("active").eq(true)
+
+        val result = OperationResult.of(patient)
+            .guardPath(expression, "Patient must be active")
+
+        assertTrue(result.isSuccessful())
+        assertThat(result.getOutcomes(), empty())
+    }
+
+    @Test
+    fun `guardPath with FhirPath records WARNING when expression is false`() {
+        val patient = Patient().apply { active = false }
+        val expression = FhirPath.relative().navigate("active").eq(true)
+
+        val result = OperationResult.of(patient)
+            .guardPath(expression, "Patient must be active")
+
+        assertTrue(result.hasErrors())
+        assertEquals(OperationOutcome.IssueSeverity.WARNING, result.getOutcomes().first().issueFirstRep.severity)
+    }
+
+    @Test
+    fun `selectByPath KClass accepts FhirPath expression`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Smith"; addGiven("John") }
+        }
+        val expression = FhirPath.relative().navigate("name").first()
+
+        val result = OperationResult.of(patient)
+            .selectByPath(HumanName::class, expression)
+
+        assertTrue(result.isSuccessful())
+        assertEquals("Smith", result.getResult().family)
+    }
+
+    @Test
+    fun `selectByPath reified accepts FhirPath expression`() {
+        val patient = Patient().apply {
+            addName().apply { family = "Jones" }
+        }
+        val expression = FhirPath.relative().navigate("name").first()
+
+        val result = OperationResult.of(patient)
+            .selectByPath<HumanName>(expression)
+
+        assertTrue(result.isSuccessful())
+        assertEquals("Jones", result.getResult().family)
     }
 }


### PR DESCRIPTION
All five methods in OperationResult that previously accepted a raw
FHIRPath expression string now have a FhirPath-typed overload. Each
FhirPath overload calls `.build()` and delegates to the String variant,
so no evaluation logic is duplicated.

Methods with new FhirPath overloads (both KClass and reified forms where
applicable): addFromMatching, addAllFromMatching, whenPath, guardPath,
selectByPath. Ported to DSTU3 with identical structure.