### PR TITLE
Strengthen Bundle API: fromBundleTyped, toCollectionBundle, configBlock on convenience aliases, KDoc warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ val result = OperationResult.of(patient)
     .linkReferences()           // auto-wire FHIR references between resources
 
 result.toParameters()           // serialize to a FHIR Parameters resource
-result.toTransactionBundle()    // serialize to a FHIR transaction Bundle
+result.toTransactionBundle()    // serialize to a FHIR transaction Bundle (Resources only)
 result.getResult()              // the most recently added value (typed)
 
 // Async
@@ -924,12 +924,22 @@ result.toParameters()   // structurally identical to `original`
 
 #### FHIR Bundle
 
+Only accumulated `Resource` values appear in the bundle; primitive and complex `Type` values
+added via `addString`, `addCoding`, `addPart`, etc. are not representable as bundle entries and
+are silently omitted. Use `toParameters()` to serialise the full accumulated state.
+
 ```kotlin
-result.toTransactionBundle()          // Bundle (type = TRANSACTION), PUT/POST requests added per resource
+result.toCollectionBundle()           // Bundle (type = COLLECTION)
+result.toTransactionBundle()          // Bundle (type = TRANSACTION), PUT/POST inferred per resource
 result.toBatchBundle()                // Bundle (type = BATCH)
-result.toBundle(Bundle.BundleType.COLLECTION)
 result.toBundle(Bundle.BundleType.SEARCHSET) { entry ->
-    entry.search.mode = Bundle.SearchEntryMode.MATCH  // optional entry config block
+    entry.search.mode = Bundle.SearchEntryMode.MATCH  // optional per-entry config block
+}
+
+// configBlock is available on all three convenience aliases too,
+// e.g. to set fullUrl for cross-entry reference resolution in a transaction:
+result.toTransactionBundle { entry ->
+    entry.fullUrl = "urn:uuid:${UUID.randomUUID()}"
 }
 ```
 
