### PR TITLE
Add KDoc to all public methods and enforce documentation rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,23 @@ catch (e: Exception) {
 - Primitive convenience methods must delegate to `runPrimitiveStep` (Pattern B) — never duplicate the try/catch inline.
 - Do not add new catch patterns without updating this section.
 
+## Documentation Rule
+
+**Every public method, function, and property must have a KDoc comment (`/** … */`).**
+
+This is a hard requirement for all public API surfaces — no exceptions.
+
+Rules:
+- **Class-level KDoc is required** on every public class and object.
+- **Method-level KDoc is required** on every `fun` that is `public` (explicitly or by default) — including companion object methods, top-level functions that are part of the public API, and `override` methods that add behaviour beyond what the interface documents.
+- **Single-line `/** … */` is acceptable** for self-evident overloads (e.g. a reified wrapper that only removes the explicit `KClass` argument). Use `/** [FhirPath] overload of [xxx] — builds the expression and delegates. */` or `/** Reified overload — no [KClass] argument needed at call sites. */` as appropriate.
+- **Multi-line KDoc** is required when a method has non-trivial behaviour, error semantics, or parameters that need explanation (see existing methods for examples).
+- **`@param` tags** are required for every parameter of a public method whose purpose is not fully captured by its name alone.
+- `internal` and `private` members do not require KDoc, but a single-line comment is welcome for non-obvious logic.
+- `inline fun` with `reified` type parameters must still have KDoc; just omit `@JvmStatic`/`@JvmOverloads` as normal.
+
+When adding a new method or modifying an existing one, write or update its KDoc in the same commit. Reviewing a PR that contains public methods without KDoc is a policy violation.
+
 ## Pre-Commit and Pre-Push Requirement
 
 **This is a hard requirement — no exceptions.**

--- a/fhirmason-api/src/main/java/dev/ratkay/operation/ErrorStrategy.kt
+++ b/fhirmason-api/src/main/java/dev/ratkay/operation/ErrorStrategy.kt
@@ -1,5 +1,13 @@
 package dev.ratkay.operation
 
+/**
+ * Controls how an [IOperationResult] pipeline reacts when a step throws an exception.
+ *
+ * - [FAIL_FAST]: subsequent builder steps are skipped as soon as an error is recorded;
+ *   the pipeline short-circuits and only the error outcomes are accumulated.
+ * - [ACCUMULATE]: every step is attempted regardless of prior errors; all outcomes
+ *   (successes and failures) are collected before the caller inspects the result.
+ */
 enum class ErrorStrategy {
     FAIL_FAST,
     ACCUMULATE

--- a/fhirmason-api/src/main/java/dev/ratkay/operation/FhirPath.kt
+++ b/fhirmason-api/src/main/java/dev/ratkay/operation/FhirPath.kt
@@ -71,38 +71,96 @@ class FhirPath private constructor(private val expr: String) {
 
     // ── Collection functions ──────────────────────────────────────────────────
 
+    /** Returns the first item in the collection: `expr.first()`. */
     fun first(): FhirPath = FhirPath("$expr.first()")
+
+    /** Returns the last item in the collection: `expr.last()`. */
     fun last(): FhirPath = FhirPath("$expr.last()")
+
+    /** Returns all items except the first: `expr.tail()`. */
     fun tail(): FhirPath = FhirPath("$expr.tail()")
+
+    /** Returns the first [n] items: `expr.take(n)`. */
     fun take(n: Int): FhirPath = FhirPath("$expr.take($n)")
+
+    /** Skips the first [n] items and returns the rest: `expr.skip(n)`. */
     fun skip(n: Int): FhirPath = FhirPath("$expr.skip($n)")
+
+    /** Returns the number of items in the collection: `expr.count()`. */
     fun count(): FhirPath = FhirPath("$expr.count()")
+
+    /** Returns `true` when the collection contains no items: `expr.empty()`. */
     fun empty(): FhirPath = FhirPath("$expr.empty()")
+
+    /** Returns `true` when the collection contains at least one item: `expr.exists()`. */
     fun exists(): FhirPath = FhirPath("$expr.exists()")
+
+    /** Returns `true` when at least one item satisfies [criteria]: `expr.exists(criteria)`. */
     fun exists(criteria: String): FhirPath = FhirPath("$expr.exists($criteria)")
+
+    /** [FhirPath] overload of [exists] — builds [criteria] and delegates. */
     fun exists(criteria: FhirPath): FhirPath = FhirPath("$expr.exists(${criteria.build()})")
+
+    /** Returns `true` when every item satisfies [criteria]: `expr.all(criteria)`. */
     fun all(criteria: String): FhirPath = FhirPath("$expr.all($criteria)")
+
+    /** [FhirPath] overload of [all] — builds [criteria] and delegates. */
     fun all(criteria: FhirPath): FhirPath = FhirPath("$expr.all(${criteria.build()})")
+
+    /** Returns `true` when all items are `true`: `expr.allTrue()`. */
     fun allTrue(): FhirPath = FhirPath("$expr.allTrue()")
+
+    /** Returns `true` when at least one item is `true`: `expr.anyTrue()`. */
     fun anyTrue(): FhirPath = FhirPath("$expr.anyTrue()")
+
+    /** Returns `true` when all items are `false`: `expr.allFalse()`. */
     fun allFalse(): FhirPath = FhirPath("$expr.allFalse()")
+
+    /** Returns `true` when at least one item is `false`: `expr.anyFalse()`. */
     fun anyFalse(): FhirPath = FhirPath("$expr.anyFalse()")
+
+    /** Removes duplicate items from the collection: `expr.distinct()`. */
     fun distinct(): FhirPath = FhirPath("$expr.distinct()")
+
+    /** Returns `true` when the collection has no duplicates: `expr.isDistinct()`. */
     fun isDistinct(): FhirPath = FhirPath("$expr.isDistinct()")
+
+    /** Returns `true` when this collection is a superset of [other]: `expr.supersetOf(other)`. */
     fun supersetOf(other: String): FhirPath = FhirPath("$expr.supersetOf($other)")
+
+    /** Returns the direct child nodes of each item: `expr.children()`. */
     fun children(): FhirPath = FhirPath("$expr.children()")
+
+    /** Returns all descendant nodes recursively: `expr.descendants()`. */
     fun descendants(): FhirPath = FhirPath("$expr.descendants()")
 
     // ── Boolean operators ─────────────────────────────────────────────────────
 
+    /** Logical negation: `expr.not()`. */
     fun not(): FhirPath = FhirPath("$expr.not()")
+
+    /** Logical AND with a [FhirPath] operand: `(expr) and (other)`. */
     fun and(other: FhirPath): FhirPath = FhirPath("($expr) and (${other.build()})")
+
+    /** Logical AND with a raw string operand: `(expr) and (other)`. */
     fun and(other: String): FhirPath = FhirPath("($expr) and ($other)")
+
+    /** Logical OR with a [FhirPath] operand: `(expr) or (other)`. */
     fun or(other: FhirPath): FhirPath = FhirPath("($expr) or (${other.build()})")
+
+    /** Logical OR with a raw string operand: `(expr) or (other)`. */
     fun or(other: String): FhirPath = FhirPath("($expr) or ($other)")
+
+    /** Logical XOR with a [FhirPath] operand: `(expr) xor (other)`. */
     fun xor(other: FhirPath): FhirPath = FhirPath("($expr) xor (${other.build()})")
+
+    /** Logical XOR with a raw string operand: `(expr) xor (other)`. */
     fun xor(other: String): FhirPath = FhirPath("($expr) xor ($other)")
+
+    /** Logical implication with a [FhirPath] operand: `(expr) implies (other)`. */
     fun implies(other: FhirPath): FhirPath = FhirPath("($expr) implies (${other.build()})")
+
+    /** Logical implication with a raw string operand: `(expr) implies (other)`. */
     fun implies(other: String): FhirPath = FhirPath("($expr) implies ($other)")
 
     // ── Equality / comparison operators ──────────────────────────────────────
@@ -110,30 +168,67 @@ class FhirPath private constructor(private val expr: String) {
     // String overloads auto-quote: eq("official") → = 'official'
     // Typed overloads emit the literal directly: eq(true) → = true, eq(18) → = 18
 
+    /**
+     * Equality comparison (`=`). String values are auto-quoted: `eq("official")` → `= 'official'`.
+     * Numeric and boolean values are emitted as literals: `eq(18)` → `= 18`.
+     */
     fun eq(value: String): FhirPath = FhirPath("$expr = '$value'")
+
+    /** Equality comparison with an integer literal: `expr = value`. */
     fun eq(value: Int): FhirPath = FhirPath("$expr = $value")
+
+    /** Equality comparison with a decimal literal: `expr = value`. */
     fun eq(value: Double): FhirPath = FhirPath("$expr = $value")
+
+    /** Equality comparison with a boolean literal: `expr = value`. */
     fun eq(value: Boolean): FhirPath = FhirPath("$expr = $value")
 
+    /** Inequality comparison (`!=`). String values are auto-quoted. */
     fun ne(value: String): FhirPath = FhirPath("$expr != '$value'")
+
+    /** Inequality comparison with an integer literal: `expr != value`. */
     fun ne(value: Int): FhirPath = FhirPath("$expr != $value")
+
+    /** Inequality comparison with a decimal literal: `expr != value`. */
     fun ne(value: Double): FhirPath = FhirPath("$expr != $value")
+
+    /** Inequality comparison with a boolean literal: `expr != value`. */
     fun ne(value: Boolean): FhirPath = FhirPath("$expr != $value")
 
+    /** Less-than comparison (`<`). String values are auto-quoted. */
     fun lt(value: String): FhirPath = FhirPath("$expr < '$value'")
+
+    /** Less-than comparison with an integer literal: `expr < value`. */
     fun lt(value: Int): FhirPath = FhirPath("$expr < $value")
+
+    /** Less-than comparison with a decimal literal: `expr < value`. */
     fun lt(value: Double): FhirPath = FhirPath("$expr < $value")
 
+    /** Greater-than comparison (`>`). String values are auto-quoted. */
     fun gt(value: String): FhirPath = FhirPath("$expr > '$value'")
+
+    /** Greater-than comparison with an integer literal: `expr > value`. */
     fun gt(value: Int): FhirPath = FhirPath("$expr > $value")
+
+    /** Greater-than comparison with a decimal literal: `expr > value`. */
     fun gt(value: Double): FhirPath = FhirPath("$expr > $value")
 
+    /** Less-than-or-equal comparison (`<=`). String values are auto-quoted. */
     fun le(value: String): FhirPath = FhirPath("$expr <= '$value'")
+
+    /** Less-than-or-equal comparison with an integer literal: `expr <= value`. */
     fun le(value: Int): FhirPath = FhirPath("$expr <= $value")
+
+    /** Less-than-or-equal comparison with a decimal literal: `expr <= value`. */
     fun le(value: Double): FhirPath = FhirPath("$expr <= $value")
 
+    /** Greater-than-or-equal comparison (`>=`). String values are auto-quoted. */
     fun ge(value: String): FhirPath = FhirPath("$expr >= '$value'")
+
+    /** Greater-than-or-equal comparison with an integer literal: `expr >= value`. */
     fun ge(value: Int): FhirPath = FhirPath("$expr >= $value")
+
+    /** Greater-than-or-equal comparison with a decimal literal: `expr >= value`. */
     fun ge(value: Double): FhirPath = FhirPath("$expr >= $value")
 
     /** FHIRPath equivalence (`~`): matches regardless of insignificant whitespace, case, etc. */
@@ -153,40 +248,95 @@ class FhirPath private constructor(private val expr: String) {
     //
     // All string-parameter functions auto-quote: startsWith("Sm") → .startsWith('Sm')
 
+    /** Returns the number of characters in the string: `expr.length()`. */
     fun length(): FhirPath = FhirPath("$expr.length()")
+
+    /** Converts the string to upper case: `expr.upper()`. */
     fun upper(): FhirPath = FhirPath("$expr.upper()")
+
+    /** Converts the string to lower case: `expr.lower()`. */
     fun lower(): FhirPath = FhirPath("$expr.lower()")
+
+    /** Removes leading and trailing whitespace: `expr.trim()`. */
     fun trim(): FhirPath = FhirPath("$expr.trim()")
+
+    /** Returns `true` when the string starts with [prefix]: `expr.startsWith('prefix')`. */
     fun startsWith(prefix: String): FhirPath = FhirPath("$expr.startsWith('$prefix')")
+
+    /** Returns `true` when the string ends with [suffix]: `expr.endsWith('suffix')`. */
     fun endsWith(suffix: String): FhirPath = FhirPath("$expr.endsWith('$suffix')")
+
+    /** Returns `true` when the string contains [substring]: `expr.contains('substring')`. */
     fun contains(substring: String): FhirPath = FhirPath("$expr.contains('$substring')")
+
+    /** Returns `true` when the string matches [regex]: `expr.matches('regex')`. */
     fun matches(regex: String): FhirPath = FhirPath("$expr.matches('$regex')")
+
+    /** Returns the zero-based index of [substring] in the string: `expr.indexOf('substring')`. */
     fun indexOf(substring: String): FhirPath = FhirPath("$expr.indexOf('$substring')")
+
+    /** Returns the substring starting at index [start]: `expr.substring(start)`. */
     fun substring(start: Int): FhirPath = FhirPath("$expr.substring($start)")
+
+    /** Returns [length] characters of the substring starting at index [start]: `expr.substring(start, length)`. */
     fun substring(start: Int, length: Int): FhirPath = FhirPath("$expr.substring($start, $length)")
+
+    /** Replaces all occurrences of [pattern] with [substitution]: `expr.replace('pattern', 'substitution')`. */
     fun replace(pattern: String, substitution: String): FhirPath = FhirPath("$expr.replace('$pattern', '$substitution')")
+
+    /** Replaces substrings matching [regex] with [substitution]: `expr.replaceMatches('regex', 'substitution')`. */
     fun replaceMatches(regex: String, substitution: String): FhirPath = FhirPath("$expr.replaceMatches('$regex', '$substitution')")
+
+    /** Splits the string on [separator] and returns a collection: `expr.split('separator')`. */
     fun split(separator: String): FhirPath = FhirPath("$expr.split('$separator')")
+
+    /** Joins the items of a string collection using [separator]: `expr.join('separator')`. */
     fun join(separator: String): FhirPath = FhirPath("$expr.join('$separator')")
 
     // ── Math functions ────────────────────────────────────────────────────────
 
+    /** Returns the absolute value: `expr.abs()`. */
     fun abs(): FhirPath = FhirPath("$expr.abs()")
+
+    /** Returns the smallest integer greater than or equal to the value: `expr.ceiling()`. */
     fun ceiling(): FhirPath = FhirPath("$expr.ceiling()")
+
+    /** Returns the largest integer less than or equal to the value: `expr.floor()`. */
     fun floor(): FhirPath = FhirPath("$expr.floor()")
+
+    /** Rounds the value to the nearest integer: `expr.round()`. */
     fun round(): FhirPath = FhirPath("$expr.round()")
+
+    /** Rounds the value to [precision] decimal places: `expr.round(precision)`. */
     fun round(precision: Int): FhirPath = FhirPath("$expr.round($precision)")
+
+    /** Returns the square root of the value: `expr.sqrt()`. */
     fun sqrt(): FhirPath = FhirPath("$expr.sqrt()")
+
+    /** Raises the value to the power of [exp]: `expr.power(exp)`. */
     fun power(exp: String): FhirPath = FhirPath("$expr.power($exp)")
+
+    /** Truncates the decimal part, returning the integer portion: `expr.truncate()`. */
     fun truncate(): FhirPath = FhirPath("$expr.truncate()")
 
     // ── Arithmetic operators ──────────────────────────────────────────────────
 
+    /** Addition: `expr + value`. */
     fun plus(value: String): FhirPath = FhirPath("$expr + $value")
+
+    /** Subtraction: `expr - value`. */
     fun minus(value: String): FhirPath = FhirPath("$expr - $value")
+
+    /** Multiplication: `expr * value`. */
     fun times(value: String): FhirPath = FhirPath("$expr * $value")
+
+    /** Decimal division: `expr / value`. */
     fun dividedBy(value: String): FhirPath = FhirPath("$expr / $value")
+
+    /** Integer division: `expr div value`. */
     fun div(value: String): FhirPath = FhirPath("$expr div $value")
+
+    /** Modulo (remainder): `expr mod value`. */
     fun mod(value: String): FhirPath = FhirPath("$expr mod $value")
 
     /** FHIRPath string concatenation (`&`): `expr & value`. */
@@ -194,9 +344,16 @@ class FhirPath private constructor(private val expr: String) {
 
     // ── Type conversion ───────────────────────────────────────────────────────
 
+    /** Converts the value to a Boolean: `expr.toBoolean()`. */
     fun toBoolean(): FhirPath = FhirPath("$expr.toBoolean()")
+
+    /** Converts the value to an Integer: `expr.toInteger()`. */
     fun toInteger(): FhirPath = FhirPath("$expr.toInteger()")
+
+    /** Converts the value to a Decimal: `expr.toDecimal()`. */
     fun toDecimal(): FhirPath = FhirPath("$expr.toDecimal()")
+
+    /** Converts the value to a Quantity: `expr.toQuantity()`. */
     fun toQuantity(): FhirPath = FhirPath("$expr.toQuantity()")
 
     // ── FHIR-specific ─────────────────────────────────────────────────────────

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/AsyncOperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/AsyncOperationResult.kt
@@ -22,6 +22,29 @@ import kotlin.reflect.KClass
 import kotlin.time.measureTime
 import kotlin.time.measureTimedValue
 
+/**
+ * Builds and executes a DAG of asynchronous FHIR tasks, collecting results into an
+ * [OperationResult].
+ *
+ * Tasks are registered before execution:
+ * - Independent tasks ([add], [addList], [addWithRetry], etc.) have no dependencies and run
+ *   in parallel immediately when [run] is called.
+ * - Dependent tasks ([addAfter], [addListAfter], etc.) declare their dependencies by key and
+ *   start only after all named dependencies resolve successfully.
+ *
+ * Execution is started by calling [run] (suspending) or [runBlocking] (blocking). The returned
+ * [OperationResult] accumulates all successful task results; failed tasks add an ERROR-severity
+ * [OperationOutcome].
+ *
+ * ### Registration order
+ * Dependencies must be registered before the tasks that depend on them — [addAfter] validates
+ * at registration time and throws [IllegalArgumentException] for unknown keys or cycles.
+ *
+ * ### Configuration
+ * - [timed] — enable per-task metrics
+ * - [timeout] — set a DAG-level wall-clock timeout
+ * - [withExecutor] — override the default [kotlinx.coroutines.Dispatchers.IO] thread pool
+ */
 class AsyncOperationResult {
 
     private val logger = LoggerFactory.getLogger(AsyncOperationResult::class.java)
@@ -102,14 +125,39 @@ class AsyncOperationResult {
         nodes[key] = node
     }
 
+    /**
+     * Registers an independent DAG task that produces a single [Base] resource stored under [key].
+     *
+     * [block] is invoked with no arguments when [run] is called. If it throws, the key is absent
+     * from the final [OperationResult] and an ERROR-severity [OperationOutcome] is recorded.
+     * Downstream tasks that depend on this key are skipped.
+     */
     fun add(key: String, block: suspend () -> Base): AsyncOperationResult = also {
         registerNode(key, TaskNode.Independent(key) { listOf(block()) })
     }
 
+    /**
+     * Registers an independent DAG task that produces a list of resources stored under [key].
+     * Each element is added to the list under the same key. See [add] for error semantics.
+     */
     fun <R : Base> addList(key: String, block: suspend () -> List<R>): AsyncOperationResult = also {
         registerNode(key, TaskNode.Independent(key) { block() })
     }
 
+    /**
+     * Registers a dependent DAG task that produces a single [Base] resource stored under [key].
+     *
+     * [block] is invoked only after all [deps] have resolved successfully. It receives a map
+     * keyed by dependency name, where each entry holds the list of resources produced by that
+     * dependency. If any dependency fails, this task is skipped without calling [block].
+     *
+     * All [deps] must already be registered; duplicate keys and cycles cause
+     * [IllegalArgumentException] at registration time.
+     *
+     * @param key storage key for the result
+     * @param deps keys of previously registered tasks whose results are passed to [block]
+     * @param block the suspending lambda to invoke; receives resolved dependency results
+     */
     fun addAfter(
         key: String,
         vararg deps: String,
@@ -121,6 +169,13 @@ class AsyncOperationResult {
         registerNode(key, TaskNode.Dependent(key, depList) { map -> listOf(block(map)) })
     }
 
+    /**
+     * Like [addAfter] but [block] returns a `List<R>`. All elements are stored under [key].
+     *
+     * @param key storage key for the result list
+     * @param deps keys of previously registered tasks whose results are passed to [block]
+     * @param block the suspending lambda to invoke; receives resolved dependency results
+     */
     fun <R : Base> addListAfter(
         key: String,
         vararg deps: String,
@@ -134,6 +189,17 @@ class AsyncOperationResult {
 
     // Type-safe single-dependency convenience methods
 
+    /**
+     * Type-safe overload of [addAfter] for a single dependency.
+     *
+     * Extracts the first value stored under [dep] that is an instance of [type] and passes it
+     * directly to [block], eliminating manual map lookup and casting.
+     *
+     * @param key storage key for the result
+     * @param dep the single dependency key
+     * @param type the expected type of the dependency value
+     * @param block the suspending lambda; receives the typed dependency value
+     */
     fun <T : Base> addAfter(
         key: String,
         dep: String,
@@ -144,6 +210,17 @@ class AsyncOperationResult {
         block(value)
     }
 
+    /**
+     * Type-safe overload of [addListAfter] for a single dependency.
+     *
+     * Extracts the first value stored under [dep] that is an instance of [type] and passes it
+     * directly to [block]. See [addAfter] (typed overload) for the full contract.
+     *
+     * @param key storage key for the result list
+     * @param dep the single dependency key
+     * @param type the expected type of the dependency value
+     * @param block the suspending lambda; receives the typed dependency value
+     */
     fun <T : Base, R : Base> addListAfter(
         key: String,
         dep: String,
@@ -156,6 +233,17 @@ class AsyncOperationResult {
 
     // Type-safe list-injection convenience methods
 
+    /**
+     * Type-safe overload of [addAfter] for a single dependency where [block] receives **all**
+     * values stored under [dep] that are instances of [type], as a typed list.
+     *
+     * Use [addAfter] (typed overload) when you want only the first matching value.
+     *
+     * @param key storage key for the result
+     * @param dep the single dependency key
+     * @param type the expected type of the dependency values
+     * @param block the suspending lambda; receives the typed dependency list
+     */
     fun <T : Base> addAfterAll(
         key: String,
         dep: String,
@@ -166,6 +254,14 @@ class AsyncOperationResult {
         block(values)
     }
 
+    /**
+     * Like [addAfterAll] but [block] returns a `List<R>`.
+     *
+     * @param key storage key for the result list
+     * @param dep the single dependency key
+     * @param type the expected type of the dependency values
+     * @param block the suspending lambda; receives the typed dependency list
+     */
     fun <T : Base, R : Base> addListAfterAll(
         key: String,
         dep: String,
@@ -604,6 +700,12 @@ class AsyncOperationResult {
         OperationResult.fromMap(accumulator, outcomes, failedTasks)
     }
 
+    /**
+     * Blocking wrapper around [run] — calls [run] inside [kotlinx.coroutines.runBlocking].
+     *
+     * Inherits the DAG-level timeout configured via [timeout], if set.
+     * Prefer [run] from a coroutine context; use this method only from non-suspending call sites.
+     */
     fun runBlocking(): OperationResult<Base> = runBlocking { run() }
 
     private fun dagTimeoutOutcome(durationMs: Long): OperationOutcome = OperationOutcome().apply {

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
@@ -84,10 +84,19 @@ class OperationResult<T> private constructor(
 
     override fun isSuccessful(): Boolean = outcomes.isEmpty()
 
+    /** Returns all [OperationOutcome] instances recorded by failed pipeline steps. */
     fun getOutcomes(): List<OperationOutcome> = outcomes.toList()
 
+    /**
+     * Returns the map of task keys to their [OperationOutcome] for steps that failed when this
+     * result was produced by [AsyncOperationResult]. Empty for synchronous pipelines.
+     */
     fun getFailedTasks(): Map<String, OperationOutcome> = failedTasks.toMap()
 
+    /**
+     * Merges all recorded [OperationOutcome] instances into a single composite
+     * [OperationOutcome] whose issues are the union of every individual outcome's issues.
+     */
     fun toOperationOutcome(): OperationOutcome = OperationOutcome().apply {
         this@OperationResult.outcomes.forEach { oo ->
             oo.issue.forEach { issue ->
@@ -408,6 +417,14 @@ class OperationResult<T> private constructor(
 
     // Builder methods - single item
 
+    /**
+     * Invokes [builder] to produce a new FHIR resource, stores it under [name] (or the
+     * resource's [Base.fhirType] lowercase when [name] is `null`), and returns a new
+     * [OperationResult] with [R] as the pipeline head.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     */
     @JvmOverloads
     fun <R : Base> add(name: String? = null, builder: () -> R): OperationResult<R> =
         runBuilderStep(name) {
@@ -415,6 +432,11 @@ class OperationResult<T> private constructor(
             storeAndCopy(name, value, duration.inWholeMilliseconds)
         }
 
+    /**
+     * Like [add] but [builder] receives the current pipeline head value [T].
+     *
+     * Error handling follows Pattern A.
+     */
     @JvmOverloads
     fun <R : Base> addUsing(name: String? = null, builder: (T) -> R): OperationResult<R> =
         runBuilderStep(name) {
@@ -426,6 +448,13 @@ class OperationResult<T> private constructor(
     // addAll/addAllUsing return OperationResult<List<R>>; use getResultList() or getResult()
     // to retrieve the typed list without casting.
 
+    /**
+     * Invokes [builder] to produce a list of FHIR resources, stores each element under [name]
+     * (or each element's [Base.fhirType] lowercase when [name] is `null`), and returns a new
+     * [OperationResult] with `List<R>` as the pipeline head.
+     *
+     * Error handling follows Pattern A.
+     */
     @JvmOverloads
     fun <R : Base> addAll(name: String? = null, builder: () -> List<R>): OperationResult<List<R>> =
         runBuilderStep(name) {
@@ -433,6 +462,11 @@ class OperationResult<T> private constructor(
             storeListAndCopy(name, values, duration.inWholeMilliseconds)
         }
 
+    /**
+     * Like [addAll] but [builder] receives the current pipeline head value [T].
+     *
+     * Error handling follows Pattern A.
+     */
     @JvmOverloads
     fun <R : Base> addAllUsing(name: String? = null, builder: (T) -> List<R>): OperationResult<List<R>> =
         runBuilderStep(name) {
@@ -442,6 +476,13 @@ class OperationResult<T> private constructor(
 
     // Builder methods - from existing parameters
 
+    /**
+     * Reads all values already accumulated under [name], filters them to [type], passes the
+     * typed list to [builder], and replaces the values stored under [name] with the single
+     * result. The pipeline head becomes [R].
+     *
+     * Error handling follows Pattern A.
+     */
     fun <I : Base, R : Base> addFrom(name: String, type: KClass<I>, builder: (List<I>) -> R): OperationResult<R> =
         runBuilderStep(name) {
             val (value, duration) = measureTimedValue {
@@ -451,6 +492,11 @@ class OperationResult<T> private constructor(
             storeAndCopy(name, value, duration.inWholeMilliseconds)
         }
 
+    /**
+     * Like [addFrom] but [builder] returns a `List<R>`. The pipeline head becomes `List<R>`.
+     *
+     * Error handling follows Pattern A.
+     */
     fun <I : Base, R : Base> addAllFrom(name: String, type: KClass<I>, builder: (List<I>) -> List<R>): OperationResult<List<R>> =
         runBuilderStep(name) {
             val (values, duration) = measureTimedValue {
@@ -462,6 +508,13 @@ class OperationResult<T> private constructor(
 
     // Builder variants with explicit error handling
 
+    /**
+     * Like [add] but on exception records a WARNING-severity [OperationOutcome] and preserves
+     * the current head type [T] rather than skipping it (Pattern B — head-preserving).
+     *
+     * The result is still stored in the parameter map on success; on failure it is silently
+     * omitted and the pipeline continues with the same head.
+     */
     @JvmOverloads
     fun <R : Base> addOrSkip(name: String? = null, builder: () -> R): OperationResult<T> {
         val (builderResult, duration) = measureTimedValue { runCatching { builder() } }
@@ -485,6 +538,11 @@ class OperationResult<T> private constructor(
         )
     }
 
+    /**
+     * Like [add] but on exception stores [default] under [name] instead and returns a new
+     * [OperationResult] with [R] as the pipeline head. A WARNING-severity [OperationOutcome]
+     * is recorded on failure (Pattern B — head-preserving, result type changes to [R]).
+     */
     @JvmOverloads
     fun <R : Base> addOrDefault(name: String? = null, default: R, builder: () -> R): OperationResult<R> {
         val (builderResult, duration) = measureTimedValue { runCatching { builder() } }
@@ -619,32 +677,79 @@ class OperationResult<T> private constructor(
     }
 
     // ── Primitive value convenience methods ──────────────────────────────────
+    //
+    // All primitive methods follow Pattern B: exceptions record a WARNING-severity
+    // OperationOutcome and preserve the current head type T unchanged.
 
+    /** Stores a FHIR [StringType] under [name]. On error records a WARNING (Pattern B). */
     fun addString(name: String, value: String): OperationResult<T>       = runPrimitiveStep(name) { StringType(value) }
+
+    /** Stores a FHIR [BooleanType] under [name]. On error records a WARNING (Pattern B). */
     fun addBoolean(name: String, value: Boolean): OperationResult<T>     = runPrimitiveStep(name) { BooleanType(value) }
+
+    /** Stores a FHIR [IntegerType] under [name]. On error records a WARNING (Pattern B). */
     fun addInteger(name: String, value: Int): OperationResult<T>         = runPrimitiveStep(name) { IntegerType(value) }
+
+    /** Stores a FHIR [DecimalType] under [name]. On error records a WARNING (Pattern B). */
     fun addDecimal(name: String, value: BigDecimal): OperationResult<T>  = runPrimitiveStep(name) { DecimalType(value) }
+
+    /** Stores a FHIR [CodeType] under [name]. On error records a WARNING (Pattern B). */
     fun addCode(name: String, value: String): OperationResult<T>         = runPrimitiveStep(name) { CodeType(value) }
+
+    /** Stores a FHIR [UriType] under [name]. On error records a WARNING (Pattern B). */
     fun addUri(name: String, value: String): OperationResult<T>          = runPrimitiveStep(name) { UriType(value) }
+
+    /** Converts [value] to a FHIR date and stores it under [name]. On error records a WARNING (Pattern B). */
     fun addDate(name: String, value: DateTimeInput): OperationResult<T>     = runPrimitiveStep(name) { FhirDateTimeConverter.toFhirDate(value) }
+
+    /** Converts [value] to a FHIR dateTime and stores it under [name]. On error records a WARNING (Pattern B). */
     fun addDateTime(name: String, value: DateTimeInput): OperationResult<T> = runPrimitiveStep(name) { FhirDateTimeConverter.toFhirDateTime(value) }
+
+    /** Converts [value] to a FHIR instant and stores it under [name]. On error records a WARNING (Pattern B). */
     fun addInstant(name: String, value: DateTimeInput): OperationResult<T>  = runPrimitiveStep(name) { FhirDateTimeConverter.toFhirInstant(value) }
+
+    /** Converts [value] to a FHIR time and stores it under [name]. On error records a WARNING (Pattern B). */
     fun addTime(name: String, value: DateTimeInput): OperationResult<T>     = runPrimitiveStep(name) { FhirDateTimeConverter.toFhirTime(value) }
 
-
+    /** Like [addString] but derives [value] from the current pipeline head via [builder]. */
     fun addStringUsing(name: String, builder: (T) -> String): OperationResult<T>           = runPrimitiveStep(name) { StringType(builder(getResult())) }
+
+    /** Like [addBoolean] but derives [value] from the current pipeline head via [builder]. */
     fun addBooleanUsing(name: String, builder: (T) -> Boolean): OperationResult<T>         = runPrimitiveStep(name) { BooleanType(builder(getResult())) }
+
+    /** Like [addInteger] but derives [value] from the current pipeline head via [builder]. */
     fun addIntegerUsing(name: String, builder: (T) -> Int): OperationResult<T>             = runPrimitiveStep(name) { IntegerType(builder(getResult())) }
+
+    /** Like [addDecimal] but derives [value] from the current pipeline head via [builder]. */
     fun addDecimalUsing(name: String, builder: (T) -> BigDecimal): OperationResult<T>      = runPrimitiveStep(name) { DecimalType(builder(getResult())) }
+
+    /** Like [addCode] but derives [value] from the current pipeline head via [builder]. */
     fun addCodeUsing(name: String, builder: (T) -> String): OperationResult<T>             = runPrimitiveStep(name) { CodeType(builder(getResult())) }
+
+    /** Like [addUri] but derives [value] from the current pipeline head via [builder]. */
     fun addUriUsing(name: String, builder: (T) -> String): OperationResult<T>              = runPrimitiveStep(name) { UriType(builder(getResult())) }
+
+    /** Like [addDate] but derives [value] from the current pipeline head via [builder]. */
     fun addDateUsing(name: String, builder: (T) -> DateTimeInput): OperationResult<T>      = runPrimitiveStep(name) { FhirDateTimeConverter.toFhirDate(builder(getResult())) }
+
+    /** Like [addDateTime] but derives [value] from the current pipeline head via [builder]. */
     fun addDateTimeUsing(name: String, builder: (T) -> DateTimeInput): OperationResult<T>  = runPrimitiveStep(name) { FhirDateTimeConverter.toFhirDateTime(builder(getResult())) }
+
+    /** Like [addInstant] but derives [value] from the current pipeline head via [builder]. */
     fun addInstantUsing(name: String, builder: (T) -> DateTimeInput): OperationResult<T>   = runPrimitiveStep(name) { FhirDateTimeConverter.toFhirInstant(builder(getResult())) }
+
+    /** Like [addTime] but derives [value] from the current pipeline head via [builder]. */
     fun addTimeUsing(name: String, builder: (T) -> DateTimeInput): OperationResult<T>      = runPrimitiveStep(name) { FhirDateTimeConverter.toFhirTime(builder(getResult())) }
 
     // ── Complex data type convenience methods ────────────────────────────────
+    //
+    // All complex type methods follow Pattern B: on error a WARNING is recorded and the
+    // head type T is preserved unchanged.
 
+    /**
+     * Stores a [Coding] under [name] with the given [system], [code], and optional [display].
+     * On error records a WARNING (Pattern B).
+     */
     @JvmOverloads
     fun addCoding(name: String, system: String, code: String, display: String? = null): OperationResult<T> =
         runPrimitiveStep(name) {
@@ -655,9 +760,11 @@ class OperationResult<T> private constructor(
             }
         }
 
+    /** Stores a [Reference] under [name] with the given [reference] string. On error records a WARNING (Pattern B). */
     fun addReference(name: String, reference: String): OperationResult<T> =
         runPrimitiveStep(name) { Reference(reference) }
 
+    /** Stores an [Identifier] under [name] with the given [system] and [value]. On error records a WARNING (Pattern B). */
     fun addIdentifier(name: String, system: String, value: String): OperationResult<T> =
         runPrimitiveStep(name) {
             Identifier().apply {
@@ -666,6 +773,10 @@ class OperationResult<T> private constructor(
             }
         }
 
+    /**
+     * Stores a [Period] under [name] from raw FHIR date-time strings. `null` values are omitted
+     * from the period. On error records a WARNING (Pattern B).
+     */
     fun addPeriod(name: String, start: String?, end: String?): OperationResult<T> =
         runPrimitiveStep(name) {
             Period().apply {
@@ -674,6 +785,7 @@ class OperationResult<T> private constructor(
             }
         }
 
+    /** Stores a [Period] under [name] from [LocalDateTime] values. `null` values are omitted. On error records a WARNING (Pattern B). */
     fun addPeriod(name: String, start: LocalDateTime?, end: LocalDateTime?): OperationResult<T> =
         runPrimitiveStep(name) {
             Period().apply {
@@ -682,6 +794,7 @@ class OperationResult<T> private constructor(
             }
         }
 
+    /** Stores a [Period] under [name] from [ZonedDateTime] values. `null` values are omitted. On error records a WARNING (Pattern B). */
     fun addPeriod(name: String, start: ZonedDateTime?, end: ZonedDateTime?): OperationResult<T> =
         runPrimitiveStep(name) {
             Period().apply {
@@ -690,6 +803,7 @@ class OperationResult<T> private constructor(
             }
         }
 
+    /** Stores a [Period] under [name] from [OffsetDateTime] values. `null` values are omitted. On error records a WARNING (Pattern B). */
     fun addPeriod(name: String, start: OffsetDateTime?, end: OffsetDateTime?): OperationResult<T> =
         runPrimitiveStep(name) {
             Period().apply {
@@ -698,6 +812,10 @@ class OperationResult<T> private constructor(
             }
         }
 
+    /**
+     * Stores a [Quantity] under [name] with [value], [unit], and optional [system] and [code].
+     * On error records a WARNING (Pattern B).
+     */
     @JvmOverloads
     fun addQuantity(name: String, value: BigDecimal, unit: String, system: String? = null, code: String? = null): OperationResult<T> =
         runPrimitiveStep(name) {
@@ -709,6 +827,10 @@ class OperationResult<T> private constructor(
             }
         }
 
+    /**
+     * Stores a [CodeableConcept] under [name] with a single [Coding] built from [system], [code],
+     * and optional [display], plus an optional free-text [text]. On error records a WARNING (Pattern B).
+     */
     @JvmOverloads
     fun addCodeableConcept(name: String, system: String, code: String, display: String? = null, text: String? = null): OperationResult<T> =
         runPrimitiveStep(name) {
@@ -789,9 +911,11 @@ class OperationResult<T> private constructor(
 
     // Query methods
 
+    /** Returns a read-only snapshot of the full parameter map (all keys and all their values). */
     fun getAllParameters(): Map<String, List<Base>> =
         parameters.mapValues { it.value.toList() }
 
+    /** Returns all values accumulated under [name], or an empty list if the key is absent. */
     fun getAll(name: String): List<Base> =
         parameters[name]?.toList() ?: emptyList()
 
@@ -843,6 +967,7 @@ class OperationResult<T> private constructor(
     /** Reified overload — no [KClass] argument needed at call sites. */
     inline fun <reified R : Base> filterByType(): OperationResult<T> = filterByType(R::class)
 
+    /** Returns a new result containing only the entry for [name]. All other keys are dropped. No-op if [name] is absent. */
     fun filterByName(name: String): OperationResult<T> {
         val filtered = mutableMapOf<String, MutableList<Base>>()
         parameters[name]?.let { values ->
@@ -851,6 +976,11 @@ class OperationResult<T> private constructor(
         return copyWith(result, params = filtered)
     }
 
+    /**
+     * Applies [transform] to every value in the parameter map and returns a new result with the
+     * transformed values. The pipeline head is cleared to `null`; use [getResult] only after a
+     * subsequent builder step sets a new head.
+     */
     fun <R : Base> mapValues(transform: (Base) -> R): OperationResult<R> {
         val transformed = parameters.mapValues { (_, values) ->
             values.map(transform).toMutableList<Base>()
@@ -1306,6 +1436,11 @@ class OperationResult<T> private constructor(
      */
     fun toParameters(): Parameters = ParameterMapSerializer.unflatten(parameters, extensions)
 
+    /**
+     * Wraps [resource] in a [Bundle.BundleEntryComponent]. When [resource] is a [Resource]
+     * subtype, it is set as the entry's resource; non-Resource values produce an empty entry.
+     * Used internally by [toBundle] and its convenience aliases.
+     */
     fun toBundleEntry(resource: Base): Bundle.BundleEntryComponent =
         Bundle.BundleEntryComponent().apply {
             if (resource is Resource) setResource(resource)
@@ -1437,6 +1572,13 @@ class OperationResult<T> private constructor(
             return OperationResult(mutable, null, outcomes.toMutableList(), ErrorStrategy.FAIL_FAST, failedTasks.toMutableMap())
         }
 
+        /**
+         * Creates an [OperationResult] with [value] as both the pipeline head and the first
+         * parameter-map entry, stored under [name] (or [value]'s [Base.fhirType] lowercase when
+         * [name] is `null`).
+         *
+         * @param errorStrategy controls how subsequent steps behave when an error is recorded
+         */
         @JvmStatic
         @JvmOverloads
         fun <T : Base> of(value: T, name: String? = null, errorStrategy: ErrorStrategy = ErrorStrategy.FAIL_FAST): OperationResult<T> {
@@ -1446,6 +1588,13 @@ class OperationResult<T> private constructor(
             return OperationResult(params, value, mutableListOf(), errorStrategy, mutableMapOf())
         }
 
+        /**
+         * Creates an [OperationResult] with [values] as both the pipeline head (`List<T>`) and
+         * the initial parameter-map entries. Each element is stored under [name] (or the element's
+         * [Base.fhirType] lowercase when [name] is `null`).
+         *
+         * @param errorStrategy controls how subsequent steps behave when an error is recorded
+         */
         @JvmStatic
         @JvmOverloads
         fun <T : Base> of(values: List<T>, name: String? = null, errorStrategy: ErrorStrategy = ErrorStrategy.FAIL_FAST): OperationResult<List<T>> {

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/AsyncOperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/AsyncOperationResult.kt
@@ -22,6 +22,29 @@ import kotlin.reflect.KClass
 import kotlin.time.measureTime
 import kotlin.time.measureTimedValue
 
+/**
+ * Builds and executes a DAG of asynchronous FHIR tasks, collecting results into an
+ * [OperationResult].
+ *
+ * Tasks are registered before execution:
+ * - Independent tasks ([add], [addList], [addWithRetry], etc.) have no dependencies and run
+ *   in parallel immediately when [run] is called.
+ * - Dependent tasks ([addAfter], [addListAfter], etc.) declare their dependencies by key and
+ *   start only after all named dependencies resolve successfully.
+ *
+ * Execution is started by calling [run] (suspending) or [runBlocking] (blocking). The returned
+ * [OperationResult] accumulates all successful task results; failed tasks add an ERROR-severity
+ * [OperationOutcome].
+ *
+ * ### Registration order
+ * Dependencies must be registered before the tasks that depend on them — [addAfter] validates
+ * at registration time and throws [IllegalArgumentException] for unknown keys or cycles.
+ *
+ * ### Configuration
+ * - [timed] — enable per-task metrics
+ * - [timeout] — set a DAG-level wall-clock timeout
+ * - [withExecutor] — override the default [kotlinx.coroutines.Dispatchers.IO] thread pool
+ */
 class AsyncOperationResult {
 
     private val logger = LoggerFactory.getLogger(AsyncOperationResult::class.java)
@@ -102,14 +125,39 @@ class AsyncOperationResult {
         nodes[key] = node
     }
 
+    /**
+     * Registers an independent DAG task that produces a single [Base] resource stored under [key].
+     *
+     * [block] is invoked with no arguments when [run] is called. If it throws, the key is absent
+     * from the final [OperationResult] and an ERROR-severity [OperationOutcome] is recorded.
+     * Downstream tasks that depend on this key are skipped.
+     */
     fun add(key: String, block: suspend () -> Base): AsyncOperationResult = also {
         registerNode(key, TaskNode.Independent(key) { listOf(block()) })
     }
 
+    /**
+     * Registers an independent DAG task that produces a list of resources stored under [key].
+     * Each element is added to the list under the same key. See [add] for error semantics.
+     */
     fun <R : Base> addList(key: String, block: suspend () -> List<R>): AsyncOperationResult = also {
         registerNode(key, TaskNode.Independent(key) { block() })
     }
 
+    /**
+     * Registers a dependent DAG task that produces a single [Base] resource stored under [key].
+     *
+     * [block] is invoked only after all [deps] have resolved successfully. It receives a map
+     * keyed by dependency name, where each entry holds the list of resources produced by that
+     * dependency. If any dependency fails, this task is skipped without calling [block].
+     *
+     * All [deps] must already be registered; duplicate keys and cycles cause
+     * [IllegalArgumentException] at registration time.
+     *
+     * @param key storage key for the result
+     * @param deps keys of previously registered tasks whose results are passed to [block]
+     * @param block the suspending lambda to invoke; receives resolved dependency results
+     */
     fun addAfter(
         key: String,
         vararg deps: String,
@@ -121,6 +169,13 @@ class AsyncOperationResult {
         registerNode(key, TaskNode.Dependent(key, depList) { map -> listOf(block(map)) })
     }
 
+    /**
+     * Like [addAfter] but [block] returns a `List<R>`. All elements are stored under [key].
+     *
+     * @param key storage key for the result list
+     * @param deps keys of previously registered tasks whose results are passed to [block]
+     * @param block the suspending lambda to invoke; receives resolved dependency results
+     */
     fun <R : Base> addListAfter(
         key: String,
         vararg deps: String,
@@ -134,6 +189,17 @@ class AsyncOperationResult {
 
     // Type-safe single-dependency convenience methods
 
+    /**
+     * Type-safe overload of [addAfter] for a single dependency.
+     *
+     * Extracts the first value stored under [dep] that is an instance of [type] and passes it
+     * directly to [block], eliminating manual map lookup and casting.
+     *
+     * @param key storage key for the result
+     * @param dep the single dependency key
+     * @param type the expected type of the dependency value
+     * @param block the suspending lambda; receives the typed dependency value
+     */
     fun <T : Base> addAfter(
         key: String,
         dep: String,
@@ -144,6 +210,17 @@ class AsyncOperationResult {
         block(value)
     }
 
+    /**
+     * Type-safe overload of [addListAfter] for a single dependency.
+     *
+     * Extracts the first value stored under [dep] that is an instance of [type] and passes it
+     * directly to [block]. See [addAfter] (typed overload) for the full contract.
+     *
+     * @param key storage key for the result list
+     * @param dep the single dependency key
+     * @param type the expected type of the dependency value
+     * @param block the suspending lambda; receives the typed dependency value
+     */
     fun <T : Base, R : Base> addListAfter(
         key: String,
         dep: String,
@@ -156,6 +233,17 @@ class AsyncOperationResult {
 
     // Type-safe list-injection convenience methods
 
+    /**
+     * Type-safe overload of [addAfter] for a single dependency where [block] receives **all**
+     * values stored under [dep] that are instances of [type], as a typed list.
+     *
+     * Use [addAfter] (typed overload) when you want only the first matching value.
+     *
+     * @param key storage key for the result
+     * @param dep the single dependency key
+     * @param type the expected type of the dependency values
+     * @param block the suspending lambda; receives the typed dependency list
+     */
     fun <T : Base> addAfterAll(
         key: String,
         dep: String,
@@ -166,6 +254,14 @@ class AsyncOperationResult {
         block(values)
     }
 
+    /**
+     * Like [addAfterAll] but [block] returns a `List<R>`.
+     *
+     * @param key storage key for the result list
+     * @param dep the single dependency key
+     * @param type the expected type of the dependency values
+     * @param block the suspending lambda; receives the typed dependency list
+     */
     fun <T : Base, R : Base> addListAfterAll(
         key: String,
         dep: String,
@@ -912,6 +1008,12 @@ class AsyncOperationResult {
         OperationResult.fromMap(accumulator, outcomes, failedTasks)
     }
 
+    /**
+     * Blocking wrapper around [run] — calls [run] inside [kotlinx.coroutines.runBlocking].
+     *
+     * Inherits the DAG-level timeout configured via [timeout], if set.
+     * Prefer [run] from a coroutine context; use this method only from non-suspending call sites.
+     */
     fun runBlocking(): OperationResult<Base> = runBlocking { run() }
 
     private fun dagTimeoutOutcome(durationMs: Long): OperationOutcome = OperationOutcome().apply {

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -87,10 +87,19 @@ class OperationResult<T> private constructor(
 
     override fun isSuccessful(): Boolean = outcomes.isEmpty()
 
+    /** Returns all [OperationOutcome] instances recorded by failed pipeline steps. */
     fun getOutcomes(): List<OperationOutcome> = outcomes.toList()
 
+    /**
+     * Returns the map of task keys to their [OperationOutcome] for steps that failed when this
+     * result was produced by [AsyncOperationResult]. Empty for synchronous pipelines.
+     */
     fun getFailedTasks(): Map<String, OperationOutcome> = failedTasks.toMap()
 
+    /**
+     * Merges all recorded [OperationOutcome] instances into a single composite
+     * [OperationOutcome] whose issues are the union of every individual outcome's issues.
+     */
     fun toOperationOutcome(): OperationOutcome = OperationOutcome().apply {
         this@OperationResult.outcomes.forEach { oo ->
             oo.issue.forEach { issue ->
@@ -411,6 +420,14 @@ class OperationResult<T> private constructor(
 
     // Builder methods - single item
 
+    /**
+     * Invokes [builder] to produce a new FHIR resource, stores it under [name] (or the
+     * resource's [Base.fhirType] lowercase when [name] is `null`), and returns a new
+     * [OperationResult] with [R] as the pipeline head.
+     *
+     * Error handling follows Pattern A: exceptions record an ERROR-severity [OperationOutcome]
+     * and skip the head value.
+     */
     @JvmOverloads
     fun <R : Base> add(name: String? = null, builder: () -> R): OperationResult<R> =
         runBuilderStep(name) {
@@ -418,6 +435,11 @@ class OperationResult<T> private constructor(
             storeAndCopy(name, value, duration.inWholeMilliseconds)
         }
 
+    /**
+     * Like [add] but [builder] receives the current pipeline head value [T].
+     *
+     * Error handling follows Pattern A.
+     */
     @JvmOverloads
     fun <R : Base> addUsing(name: String? = null, builder: (T) -> R): OperationResult<R> =
         runBuilderStep(name) {
@@ -429,6 +451,13 @@ class OperationResult<T> private constructor(
     // addAll/addAllUsing return OperationResult<List<R>>; use getResultList() or getResult()
     // to retrieve the typed list without casting.
 
+    /**
+     * Invokes [builder] to produce a list of FHIR resources, stores each element under [name]
+     * (or each element's [Base.fhirType] lowercase when [name] is `null`), and returns a new
+     * [OperationResult] with `List<R>` as the pipeline head.
+     *
+     * Error handling follows Pattern A.
+     */
     @JvmOverloads
     fun <R : Base> addAll(name: String? = null, builder: () -> List<R>): OperationResult<List<R>> =
         runBuilderStep(name) {
@@ -436,6 +465,11 @@ class OperationResult<T> private constructor(
             storeListAndCopy(name, values, duration.inWholeMilliseconds)
         }
 
+    /**
+     * Like [addAll] but [builder] receives the current pipeline head value [T].
+     *
+     * Error handling follows Pattern A.
+     */
     @JvmOverloads
     fun <R : Base> addAllUsing(name: String? = null, builder: (T) -> List<R>): OperationResult<List<R>> =
         runBuilderStep(name) {
@@ -445,6 +479,13 @@ class OperationResult<T> private constructor(
 
     // Builder methods - from existing parameters
 
+    /**
+     * Reads all values already accumulated under [name], filters them to [type], passes the
+     * typed list to [builder], and replaces the values stored under [name] with the single
+     * result. The pipeline head becomes [R].
+     *
+     * Error handling follows Pattern A.
+     */
     fun <I : Base, R : Base> addFrom(name: String, type: KClass<I>, builder: (List<I>) -> R): OperationResult<R> =
         runBuilderStep(name) {
             val (value, duration) = measureTimedValue {
@@ -454,6 +495,11 @@ class OperationResult<T> private constructor(
             storeAndCopy(name, value, duration.inWholeMilliseconds)
         }
 
+    /**
+     * Like [addFrom] but [builder] returns a `List<R>`. The pipeline head becomes `List<R>`.
+     *
+     * Error handling follows Pattern A.
+     */
     fun <I : Base, R : Base> addAllFrom(name: String, type: KClass<I>, builder: (List<I>) -> List<R>): OperationResult<List<R>> =
         runBuilderStep(name) {
             val (values, duration) = measureTimedValue {
@@ -465,6 +511,13 @@ class OperationResult<T> private constructor(
 
     // Builder variants with explicit error handling
 
+    /**
+     * Like [add] but on exception records a WARNING-severity [OperationOutcome] and preserves
+     * the current head type [T] rather than skipping it (Pattern B — head-preserving).
+     *
+     * The result is still stored in the parameter map on success; on failure it is silently
+     * omitted and the pipeline continues with the same head.
+     */
     @JvmOverloads
     fun <R : Base> addOrSkip(name: String? = null, builder: () -> R): OperationResult<T> {
         val (builderResult, duration) = measureTimedValue { runCatching { builder() } }
@@ -488,6 +541,11 @@ class OperationResult<T> private constructor(
         )
     }
 
+    /**
+     * Like [add] but on exception stores [default] under [name] instead and returns a new
+     * [OperationResult] with [R] as the pipeline head. A WARNING-severity [OperationOutcome]
+     * is recorded on failure (Pattern B — head-preserving, result type changes to [R]).
+     */
     @JvmOverloads
     fun <R : Base> addOrDefault(name: String? = null, default: R, builder: () -> R): OperationResult<R> {
         val (builderResult, duration) = measureTimedValue { runCatching { builder() } }
@@ -622,34 +680,85 @@ class OperationResult<T> private constructor(
     }
 
     // ── Primitive value convenience methods ──────────────────────────────────
+    //
+    // All primitive methods follow Pattern B: exceptions record a WARNING-severity
+    // OperationOutcome and preserve the current head type T unchanged.
 
+    /** Stores a FHIR [StringType] under [name]. On error records a WARNING (Pattern B). */
     fun addString(name: String, value: String): OperationResult<T>       = runPrimitiveStep(name) { StringType(value) }
+
+    /** Stores a FHIR [BooleanType] under [name]. On error records a WARNING (Pattern B). */
     fun addBoolean(name: String, value: Boolean): OperationResult<T>     = runPrimitiveStep(name) { BooleanType(value) }
+
+    /** Stores a FHIR [IntegerType] under [name]. On error records a WARNING (Pattern B). */
     fun addInteger(name: String, value: Int): OperationResult<T>         = runPrimitiveStep(name) { IntegerType(value) }
+
+    /** Stores a FHIR [DecimalType] under [name]. On error records a WARNING (Pattern B). */
     fun addDecimal(name: String, value: BigDecimal): OperationResult<T>  = runPrimitiveStep(name) { DecimalType(value) }
+
+    /** Stores a FHIR [CodeType] under [name]. On error records a WARNING (Pattern B). */
     fun addCode(name: String, value: String): OperationResult<T>         = runPrimitiveStep(name) { CodeType(value) }
+
+    /** Stores a FHIR [UriType] under [name]. On error records a WARNING (Pattern B). */
     fun addUri(name: String, value: String): OperationResult<T>          = runPrimitiveStep(name) { UriType(value) }
+
+    /** Converts [value] to a FHIR date and stores it under [name]. On error records a WARNING (Pattern B). */
     fun addDate(name: String, value: DateTimeInput): OperationResult<T>     = runPrimitiveStep(name) { FhirDateTimeConverter.toFhirDate(value) }
+
+    /** Converts [value] to a FHIR dateTime and stores it under [name]. On error records a WARNING (Pattern B). */
     fun addDateTime(name: String, value: DateTimeInput): OperationResult<T> = runPrimitiveStep(name) { FhirDateTimeConverter.toFhirDateTime(value) }
+
+    /** Converts [value] to a FHIR instant and stores it under [name]. On error records a WARNING (Pattern B). */
     fun addInstant(name: String, value: DateTimeInput): OperationResult<T>  = runPrimitiveStep(name) { FhirDateTimeConverter.toFhirInstant(value) }
+
+    /** Converts [value] to a FHIR time and stores it under [name]. On error records a WARNING (Pattern B). */
     fun addTime(name: String, value: DateTimeInput): OperationResult<T>     = runPrimitiveStep(name) { FhirDateTimeConverter.toFhirTime(value) }
 
+    /** Stores a FHIR [CanonicalType] under [name]. On error records a WARNING (Pattern B). */
     fun addCanonical(name: String, value: String): OperationResult<T>    = runPrimitiveStep(name) { CanonicalType(value) }
 
+    /** Like [addString] but derives [value] from the current pipeline head via [builder]. */
     fun addStringUsing(name: String, builder: (T) -> String): OperationResult<T>           = runPrimitiveStep(name) { StringType(builder(getResult())) }
+
+    /** Like [addBoolean] but derives [value] from the current pipeline head via [builder]. */
     fun addBooleanUsing(name: String, builder: (T) -> Boolean): OperationResult<T>         = runPrimitiveStep(name) { BooleanType(builder(getResult())) }
+
+    /** Like [addInteger] but derives [value] from the current pipeline head via [builder]. */
     fun addIntegerUsing(name: String, builder: (T) -> Int): OperationResult<T>             = runPrimitiveStep(name) { IntegerType(builder(getResult())) }
+
+    /** Like [addDecimal] but derives [value] from the current pipeline head via [builder]. */
     fun addDecimalUsing(name: String, builder: (T) -> BigDecimal): OperationResult<T>      = runPrimitiveStep(name) { DecimalType(builder(getResult())) }
+
+    /** Like [addCode] but derives [value] from the current pipeline head via [builder]. */
     fun addCodeUsing(name: String, builder: (T) -> String): OperationResult<T>             = runPrimitiveStep(name) { CodeType(builder(getResult())) }
+
+    /** Like [addUri] but derives [value] from the current pipeline head via [builder]. */
     fun addUriUsing(name: String, builder: (T) -> String): OperationResult<T>              = runPrimitiveStep(name) { UriType(builder(getResult())) }
+
+    /** Like [addDate] but derives [value] from the current pipeline head via [builder]. */
     fun addDateUsing(name: String, builder: (T) -> DateTimeInput): OperationResult<T>      = runPrimitiveStep(name) { FhirDateTimeConverter.toFhirDate(builder(getResult())) }
+
+    /** Like [addDateTime] but derives [value] from the current pipeline head via [builder]. */
     fun addDateTimeUsing(name: String, builder: (T) -> DateTimeInput): OperationResult<T>  = runPrimitiveStep(name) { FhirDateTimeConverter.toFhirDateTime(builder(getResult())) }
+
+    /** Like [addInstant] but derives [value] from the current pipeline head via [builder]. */
     fun addInstantUsing(name: String, builder: (T) -> DateTimeInput): OperationResult<T>   = runPrimitiveStep(name) { FhirDateTimeConverter.toFhirInstant(builder(getResult())) }
+
+    /** Like [addTime] but derives [value] from the current pipeline head via [builder]. */
     fun addTimeUsing(name: String, builder: (T) -> DateTimeInput): OperationResult<T>      = runPrimitiveStep(name) { FhirDateTimeConverter.toFhirTime(builder(getResult())) }
+
+    /** Like [addCanonical] but derives [value] from the current pipeline head via [builder]. */
     fun addCanonicalUsing(name: String, builder: (T) -> String): OperationResult<T>        = runPrimitiveStep(name) { CanonicalType(builder(getResult())) }
 
     // ── Complex data type convenience methods ────────────────────────────────
+    //
+    // All complex type methods follow Pattern B: on error a WARNING is recorded and the
+    // head type T is preserved unchanged.
 
+    /**
+     * Stores a [Coding] under [name] with the given [system], [code], and optional [display].
+     * On error records a WARNING (Pattern B).
+     */
     @JvmOverloads
     fun addCoding(name: String, system: String, code: String, display: String? = null): OperationResult<T> =
         runPrimitiveStep(name) {
@@ -660,9 +769,11 @@ class OperationResult<T> private constructor(
             }
         }
 
+    /** Stores a [Reference] under [name] with the given [reference] string. On error records a WARNING (Pattern B). */
     fun addReference(name: String, reference: String): OperationResult<T> =
         runPrimitiveStep(name) { Reference(reference) }
 
+    /** Stores an [Identifier] under [name] with the given [system] and [value]. On error records a WARNING (Pattern B). */
     fun addIdentifier(name: String, system: String, value: String): OperationResult<T> =
         runPrimitiveStep(name) {
             Identifier().apply {
@@ -671,6 +782,10 @@ class OperationResult<T> private constructor(
             }
         }
 
+    /**
+     * Stores a [Period] under [name] from raw FHIR date-time strings. `null` values are omitted
+     * from the period. On error records a WARNING (Pattern B).
+     */
     fun addPeriod(name: String, start: String?, end: String?): OperationResult<T> =
         runPrimitiveStep(name) {
             Period().apply {
@@ -679,6 +794,7 @@ class OperationResult<T> private constructor(
             }
         }
 
+    /** Stores a [Period] under [name] from [LocalDateTime] values. `null` values are omitted. On error records a WARNING (Pattern B). */
     fun addPeriod(name: String, start: LocalDateTime?, end: LocalDateTime?): OperationResult<T> =
         runPrimitiveStep(name) {
             Period().apply {
@@ -687,6 +803,7 @@ class OperationResult<T> private constructor(
             }
         }
 
+    /** Stores a [Period] under [name] from [ZonedDateTime] values. `null` values are omitted. On error records a WARNING (Pattern B). */
     fun addPeriod(name: String, start: ZonedDateTime?, end: ZonedDateTime?): OperationResult<T> =
         runPrimitiveStep(name) {
             Period().apply {
@@ -695,6 +812,7 @@ class OperationResult<T> private constructor(
             }
         }
 
+    /** Stores a [Period] under [name] from [OffsetDateTime] values. `null` values are omitted. On error records a WARNING (Pattern B). */
     fun addPeriod(name: String, start: OffsetDateTime?, end: OffsetDateTime?): OperationResult<T> =
         runPrimitiveStep(name) {
             Period().apply {
@@ -703,6 +821,10 @@ class OperationResult<T> private constructor(
             }
         }
 
+    /**
+     * Stores a [Quantity] under [name] with [value], [unit], and optional [system] and [code].
+     * On error records a WARNING (Pattern B).
+     */
     @JvmOverloads
     fun addQuantity(name: String, value: BigDecimal, unit: String, system: String? = null, code: String? = null): OperationResult<T> =
         runPrimitiveStep(name) {
@@ -714,6 +836,10 @@ class OperationResult<T> private constructor(
             }
         }
 
+    /**
+     * Stores a [CodeableConcept] under [name] with a single [Coding] built from [system], [code],
+     * and optional [display], plus an optional free-text [text]. On error records a WARNING (Pattern B).
+     */
     @JvmOverloads
     fun addCodeableConcept(name: String, system: String, code: String, display: String? = null, text: String? = null): OperationResult<T> =
         runPrimitiveStep(name) {
@@ -794,9 +920,11 @@ class OperationResult<T> private constructor(
 
     // Query methods
 
+    /** Returns a read-only snapshot of the full parameter map (all keys and all their values). */
     fun getAllParameters(): Map<String, List<Base>> =
         parameters.mapValues { it.value.toList() }
 
+    /** Returns all values accumulated under [name], or an empty list if the key is absent. */
     fun getAll(name: String): List<Base> =
         parameters[name]?.toList() ?: emptyList()
 
@@ -848,6 +976,7 @@ class OperationResult<T> private constructor(
     /** Reified overload — no [KClass] argument needed at call sites. */
     inline fun <reified R : Base> filterByType(): OperationResult<T> = filterByType(R::class)
 
+    /** Returns a new result containing only the entry for [name]. All other keys are dropped. No-op if [name] is absent. */
     fun filterByName(name: String): OperationResult<T> {
         val filtered = mutableMapOf<String, MutableList<Base>>()
         parameters[name]?.let { values ->
@@ -856,6 +985,11 @@ class OperationResult<T> private constructor(
         return copyWith(result, params = filtered)
     }
 
+    /**
+     * Applies [transform] to every value in the parameter map and returns a new result with the
+     * transformed values. The pipeline head is cleared to `null`; use [getResult] only after a
+     * subsequent builder step sets a new head.
+     */
     fun <R : Base> mapValues(transform: (Base) -> R): OperationResult<R> {
         val transformed = parameters.mapValues { (_, values) ->
             values.map(transform).toMutableList<Base>()
@@ -1311,6 +1445,11 @@ class OperationResult<T> private constructor(
      */
     fun toParameters(): Parameters = ParameterMapSerializer.unflatten(parameters, extensions)
 
+    /**
+     * Wraps [resource] in a [Bundle.BundleEntryComponent]. When [resource] is a [Resource]
+     * subtype, it is set as the entry's resource; non-Resource values produce an empty entry.
+     * Used internally by [toBundle] and its convenience aliases.
+     */
     fun toBundleEntry(resource: Base): Bundle.BundleEntryComponent =
         Bundle.BundleEntryComponent().apply {
             if (resource is Resource) setResource(resource)
@@ -1442,6 +1581,13 @@ class OperationResult<T> private constructor(
             return OperationResult(mutable, null, outcomes.toMutableList(), ErrorStrategy.FAIL_FAST, failedTasks.toMutableMap())
         }
 
+        /**
+         * Creates an [OperationResult] with [value] as both the pipeline head and the first
+         * parameter-map entry, stored under [name] (or [value]'s [Base.fhirType] lowercase when
+         * [name] is `null`).
+         *
+         * @param errorStrategy controls how subsequent steps behave when an error is recorded
+         */
         @JvmStatic
         @JvmOverloads
         fun <T : Base> of(value: T, name: String? = null, errorStrategy: ErrorStrategy = ErrorStrategy.FAIL_FAST): OperationResult<T> {
@@ -1451,6 +1597,13 @@ class OperationResult<T> private constructor(
             return OperationResult(params, value, mutableListOf(), errorStrategy, mutableMapOf())
         }
 
+        /**
+         * Creates an [OperationResult] with [values] as both the pipeline head (`List<T>`) and
+         * the initial parameter-map entries. Each element is stored under [name] (or the element's
+         * [Base.fhirType] lowercase when [name] is `null`).
+         *
+         * @param errorStrategy controls how subsequent steps behave when an error is recorded
+         */
         @JvmStatic
         @JvmOverloads
         fun <T : Base> of(values: List<T>, name: String? = null, errorStrategy: ErrorStrategy = ErrorStrategy.FAIL_FAST): OperationResult<List<T>> {


### PR DESCRIPTION
Every public method, function, and property must now have a KDoc
comment — this was inconsistently applied across the codebase.

Files updated (R4 and DSTU3 mirrored):
- ErrorStrategy: class-level KDoc added
- FhirPath: KDoc added to all undocumented collection, boolean,
  comparison, string, math, arithmetic, and type-conversion methods
- OperationResult: KDoc added to getOutcomes, getFailedTasks,
  toOperationOutcome, add, addUsing, addAll, addAllUsing, addFrom,
  addAllFrom, addOrSkip, addOrDefault, all primitive and complex-type
  convenience methods, getAllParameters, getAll, filterByName,
  mapValues, toBundleEntry, and the two `of` factory methods
- AsyncOperationResult: class-level KDoc added; KDoc added to add,
  addList, addAfter (vararg + typed overloads), addListAfter (vararg
  + typed overloads), addAfterAll, addListAfterAll, and runBlocking

CLAUDE.md: added "Documentation Rule" section requiring KDoc on all
public methods, with guidance on single-line vs multi-line KDoc,
@param tags, and inline/reified exceptions.