@@ -950,6 +960,9 @@ val result = OperationResult.fromParametersTyped<Patient>(parameters, primaryKey
 
 // From a Bundle — keys default to fhirType().lowercase()
 val result = OperationResult.fromBundle(bundle)
+
+// Typed head — getResult() returns a Patient without casting
+val result = OperationResult.fromBundleTyped<Patient>(bundle, primaryKey = "patient")
 
 // Custom key strategy
 val result = OperationResult.fromBundle(bundle) { entry ->
@@ -1559,8 +1572,13 @@ val result = OperationResult.fromBundle(bundle)
 // or with a custom key per entry:
 val result = OperationResult.fromBundle(bundle) { entry -> entry.fullUrl }
 
+// Typed head — getResult() returns a Patient without casting
+val result = OperationResult.fromBundleTyped<Patient>(bundle, primaryKey = "patient")
+
 result.getByType<Patient>()
+result.toCollectionBundle()
 result.toTransactionBundle()
+result.toTransactionBundle { entry -> entry.fullUrl = "urn:uuid:${UUID.randomUUID()}" }
 ```
 
 ### 10. Filtering and transforming
@@ -1955,8 +1973,16 @@ result.addCodeableConcept("category", "http://loinc.org", "vital-signs")
       .addCodeableConcept("category", "http://loinc.org", "vital-signs", "Vital Signs", "Patient vitals");
 
 // toBundle — configBlock is optional
-Bundle plain = result.toBundle(Bundle.BundleType.COLLECTION);
+Bundle plain  = result.toBundle(Bundle.BundleType.COLLECTION);
 Bundle custom = result.toBundle(Bundle.BundleType.COLLECTION, entry -> entry.setFullUrl("urn:uuid:" + UUID.randomUUID()));
+
+// Convenience aliases — configBlock is optional on all three
+Bundle collection  = result.toCollectionBundle();
+Bundle transaction = result.toTransactionBundle(entry -> entry.setFullUrl("urn:uuid:" + UUID.randomUUID()));
+Bundle batch       = result.toBatchBundle();
+
+// fromBundleTyped — sets a typed pipeline head
+OperationResult<Patient> fromBundle = OperationResult.fromBundleTyped(bundle, "patient", Patient.class);
 ```
 
 ### Retry methods

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
@@ -64,8 +64,8 @@ import kotlin.time.measureTimedValue
  * | FHIRPath extraction | `selectByPath` |
  * | Extraction | `takeFirst`, `takeFirstTyped`, `extractParam`, `extractParamList` |
  * | Reference linking | `linkReferences` |
- * | Serialization | `toParameters`, `toBundleEntry`, `toBundle`, `toTransactionBundle`, `toBatchBundle`, `getResult` |
- * | Factory *(companion)* | `of`, `fromParameters`, `fromParametersTyped`, `fromBundle`, `empty` |
+ * | Serialization | `toParameters`, `toBundleEntry`, `toBundle`, `toCollectionBundle`, `toTransactionBundle`, `toBatchBundle`, `getResult` |
+ * | Factory *(companion)* | `of`, `fromParameters`, `fromParametersTyped`, `fromBundle`, `fromBundleTyped`, `empty` |
  */
 class OperationResult<T> private constructor(
     private val parameters: MutableMap<String, MutableList<Base>>,
@@ -1311,6 +1311,24 @@ class OperationResult<T> private constructor(
             if (resource is Resource) setResource(resource)
         }
 
+    /**
+     * Serialises all accumulated [Resource] values to a FHIR [Bundle] of the given [type].
+     *
+     * Only [Resource] subtypes from the parameter map are written as bundle entries.
+     * Primitive and complex FHIR [Type] values added via `addString`, `addCoding`, `addPart`,
+     * etc. are not representable in a Bundle entry and are silently omitted.
+     * Use [toParameters] to serialise the full accumulated state including non-Resource values.
+     *
+     * Type-specific behaviour:
+     * - **TRANSACTION / BATCH**: each entry gets a `request` component; PUT with
+     *   `"ResourceType/id"` when the resource has an id, POST with `"ResourceType"` otherwise.
+     * - **SEARCHSET**: each entry gets `search.mode = MATCH`; `bundle.total` is set to the
+     *   number of entries.
+     * - All other types (e.g. COLLECTION): plain entries with no request/search metadata.
+     *
+     * @param configBlock optional lambda applied to each [Bundle.BundleEntryComponent] after the
+     *   automatic type-specific logic, useful for setting `fullUrl` or overriding search mode.
+     */
     @JvmOverloads
     fun toBundle(
         type: Bundle.BundleType,
@@ -1347,9 +1365,46 @@ class OperationResult<T> private constructor(
         }
     }
 
-    fun toTransactionBundle(): Bundle = toBundle(Bundle.BundleType.TRANSACTION)
+    /**
+     * Convenience alias for `toBundle(Bundle.BundleType.COLLECTION, configBlock)`.
+     *
+     * Only [Resource] values are included; non-Resource accumulated values are silently omitted.
+     * Use [toParameters] to serialise the full state.
+     *
+     * @param configBlock optional lambda applied to each entry, e.g. to set `fullUrl`.
+     */
+    @JvmOverloads
+    fun toCollectionBundle(
+        configBlock: ((Bundle.BundleEntryComponent) -> Unit)? = null
+    ): Bundle = toBundle(Bundle.BundleType.COLLECTION, configBlock)
 
-    fun toBatchBundle(): Bundle = toBundle(Bundle.BundleType.BATCH)
+    /**
+     * Convenience alias for `toBundle(Bundle.BundleType.TRANSACTION, configBlock)`.
+     *
+     * Only [Resource] values are included; non-Resource accumulated values are silently omitted.
+     * Use [toParameters] to serialise the full state.
+     *
+     * @param configBlock optional lambda applied to each entry after the automatic PUT/POST
+     *   inference, e.g. to set `fullUrl` for cross-entry reference resolution.
+     */
+    @JvmOverloads
+    fun toTransactionBundle(
+        configBlock: ((Bundle.BundleEntryComponent) -> Unit)? = null
+    ): Bundle = toBundle(Bundle.BundleType.TRANSACTION, configBlock)
+
+    /**
+     * Convenience alias for `toBundle(Bundle.BundleType.BATCH, configBlock)`.
+     *
+     * Only [Resource] values are included; non-Resource accumulated values are silently omitted.
+     * Use [toParameters] to serialise the full state.
+     *
+     * @param configBlock optional lambda applied to each entry after the automatic PUT/POST
+     *   inference, e.g. to set `fullUrl`.
+     */
+    @JvmOverloads
+    fun toBatchBundle(
+        configBlock: ((Bundle.BundleEntryComponent) -> Unit)? = null
+    ): Bundle = toBundle(Bundle.BundleType.BATCH, configBlock)
 
     /**
      * Returns the most recently added value, typed as [T].
@@ -1492,6 +1547,52 @@ class OperationResult<T> private constructor(
                 }
             return OperationResult(params, null, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
         }
+
+        /**
+         * Builds an [OperationResult] from a FHIR [Bundle] and sets the typed pipeline head to
+         * the first resource stored under [primaryKey] that is an instance of [type].
+         *
+         * Resources are keyed by `resource.fhirType().lowercase()` (same as the default
+         * [fromBundle] overload).  All resources are loaded into the parameter map; only the
+         * head is narrowed to [T].
+         *
+         * @throws IllegalArgumentException if no resource of [type] exists under [primaryKey].
+         */
+        @JvmStatic
+        fun <T : Resource> fromBundleTyped(
+            bundle: Bundle,
+            primaryKey: String,
+            type: KClass<T>
+        ): OperationResult<T> {
+            val params = mutableMapOf<String, MutableList<Base>>()
+            bundle.entry
+                .filter { it.hasResource() }
+                .forEach { entry ->
+                    val key = entry.resource.fhirType().lowercase()
+                    params.getOrPut(key) { mutableListOf() }.add(entry.resource)
+                }
+            val primary = params[primaryKey]
+                ?.filterIsInstance(type.java)
+                ?.firstOrNull()
+                ?: throw IllegalArgumentException(
+                    "No value of type '${type.simpleName}' found under key '$primaryKey'"
+                )
+            return OperationResult(params, primary, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
+        }
+
+        /** Java-friendly overload of [fromBundleTyped] — accepts [Class] instead of [KClass]. */
+        @JvmStatic
+        fun <T : Resource> fromBundleTyped(
+            bundle: Bundle,
+            primaryKey: String,
+            type: Class<T>
+        ): OperationResult<T> = fromBundleTyped(bundle, primaryKey, type.kotlin)
+
+        /** Reified overload of [fromBundleTyped] — no [KClass] argument needed at call sites. */
+        inline fun <reified T : Resource> fromBundleTyped(
+            bundle: Bundle,
+            primaryKey: String
+        ): OperationResult<T> = fromBundleTyped(bundle, primaryKey, T::class)
 
         /**
          * Creates an empty [OperationResult] with no parameters and no pipeline head.

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFromTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFromTest.kt
@@ -508,6 +508,89 @@ class OperationResultFromTest {
         assertEquals(2, roundTripped.totalCount())
     }
 
+    // ── fromBundleTyped ───────────────────────────────────────────────────────
+
+    @Test
+    fun `fromBundleTyped - sets typed head to first resource under primary key`() {
+        val p = Patient().apply { id = "p1" }
+        val bundle = Bundle().apply {
+            type = Bundle.BundleType.COLLECTION
+            addEntry().resource = p
+        }
+
+        val result = OperationResult.fromBundleTyped(bundle, "patient", Patient::class)
+
+        assertInstanceOf(Patient::class.java, result.getResult())
+        assertEquals("p1", result.getResult().idPart)
+    }
+
+    @Test
+    fun `fromBundleTyped reified overload - no KClass argument needed`() {
+        val p = patient()
+        val bundle = Bundle().apply {
+            type = Bundle.BundleType.COLLECTION
+            addEntry().resource = p
+        }
+
+        val result = OperationResult.fromBundleTyped<Patient>(bundle, "patient")
+
+        assertInstanceOf(Patient::class.java, result.getResult())
+    }
+
+    @Test
+    fun `fromBundleTyped Class overload - Java-friendly`() {
+        val p = patient()
+        val bundle = Bundle().apply {
+            type = Bundle.BundleType.COLLECTION
+            addEntry().resource = p
+        }
+
+        val result = OperationResult.fromBundleTyped(bundle, "patient", Patient::class.java)
+
+        assertInstanceOf(Patient::class.java, result.getResult())
+    }
+
+    @Test
+    fun `fromBundleTyped - all other resources are still accessible`() {
+        val p = patient()
+        val a = appointment()
+        val bundle = Bundle().apply {
+            type = Bundle.BundleType.COLLECTION
+            addEntry().resource = p
+            addEntry().resource = a
+        }
+
+        val result = OperationResult.fromBundleTyped<Patient>(bundle, "patient")
+
+        assertThat(result.getByType<Patient>(), hasSize(1))
+        assertThat(result.getByType<Appointment>(), hasSize(1))
+        assertEquals(2, result.totalCount())
+    }
+
+    @Test
+    fun `fromBundleTyped - throws when primary key is absent`() {
+        val bundle = Bundle().apply {
+            type = Bundle.BundleType.COLLECTION
+            addEntry().resource = appointment()
+        }
+
+        assertThrows<IllegalArgumentException> {
+            OperationResult.fromBundleTyped<Patient>(bundle, "patient")
+        }
+    }
+
+    @Test
+    fun `fromBundleTyped - throws when key exists but type does not match`() {
+        val bundle = Bundle().apply {
+            type = Bundle.BundleType.COLLECTION
+            addEntry().resource = appointment()
+        }
+
+        assertThrows<IllegalArgumentException> {
+            OperationResult.fromBundleTyped<Patient>(bundle, "appointment")
+        }
+    }
+
     // ── extractParam / extractParamList ──────────────────────────────────────
 
     @Test

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultTest.kt
@@ -1081,6 +1081,55 @@ class OperationResultTest {
         assertEquals(Bundle.HTTPVerb.POST, bundle.entryFirstRep.request.method)
     }
 
+    @Test
+    fun `toCollectionBundle - convenience alias produces COLLECTION bundle`() {
+        val result = OperationResult.of(patient(), "patient")
+            .add("appt") { appointment() }
+
+        val bundle = result.toCollectionBundle()
+
+        assertEquals(Bundle.BundleType.COLLECTION, bundle.type)
+        assertThat(bundle.entry, hasSize(2))
+        assertThat(bundle.entry[0].resource, instanceOf(Patient::class.java))
+        assertThat(bundle.entry[1].resource, instanceOf(Appointment::class.java))
+    }
+
+    @Test
+    fun `toCollectionBundle with configBlock - applies configuration to each entry`() {
+        val result = OperationResult.of(patient(), "patient")
+
+        val bundle = result.toCollectionBundle { entry ->
+            entry.fullUrl = "http://example.com/fhir/Patient/test"
+        }
+
+        assertEquals("http://example.com/fhir/Patient/test", bundle.entryFirstRep.fullUrl)
+    }
+
+    @Test
+    fun `toTransactionBundle with configBlock - sets fullUrl on each entry`() {
+        val result = OperationResult.of(Patient().apply { id = "p1" }, "patient")
+
+        val bundle = result.toTransactionBundle { entry ->
+            entry.fullUrl = "urn:uuid:patient-p1"
+        }
+
+        assertEquals(Bundle.BundleType.TRANSACTION, bundle.type)
+        assertEquals("urn:uuid:patient-p1", bundle.entryFirstRep.fullUrl)
+        assertEquals(Bundle.HTTPVerb.PUT, bundle.entryFirstRep.request.method)
+    }
+
+    @Test
+    fun `toBatchBundle with configBlock - sets fullUrl on each entry`() {
+        val result = OperationResult.of(patient(), "patient")
+
+        val bundle = result.toBatchBundle { entry ->
+            entry.fullUrl = "urn:uuid:patient-new"
+        }
+
+        assertEquals(Bundle.BundleType.BATCH, bundle.type)
+        assertEquals("urn:uuid:patient-new", bundle.entryFirstRep.fullUrl)
+    }
+
     // ── Type safety ───────────────────────────────────────────────────────────
     // These tests prove compile-time type enforcement: if the generic machinery
     // were broken the typed assignments below would fail to compile.

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -67,8 +67,8 @@ import kotlin.time.measureTimedValue
  * | FHIRPath extraction | `selectByPath` |
  * | Extraction | `takeFirst`, `takeFirstTyped`, `extractParam`, `extractParamList` |
  * | Reference linking | `linkReferences` |
- * | Serialization | `toParameters`, `toBundleEntry`, `toBundle`, `toTransactionBundle`, `toBatchBundle`, `getResult` |
- * | Factory *(companion)* | `of`, `fromParameters`, `fromParametersTyped`, `fromBundle`, `empty` |
+ * | Serialization | `toParameters`, `toBundleEntry`, `toBundle`, `toCollectionBundle`, `toTransactionBundle`, `toBatchBundle`, `getResult` |
+ * | Factory *(companion)* | `of`, `fromParameters`, `fromParametersTyped`, `fromBundle`, `fromBundleTyped`, `empty` |
  */
 class OperationResult<T> private constructor(
     private val parameters: MutableMap<String, MutableList<Base>>,
@@ -1316,6 +1316,24 @@ class OperationResult<T> private constructor(
             if (resource is Resource) setResource(resource)
         }
 
+    /**
+     * Serialises all accumulated [Resource] values to a FHIR [Bundle] of the given [type].
+     *
+     * Only [Resource] subtypes from the parameter map are written as bundle entries.
+     * Primitive and complex FHIR [Type] values added via `addString`, `addCoding`, `addPart`,
+     * etc. are not representable in a Bundle entry and are silently omitted.
+     * Use [toParameters] to serialise the full accumulated state including non-Resource values.
+     *
+     * Type-specific behaviour:
+     * - **TRANSACTION / BATCH**: each entry gets a `request` component; PUT with
+     *   `"ResourceType/id"` when the resource has an id, POST with `"ResourceType"` otherwise.
+     * - **SEARCHSET**: each entry gets `search.mode = MATCH`; `bundle.total` is set to the
+     *   number of entries.
+     * - All other types (e.g. COLLECTION): plain entries with no request/search metadata.
+     *
+     * @param configBlock optional lambda applied to each [Bundle.BundleEntryComponent] after the
+     *   automatic type-specific logic, useful for setting `fullUrl` or overriding search mode.
+     */
     @JvmOverloads
     fun toBundle(
         type: Bundle.BundleType,
@@ -1352,9 +1370,46 @@ class OperationResult<T> private constructor(
         }
     }
 
-    fun toTransactionBundle(): Bundle = toBundle(Bundle.BundleType.TRANSACTION)
+    /**
+     * Convenience alias for `toBundle(Bundle.BundleType.COLLECTION, configBlock)`.
+     *
+     * Only [Resource] values are included; non-Resource accumulated values are silently omitted.
+     * Use [toParameters] to serialise the full state.
+     *
+     * @param configBlock optional lambda applied to each entry, e.g. to set `fullUrl`.
+     */
+    @JvmOverloads
+    fun toCollectionBundle(
+        configBlock: ((Bundle.BundleEntryComponent) -> Unit)? = null
+    ): Bundle = toBundle(Bundle.BundleType.COLLECTION, configBlock)
 
-    fun toBatchBundle(): Bundle = toBundle(Bundle.BundleType.BATCH)
+    /**
+     * Convenience alias for `toBundle(Bundle.BundleType.TRANSACTION, configBlock)`.
+     *
+     * Only [Resource] values are included; non-Resource accumulated values are silently omitted.
+     * Use [toParameters] to serialise the full state.
+     *
+     * @param configBlock optional lambda applied to each entry after the automatic PUT/POST
+     *   inference, e.g. to set `fullUrl` for cross-entry reference resolution.
+     */
+    @JvmOverloads
+    fun toTransactionBundle(
+        configBlock: ((Bundle.BundleEntryComponent) -> Unit)? = null
+    ): Bundle = toBundle(Bundle.BundleType.TRANSACTION, configBlock)
+
+    /**
+     * Convenience alias for `toBundle(Bundle.BundleType.BATCH, configBlock)`.
+     *
+     * Only [Resource] values are included; non-Resource accumulated values are silently omitted.
+     * Use [toParameters] to serialise the full state.
+     *
+     * @param configBlock optional lambda applied to each entry after the automatic PUT/POST
+     *   inference, e.g. to set `fullUrl`.
+     */
+    @JvmOverloads
+    fun toBatchBundle(
+        configBlock: ((Bundle.BundleEntryComponent) -> Unit)? = null
+    ): Bundle = toBundle(Bundle.BundleType.BATCH, configBlock)
 
     /**
      * Returns the most recently added value, typed as [T].
@@ -1497,6 +1552,52 @@ class OperationResult<T> private constructor(
                 }
             return OperationResult(params, null, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
         }
+
+        /**
+         * Builds an [OperationResult] from a FHIR [Bundle] and sets the typed pipeline head to
+         * the first resource stored under [primaryKey] that is an instance of [type].
+         *
+         * Resources are keyed by `resource.fhirType().lowercase()` (same as the default
+         * [fromBundle] overload).  All resources are loaded into the parameter map; only the
+         * head is narrowed to [T].
+         *
+         * @throws IllegalArgumentException if no resource of [type] exists under [primaryKey].
+         */
+        @JvmStatic
+        fun <T : Resource> fromBundleTyped(
+            bundle: Bundle,
+            primaryKey: String,
+            type: KClass<T>
+        ): OperationResult<T> {
+            val params = mutableMapOf<String, MutableList<Base>>()
+            bundle.entry
+                .filter { it.hasResource() }
+                .forEach { entry ->
+                    val key = entry.resource.fhirType().lowercase()
+                    params.getOrPut(key) { mutableListOf() }.add(entry.resource)
+                }
+            val primary = params[primaryKey]
+                ?.filterIsInstance(type.java)
+                ?.firstOrNull()
+                ?: throw IllegalArgumentException(
+                    "No value of type '${type.simpleName}' found under key '$primaryKey'"
+                )
+            return OperationResult(params, primary, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
+        }
+
+        /** Java-friendly overload of [fromBundleTyped] — accepts [Class] instead of [KClass]. */
+        @JvmStatic
+        fun <T : Resource> fromBundleTyped(
+            bundle: Bundle,
+            primaryKey: String,
+            type: Class<T>
+        ): OperationResult<T> = fromBundleTyped(bundle, primaryKey, type.kotlin)
+
+        /** Reified overload of [fromBundleTyped] — no [KClass] argument needed at call sites. */
+        inline fun <reified T : Resource> fromBundleTyped(
+            bundle: Bundle,
+            primaryKey: String
+        ): OperationResult<T> = fromBundleTyped(bundle, primaryKey, T::class)
 
         /**
          * Creates an empty [OperationResult] with no parameters and no pipeline head.

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFromTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFromTest.kt
@@ -508,6 +508,89 @@ class OperationResultFromTest {
         assertEquals(2, roundTripped.totalCount())
     }
 
+    // ── fromBundleTyped ───────────────────────────────────────────────────────
+
+    @Test
+    fun `fromBundleTyped - sets typed head to first resource under primary key`() {
+        val p = Patient().apply { id = "p1" }
+        val bundle = Bundle().apply {
+            type = Bundle.BundleType.COLLECTION
+            addEntry().resource = p
+        }
+
+        val result = OperationResult.fromBundleTyped(bundle, "patient", Patient::class)
+
+        assertInstanceOf(Patient::class.java, result.getResult())
+        assertEquals("p1", result.getResult().idPart)
+    }
+
+    @Test
+    fun `fromBundleTyped reified overload - no KClass argument needed`() {
+        val p = patient()
+        val bundle = Bundle().apply {
+            type = Bundle.BundleType.COLLECTION
+            addEntry().resource = p
+        }
+
+        val result = OperationResult.fromBundleTyped<Patient>(bundle, "patient")
+
+        assertInstanceOf(Patient::class.java, result.getResult())
+    }
+
+    @Test
+    fun `fromBundleTyped Class overload - Java-friendly`() {
+        val p = patient()
+        val bundle = Bundle().apply {
+            type = Bundle.BundleType.COLLECTION
+            addEntry().resource = p
+        }
+
+        val result = OperationResult.fromBundleTyped(bundle, "patient", Patient::class.java)
+
+        assertInstanceOf(Patient::class.java, result.getResult())
+    }
+
+    @Test
+    fun `fromBundleTyped - all other resources are still accessible`() {
+        val p = patient()
+        val a = appointment()
+        val bundle = Bundle().apply {
+            type = Bundle.BundleType.COLLECTION
+            addEntry().resource = p
+            addEntry().resource = a
+        }
+
+        val result = OperationResult.fromBundleTyped<Patient>(bundle, "patient")
+
+        assertThat(result.getByType<Patient>(), hasSize(1))
+        assertThat(result.getByType<Appointment>(), hasSize(1))
+        assertEquals(2, result.totalCount())
+    }
+
+    @Test
+    fun `fromBundleTyped - throws when primary key is absent`() {
+        val bundle = Bundle().apply {
+            type = Bundle.BundleType.COLLECTION
+            addEntry().resource = appointment()
+        }
+
+        assertThrows<IllegalArgumentException> {
+            OperationResult.fromBundleTyped<Patient>(bundle, "patient")
+        }
+    }
+
+    @Test
+    fun `fromBundleTyped - throws when key exists but type does not match`() {
+        val bundle = Bundle().apply {
+            type = Bundle.BundleType.COLLECTION
+            addEntry().resource = appointment()
+        }
+
+        assertThrows<IllegalArgumentException> {
+            OperationResult.fromBundleTyped<Patient>(bundle, "appointment")
+        }
+    }
+
     // ── extractParam / extractParamList ──────────────────────────────────────
 
     @Test

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultTest.kt
@@ -1080,6 +1080,55 @@ class OperationResultTest {
         assertEquals(Bundle.HTTPVerb.POST, bundle.entryFirstRep.request.method)
     }
 
+    @Test
+    fun `toCollectionBundle - convenience alias produces COLLECTION bundle`() {
+        val result = OperationResult.of(patient(), "patient")
+            .add("appt") { appointment() }
+
+        val bundle = result.toCollectionBundle()
+
+        assertEquals(Bundle.BundleType.COLLECTION, bundle.type)
+        assertThat(bundle.entry, hasSize(2))
+        assertThat(bundle.entry[0].resource, instanceOf(Patient::class.java))
+        assertThat(bundle.entry[1].resource, instanceOf(Appointment::class.java))
+    }
+
+    @Test
+    fun `toCollectionBundle with configBlock - applies configuration to each entry`() {
+        val result = OperationResult.of(patient(), "patient")
+
+        val bundle = result.toCollectionBundle { entry ->
+            entry.fullUrl = "http://example.com/fhir/Patient/test"
+        }
+
+        assertEquals("http://example.com/fhir/Patient/test", bundle.entryFirstRep.fullUrl)
+    }
+
+    @Test
+    fun `toTransactionBundle with configBlock - sets fullUrl on each entry`() {
+        val result = OperationResult.of(Patient().apply { id = "p1" }, "patient")
+
+        val bundle = result.toTransactionBundle { entry ->
+            entry.fullUrl = "urn:uuid:patient-p1"
+        }
+
+        assertEquals(Bundle.BundleType.TRANSACTION, bundle.type)
+        assertEquals("urn:uuid:patient-p1", bundle.entryFirstRep.fullUrl)
+        assertEquals(Bundle.HTTPVerb.PUT, bundle.entryFirstRep.request.method)
+    }
+
+    @Test
+    fun `toBatchBundle with configBlock - sets fullUrl on each entry`() {
+        val result = OperationResult.of(patient(), "patient")
+
+        val bundle = result.toBatchBundle { entry ->
+            entry.fullUrl = "urn:uuid:patient-new"
+        }
+
+        assertEquals(Bundle.BundleType.BATCH, bundle.type)
+        assertEquals("urn:uuid:patient-new", bundle.entryFirstRep.fullUrl)
+    }
+
     // ── Type safety ───────────────────────────────────────────────────────────
     // These tests prove compile-time type enforcement: if the generic machinery
     // were broken the typed assignments below would fail to compile.


### PR DESCRIPTION
- Add `fromBundleTyped<T>(bundle, primaryKey)` (KClass, Class, and reified overloads) to mirror
  the existing `fromParametersTyped` pattern; sets a typed pipeline head so `getResult()` returns
  T without casting. Throws IllegalArgumentException if the key is absent or the type mismatches.

- Add `toCollectionBundle(configBlock?)` convenience alias to complete the trio alongside
  `toTransactionBundle` and `toBatchBundle`.

- Add optional `configBlock` parameter to `toTransactionBundle` and `toBatchBundle` so callers
  can set `fullUrl` (or anything else) per entry with the short-form methods, e.g. for
  cross-entry reference resolution in FHIR transactions.

- Add KDoc to `toBundle`, `toCollectionBundle`, `toTransactionBundle`, and `toBatchBundle`
  clarifying that only Resource subtypes appear in the output; primitive and complex Type values
  (addString, addCoding, addPart, etc.) are silently omitted and toParameters() should be used
  to serialise the full accumulated state.