### PR TITLE
Broaden collection API from List to Collection in OperationResult and AsyncOperationResult

### DIFF
--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/AsyncOperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/AsyncOperationResult.kt
@@ -137,11 +137,14 @@ class AsyncOperationResult {
     }
 
     /**
-     * Registers an independent DAG task that produces a list of resources stored under [key].
+     * Registers an independent DAG task that produces a collection of resources stored under [key].
      * Each element is added to the list under the same key. See [add] for error semantics.
+     *
+     * Accepts any [Collection] (e.g. [List], [Set], [LinkedHashSet]); elements are stored as a
+     * [List] internally.
      */
-    fun <R : Base> addList(key: String, block: suspend () -> List<R>): AsyncOperationResult = also {
-        registerNode(key, TaskNode.Independent(key) { block() })
+    fun <R : Base> addList(key: String, block: suspend () -> Collection<R>): AsyncOperationResult = also {
+        registerNode(key, TaskNode.Independent(key) { block().toList() })
     }
 
     /**
@@ -170,7 +173,10 @@ class AsyncOperationResult {
     }
 
     /**
-     * Like [addAfter] but [block] returns a `List<R>`. All elements are stored under [key].
+     * Like [addAfter] but [block] returns a `Collection<R>`. All elements are stored under [key].
+     *
+     * Accepts any [Collection] return (e.g. [List], [Set], [LinkedHashSet]); elements are stored
+     * as a [List] internally.
      *
      * @param key storage key for the result list
      * @param deps keys of previously registered tasks whose results are passed to [block]
@@ -179,12 +185,12 @@ class AsyncOperationResult {
     fun <R : Base> addListAfter(
         key: String,
         vararg deps: String,
-        block: suspend (Map<String, List<Base>>) -> List<R>
+        block: suspend (Map<String, List<Base>>) -> Collection<R>
     ): AsyncOperationResult = also {
         val depList = deps.toList()
         requireKeysExist(depList)
         requireNoCycle(key, depList)
-        registerNode(key, TaskNode.Dependent(key, depList) { map -> block(map) })
+        registerNode(key, TaskNode.Dependent(key, depList) { map -> block(map).toList() })
     }
 
     // Type-safe single-dependency convenience methods
@@ -216,6 +222,8 @@ class AsyncOperationResult {
      * Extracts the first value stored under [dep] that is an instance of [type] and passes it
      * directly to [block]. See [addAfter] (typed overload) for the full contract.
      *
+     * Accepts any [Collection] return from [block]; elements are stored as a [List] internally.
+     *
      * @param key storage key for the result list
      * @param dep the single dependency key
      * @param type the expected type of the dependency value
@@ -225,7 +233,7 @@ class AsyncOperationResult {
         key: String,
         dep: String,
         type: KClass<T>,
-        block: suspend (T) -> List<R>
+        block: suspend (T) -> Collection<R>
     ): AsyncOperationResult = addListAfter(key, dep) { deps ->
         val value = deps[dep]!!.filterIsInstance(type.java).first()
         block(value)
@@ -255,7 +263,10 @@ class AsyncOperationResult {
     }
 
     /**
-     * Like [addAfterAll] but [block] returns a `List<R>`.
+     * Like [addAfterAll] but [block] returns a `Collection<R>`.
+     *
+     * Accepts any [Collection] return (e.g. [List], [Set], [LinkedHashSet]); elements are stored
+     * as a [List] internally.
      *
      * @param key storage key for the result list
      * @param dep the single dependency key
@@ -266,7 +277,7 @@ class AsyncOperationResult {
         key: String,
         dep: String,
         type: KClass<T>,
-        block: suspend (List<T>) -> List<R>
+        block: suspend (List<T>) -> Collection<R>
     ): AsyncOperationResult = addListAfter(key, dep) { deps ->
         val values = deps[dep]!!.filterIsInstance(type.java)
         block(values)
@@ -323,10 +334,10 @@ class AsyncOperationResult {
         })
     }
 
-    fun <R : Base> addListWithTimeout(key: String, timeoutMs: Long, block: suspend () -> List<R>): AsyncOperationResult = also {
+    fun <R : Base> addListWithTimeout(key: String, timeoutMs: Long, block: suspend () -> Collection<R>): AsyncOperationResult = also {
         require(timeoutMs > 0) { "timeoutMs must be positive" }
         registerNode(key, TaskNode.Independent(key) {
-            withTimeout(timeoutMs) { block() }
+            withTimeout(timeoutMs) { block() }.toList()
         })
     }
 
@@ -351,14 +362,14 @@ class AsyncOperationResult {
         key: String,
         vararg deps: String,
         timeoutMs: Long,
-        block: suspend (Map<String, List<Base>>) -> List<R>
+        block: suspend (Map<String, List<Base>>) -> Collection<R>
     ): AsyncOperationResult = also {
         require(timeoutMs > 0) { "timeoutMs must be positive" }
         val depList = deps.toList()
         requireKeysExist(depList)
         requireNoCycle(key, depList)
         registerNode(key, TaskNode.Dependent(key, depList) { depResults ->
-            withTimeout(timeoutMs) { block(depResults) }
+            withTimeout(timeoutMs) { block(depResults) }.toList()
         })
     }
 
@@ -380,7 +391,7 @@ class AsyncOperationResult {
         dep: String,
         type: KClass<T>,
         timeoutMs: Long,
-        block: suspend (T) -> List<R>
+        block: suspend (T) -> Collection<R>
     ): AsyncOperationResult = addListAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
         val value = deps[dep]!!.filterIsInstance(type.java).first()
         block(value)
@@ -402,7 +413,7 @@ class AsyncOperationResult {
         dep: String,
         type: KClass<T>,
         timeoutMs: Long,
-        block: suspend (List<T>) -> List<R>
+        block: suspend (List<T>) -> Collection<R>
     ): AsyncOperationResult = addListAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
         val values = deps[dep]!!.filterIsInstance(type.java)
         block(values)
@@ -437,7 +448,7 @@ class AsyncOperationResult {
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
-        block: suspend (Map<String, List<Base>>) -> List<R>
+        block: suspend (Map<String, List<Base>>) -> Collection<R>
     ): AsyncOperationResult {
         require(maxAttempts >= 1) { "maxAttempts must be at least 1" }
         require(initialDelayMs >= 0) { "initialDelayMs must be non-negative" }
@@ -446,7 +457,7 @@ class AsyncOperationResult {
         requireNoCycle(key, depList)
         return also {
             registerNode(key, TaskNode.Dependent(key, depList) { depResults ->
-                suspendExecuteWithRetry(maxAttempts, initialDelayMs, retryOn) { block(depResults) }
+                suspendExecuteWithRetry(maxAttempts, initialDelayMs, retryOn) { block(depResults) }.toList()
             })
         }
     }
@@ -479,7 +490,7 @@ class AsyncOperationResult {
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
-        block: suspend (T) -> List<R>
+        block: suspend (T) -> Collection<R>
     ): AsyncOperationResult = addListAfterWithRetry(
         key, dep,
         maxAttempts = maxAttempts,
@@ -516,7 +527,7 @@ class AsyncOperationResult {
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
-        block: suspend (List<T>) -> List<R>
+        block: suspend (List<T>) -> Collection<R>
     ): AsyncOperationResult = addListAfterWithRetry(
         key, dep,
         maxAttempts = maxAttempts,
@@ -543,16 +554,17 @@ class AsyncOperationResult {
         })
     }
 
-    fun <R : Base> addListWithDefault(key: String, default: List<R>, block: suspend () -> List<R>): AsyncOperationResult = also {
+    fun <R : Base> addListWithDefault(key: String, default: Collection<R>, block: suspend () -> Collection<R>): AsyncOperationResult = also {
+        val defaultList = default.toList()
         registerNode(key, TaskNode.Independent(key) {
             try {
-                block()
+                block().toList()
             } catch (e: BaseServerResponseException) {
                 logger.warn("FHIRMason.async | task='{}' | using default list: {}", key, e.message)
-                default
+                defaultList
             } catch (e: Exception) {
                 logger.warn("FHIRMason.async | task='{}' | using default list: {}", key, e.message)
-                default
+                defaultList
             }
         })
     }
@@ -562,7 +574,7 @@ class AsyncOperationResult {
     fun addIf(condition: Boolean, key: String, block: suspend () -> Base): AsyncOperationResult =
         if (condition) add(key, block) else this
 
-    fun <R : Base> addListIf(condition: Boolean, key: String, block: suspend () -> List<R>): AsyncOperationResult =
+    fun <R : Base> addListIf(condition: Boolean, key: String, block: suspend () -> Collection<R>): AsyncOperationResult =
         if (condition) addList(key, block) else this
 
     // ── DAG composition ──────────────────────────────────────────────────────

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
@@ -236,13 +236,14 @@ class OperationResult<T> private constructor(
         return copyWith(value)
     }
 
-    private fun <R : Base> storeListAndCopy(name: String?, values: List<R>, durationMs: Long): OperationResult<List<R>> {
-        addToParameters(values, name)
-        val key = name ?: values.firstOrNull()?.fhirType()?.lowercase() ?: "list"
-        val typeDesc = "${values.firstOrNull()?.fhirType() ?: "Empty"}[${values.size}]"
+    private fun <R : Base> storeListAndCopy(name: String?, values: Collection<R>, durationMs: Long): OperationResult<List<R>> {
+        val list = values.toList()
+        addToParameters(list, name)
+        val key = name ?: list.firstOrNull()?.fhirType()?.lowercase() ?: "list"
+        val typeDesc = "${list.firstOrNull()?.fhirType() ?: "Empty"}[${list.size}]"
         recordMetric(key, typeDesc, durationMs, true)
         logStep(key, typeDesc, durationMs)
-        return copyWith(values)
+        return copyWith(list)
     }
 
 
@@ -287,15 +288,18 @@ class OperationResult<T> private constructor(
     ): OperationResult<R> = addFromFiltered(name, type.kotlin, predicate, builder)
 
     /**
-     * Like [addFromFiltered] but [builder] returns a `List<R>`, making the new
+     * Like [addFromFiltered] but [builder] returns a `Collection<R>`, making the new
      * pipeline head `List<R>`.
+     *
+     * Accepts any [Collection] return (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
+     * always stored as a [List].
      */
     @JvmOverloads
     fun <I : Base, R : Base> addAllFromFiltered(
         name: String? = null,
         type: KClass<I>,
         predicate: (I) -> Boolean,
-        builder: (List<I>) -> List<R>
+        builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = runBuilderStep(name) {
         val (values, duration) = measureTimedValue {
             builder(parameters.values.flatten().filterIsInstance(type.java).filter(predicate))
@@ -307,7 +311,7 @@ class OperationResult<T> private constructor(
     inline fun <reified I : Base, R : Base> addAllFromFiltered(
         name: String? = null,
         noinline predicate: (I) -> Boolean,
-        noinline builder: (List<I>) -> List<R>
+        noinline builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = addAllFromFiltered(name, I::class, predicate, builder)
 
     /** Java-friendly overload of [addAllFromFiltered] — accepts [Class] instead of [KClass]. */
@@ -316,7 +320,7 @@ class OperationResult<T> private constructor(
         name: String? = null,
         type: Class<I>,
         predicate: (I) -> Boolean,
-        builder: (List<I>) -> List<R>
+        builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = addAllFromFiltered(name, type.kotlin, predicate, builder)
 
     // Builder methods — filter all accumulated parameters by type and FHIRPath expression
@@ -361,16 +365,19 @@ class OperationResult<T> private constructor(
     ): OperationResult<R> = addFromMatching(name, type, expression.build(), builder)
 
     /**
-     * Like [addFromMatching] but [builder] returns a `List<R>`.
+     * Like [addFromMatching] but [builder] returns a `Collection<R>`.
      * When [name] is `null`, the output key defaults to the first element's [Base.fhirType]
      * (lowercase) — consistent with [addAll].
+     *
+     * Accepts any [Collection] return (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
+     * always stored as a [List].
      */
     @JvmOverloads
     fun <I : Base, R : Base> addAllFromMatching(
         name: String? = null,
         type: KClass<I>,
         expression: String,
-        builder: (List<I>) -> List<R>
+        builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> {
         return runBuilderStep(name) {
             val (values, duration) = measureTimedValue { builder(collectByPath(type, expression)) }
@@ -384,7 +391,7 @@ class OperationResult<T> private constructor(
         name: String? = null,
         type: KClass<I>,
         expression: FhirPath,
-        builder: (List<I>) -> List<R>
+        builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = addAllFromMatching(name, type, expression.build(), builder)
 
     /** Reified overload of [addFromMatching] — no [KClass] argument needed at call sites. */
@@ -405,14 +412,14 @@ class OperationResult<T> private constructor(
     inline fun <reified I : Base, R : Base> addAllFromMatching(
         name: String? = null,
         expression: String,
-        noinline builder: (List<I>) -> List<R>
+        noinline builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = addAllFromMatching(name, I::class, expression, builder)
 
     /** [FhirPath] reified overload of [addAllFromMatching]. */
     inline fun <reified I : Base, R : Base> addAllFromMatching(
         name: String? = null,
         expression: FhirPath,
-        noinline builder: (List<I>) -> List<R>
+        noinline builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = addAllFromMatching(name, I::class, expression.build(), builder)
 
     // Builder methods - single item
@@ -449,14 +456,17 @@ class OperationResult<T> private constructor(
     // to retrieve the typed list without casting.
 
     /**
-     * Invokes [builder] to produce a list of FHIR resources, stores each element under [name]
-     * (or each element's [Base.fhirType] lowercase when [name] is `null`), and returns a new
-     * [OperationResult] with `List<R>` as the pipeline head.
+     * Invokes [builder] to produce a collection of FHIR resources, stores each element under
+     * [name] (or each element's [Base.fhirType] lowercase when [name] is `null`), and returns a
+     * new [OperationResult] with `List<R>` as the pipeline head.
+     *
+     * Accepts any [Collection] (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
+     * always stored as a [List].
      *
      * Error handling follows Pattern A.
      */
     @JvmOverloads
-    fun <R : Base> addAll(name: String? = null, builder: () -> List<R>): OperationResult<List<R>> =
+    fun <R : Base> addAll(name: String? = null, builder: () -> Collection<R>): OperationResult<List<R>> =
         runBuilderStep(name) {
             val (values, duration) = measureTimedValue { builder() }
             storeListAndCopy(name, values, duration.inWholeMilliseconds)
@@ -465,10 +475,13 @@ class OperationResult<T> private constructor(
     /**
      * Like [addAll] but [builder] receives the current pipeline head value [T].
      *
+     * Accepts any [Collection] (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
+     * always stored as a [List].
+     *
      * Error handling follows Pattern A.
      */
     @JvmOverloads
-    fun <R : Base> addAllUsing(name: String? = null, builder: (T) -> List<R>): OperationResult<List<R>> =
+    fun <R : Base> addAllUsing(name: String? = null, builder: (T) -> Collection<R>): OperationResult<List<R>> =
         runBuilderStep(name) {
             val (values, duration) = measureTimedValue { builder(getResult()) }
             storeListAndCopy(name, values, duration.inWholeMilliseconds)
@@ -493,11 +506,14 @@ class OperationResult<T> private constructor(
         }
 
     /**
-     * Like [addFrom] but [builder] returns a `List<R>`. The pipeline head becomes `List<R>`.
+     * Like [addFrom] but [builder] returns a `Collection<R>`. The pipeline head becomes `List<R>`.
+     *
+     * Accepts any [Collection] return (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
+     * always stored as a [List].
      *
      * Error handling follows Pattern A.
      */
-    fun <I : Base, R : Base> addAllFrom(name: String, type: KClass<I>, builder: (List<I>) -> List<R>): OperationResult<List<R>> =
+    fun <I : Base, R : Base> addAllFrom(name: String, type: KClass<I>, builder: (List<I>) -> Collection<R>): OperationResult<List<R>> =
         runBuilderStep(name) {
             val (values, duration) = measureTimedValue {
                 val filtered = parameters[name]?.filterIsInstance(type.java) ?: emptyList()
@@ -1550,7 +1566,7 @@ class OperationResult<T> private constructor(
 
     // Private helpers
 
-    private fun addToParameters(values: List<Base>, name: String?) {
+    private fun addToParameters(values: Collection<Base>, name: String?) {
         values.forEach { value ->
             val key = name ?: value.fhirType().lowercase()
             parameters.getOrPut(key) { mutableListOf() }.add(value)
@@ -1593,14 +1609,18 @@ class OperationResult<T> private constructor(
          * the initial parameter-map entries. Each element is stored under [name] (or the element's
          * [Base.fhirType] lowercase when [name] is `null`).
          *
+         * Accepts any [Collection] (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
+         * always stored as a [List].
+         *
          * @param errorStrategy controls how subsequent steps behave when an error is recorded
          */
         @JvmStatic
         @JvmOverloads
-        fun <T : Base> of(values: List<T>, name: String? = null, errorStrategy: ErrorStrategy = ErrorStrategy.FAIL_FAST): OperationResult<List<T>> {
+        fun <T : Base> of(values: Collection<T>, name: String? = null, errorStrategy: ErrorStrategy = ErrorStrategy.FAIL_FAST): OperationResult<List<T>> {
+            val list = values.toList()
             val params = mutableMapOf<String, MutableList<Base>>()
-            val instance = OperationResult(params, values, mutableListOf(), errorStrategy, mutableMapOf())
-            instance.addToParameters(values, name)
+            val instance = OperationResult(params, list, mutableListOf(), errorStrategy, mutableMapOf())
+            instance.addToParameters(list, name)
             return instance
         }
 

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultTest.kt
@@ -463,6 +463,48 @@ class AsyncOperationResultTest {
         }
     }
 
+    // ── Collection inputs ─────────────────────────────────────────────────────
+
+    @Test
+    fun `addList block returning a Set stores all elements`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("appointments") {
+                setOf(
+                    Appointment().apply { id = "a1" },
+                    Appointment().apply { id = "a2" }
+                )
+            }
+            .run()
+
+        assertThat(result.count("appointments"), `is`(2))
+    }
+
+    @Test
+    fun `addListWithDefault default as Set is used on failure`() = runBlocking {
+        val default = setOf(Appointment().apply { id = "fallback" })
+        val result = AsyncOperationResult()
+            .addListWithDefault("appointments", default) { throw RuntimeException("fail") }
+            .run()
+
+        assertThat(result.count("appointments"), `is`(1))
+        val stored = result.getAll("appointments").first() as Appointment
+        assertThat(stored.id, `is`("fallback"))
+    }
+
+    @Test
+    fun `addListIf block returning a Set registers correctly`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addListIf(true, "appointments") {
+                setOf(
+                    Appointment().apply { id = "a1" },
+                    Appointment().apply { id = "a2" }
+                )
+            }
+            .run()
+
+        assertThat(result.count("appointments"), `is`(2))
+    }
+
     @Test
     fun `withExecutor returns this for fluent chaining`() {
         val dag = AsyncOperationResult()

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultTest.kt
@@ -240,6 +240,47 @@ class OperationResultTest {
         assertEquals("count=0", appt.participantFirstRep.actor.display)
     }
 
+    // ── Collection inputs ─────────────────────────────────────────────────────
+
+    @Test
+    fun `of accepts a Set and stores all elements`() {
+        val p1 = patient()
+        val p2 = patient()
+        val result = OperationResult.of(setOf(p1, p2))
+
+        assertEquals(2, result.count("patient"))
+        assertThat(result.getResultList(), hasSize(2))
+    }
+
+    @Test
+    fun `addAll builder returning a Set stores all elements`() {
+        val result = OperationResult.of(patient())
+            .addAll { setOf(patient(), appointment()) }
+
+        assertEquals(2, result.count("patient"))
+        assertEquals(1, result.count("appointment"))
+    }
+
+    @Test
+    fun `addAllUsing builder returning a LinkedHashSet stores all elements`() {
+        val items = linkedSetOf(appointment(), appointment())
+        val result = OperationResult.of(patient())
+            .addAllUsing { _ -> items }
+
+        assertEquals(2, result.count("appointment"))
+    }
+
+    @Test
+    fun `addAllFrom builder returning a Set stores all elements`() {
+        val result = OperationResult.of(listOf(patient(), patient()), "patients")
+            .addAllFrom("patients", Patient::class) { patients ->
+                patients.map { OperationOutcome() }.toSet()
+            }
+
+        assertThat(result.getResultList(), hasSize(2))
+        assertThat(result.getByType<OperationOutcome>(), hasSize(2))
+    }
+
     // ── addAllFrom ────────────────────────────────────────────────────────────
 
     @Test
@@ -1177,7 +1218,7 @@ class OperationResultTest {
         // getResultList() extension only exists on OperationResult<List<R>>
         val retrieved: List<Appointment> = result.getResultList()
         assertEquals(2, retrieved.size)
-        assertThat(retrieved, sameInstance(appts))
+        assertThat(retrieved, containsInAnyOrder(*appts.toTypedArray()))
     }
 
     @Test

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/AsyncOperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/AsyncOperationResult.kt
@@ -137,11 +137,14 @@ class AsyncOperationResult {
     }
 
     /**
-     * Registers an independent DAG task that produces a list of resources stored under [key].
+     * Registers an independent DAG task that produces a collection of resources stored under [key].
      * Each element is added to the list under the same key. See [add] for error semantics.
+     *
+     * Accepts any [Collection] (e.g. [List], [Set], [LinkedHashSet]); elements are stored as a
+     * [List] internally.
      */
-    fun <R : Base> addList(key: String, block: suspend () -> List<R>): AsyncOperationResult = also {
-        registerNode(key, TaskNode.Independent(key) { block() })
+    fun <R : Base> addList(key: String, block: suspend () -> Collection<R>): AsyncOperationResult = also {
+        registerNode(key, TaskNode.Independent(key) { block().toList() })
     }
 
     /**
@@ -170,7 +173,10 @@ class AsyncOperationResult {
     }
 
     /**
-     * Like [addAfter] but [block] returns a `List<R>`. All elements are stored under [key].
+     * Like [addAfter] but [block] returns a `Collection<R>`. All elements are stored under [key].
+     *
+     * Accepts any [Collection] return (e.g. [List], [Set], [LinkedHashSet]); elements are stored
+     * as a [List] internally.
      *
      * @param key storage key for the result list
      * @param deps keys of previously registered tasks whose results are passed to [block]
@@ -179,12 +185,12 @@ class AsyncOperationResult {
     fun <R : Base> addListAfter(
         key: String,
         vararg deps: String,
-        block: suspend (Map<String, List<Base>>) -> List<R>
+        block: suspend (Map<String, List<Base>>) -> Collection<R>
     ): AsyncOperationResult = also {
         val depList = deps.toList()
         requireKeysExist(depList)
         requireNoCycle(key, depList)
-        registerNode(key, TaskNode.Dependent(key, depList) { map -> block(map) })
+        registerNode(key, TaskNode.Dependent(key, depList) { map -> block(map).toList() })
     }
 
     // Type-safe single-dependency convenience methods
@@ -216,6 +222,8 @@ class AsyncOperationResult {
      * Extracts the first value stored under [dep] that is an instance of [type] and passes it
      * directly to [block]. See [addAfter] (typed overload) for the full contract.
      *
+     * Accepts any [Collection] return from [block]; elements are stored as a [List] internally.
+     *
      * @param key storage key for the result list
      * @param dep the single dependency key
      * @param type the expected type of the dependency value
@@ -225,7 +233,7 @@ class AsyncOperationResult {
         key: String,
         dep: String,
         type: KClass<T>,
-        block: suspend (T) -> List<R>
+        block: suspend (T) -> Collection<R>
     ): AsyncOperationResult = addListAfter(key, dep) { deps ->
         val value = deps[dep]!!.filterIsInstance(type.java).first()
         block(value)
@@ -255,7 +263,10 @@ class AsyncOperationResult {
     }
 
     /**
-     * Like [addAfterAll] but [block] returns a `List<R>`.
+     * Like [addAfterAll] but [block] returns a `Collection<R>`.
+     *
+     * Accepts any [Collection] return (e.g. [List], [Set], [LinkedHashSet]); elements are stored
+     * as a [List] internally.
      *
      * @param key storage key for the result list
      * @param dep the single dependency key
@@ -266,7 +277,7 @@ class AsyncOperationResult {
         key: String,
         dep: String,
         type: KClass<T>,
-        block: suspend (List<T>) -> List<R>
+        block: suspend (List<T>) -> Collection<R>
     ): AsyncOperationResult = addListAfter(key, dep) { deps ->
         val values = deps[dep]!!.filterIsInstance(type.java)
         block(values)
@@ -369,10 +380,10 @@ class AsyncOperationResult {
      * @param timeoutMs maximum allowed execution time in milliseconds; must be > 0
      * @param block the suspending lambda to execute within the timeout
      */
-    fun <R : Base> addListWithTimeout(key: String, timeoutMs: Long, block: suspend () -> List<R>): AsyncOperationResult = also {
+    fun <R : Base> addListWithTimeout(key: String, timeoutMs: Long, block: suspend () -> Collection<R>): AsyncOperationResult = also {
         require(timeoutMs > 0) { "timeoutMs must be positive" }
         registerNode(key, TaskNode.Independent(key) {
-            withTimeout(timeoutMs) { block() }
+            withTimeout(timeoutMs) { block() }.toList()
         })
     }
 
@@ -419,14 +430,14 @@ class AsyncOperationResult {
         key: String,
         vararg deps: String,
         timeoutMs: Long,
-        block: suspend (Map<String, List<Base>>) -> List<R>
+        block: suspend (Map<String, List<Base>>) -> Collection<R>
     ): AsyncOperationResult = also {
         require(timeoutMs > 0) { "timeoutMs must be positive" }
         val depList = deps.toList()
         requireKeysExist(depList)
         requireNoCycle(key, depList)
         registerNode(key, TaskNode.Dependent(key, depList) { depResults ->
-            withTimeout(timeoutMs) { block(depResults) }
+            withTimeout(timeoutMs) { block(depResults) }.toList()
         })
     }
 
@@ -472,7 +483,7 @@ class AsyncOperationResult {
         dep: String,
         type: KClass<T>,
         timeoutMs: Long,
-        block: suspend (T) -> List<R>
+        block: suspend (T) -> Collection<R>
     ): AsyncOperationResult = addListAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
         val value = deps[dep]!!.filterIsInstance(type.java).first()
         block(value)
@@ -516,7 +527,7 @@ class AsyncOperationResult {
         dep: String,
         type: KClass<T>,
         timeoutMs: Long,
-        block: suspend (List<T>) -> List<R>
+        block: suspend (List<T>) -> Collection<R>
     ): AsyncOperationResult = addListAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
         val values = deps[dep]!!.filterIsInstance(type.java)
         block(values)
@@ -583,7 +594,7 @@ class AsyncOperationResult {
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
-        block: suspend (Map<String, List<Base>>) -> List<R>
+        block: suspend (Map<String, List<Base>>) -> Collection<R>
     ): AsyncOperationResult {
         require(maxAttempts >= 1) { "maxAttempts must be at least 1" }
         require(initialDelayMs >= 0) { "initialDelayMs must be non-negative" }
@@ -592,7 +603,7 @@ class AsyncOperationResult {
         requireNoCycle(key, depList)
         return also {
             registerNode(key, TaskNode.Dependent(key, depList) { depResults ->
-                suspendExecuteWithRetry(maxAttempts, initialDelayMs, retryOn) { block(depResults) }
+                suspendExecuteWithRetry(maxAttempts, initialDelayMs, retryOn) { block(depResults) }.toList()
             })
         }
     }
@@ -654,7 +665,7 @@ class AsyncOperationResult {
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
-        block: suspend (T) -> List<R>
+        block: suspend (T) -> Collection<R>
     ): AsyncOperationResult = addListAfterWithRetry(
         key, dep,
         maxAttempts = maxAttempts,
@@ -717,7 +728,7 @@ class AsyncOperationResult {
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
-        block: suspend (List<T>) -> List<R>
+        block: suspend (List<T>) -> Collection<R>
     ): AsyncOperationResult = addListAfterWithRetry(
         key, dep,
         maxAttempts = maxAttempts,
@@ -766,16 +777,17 @@ class AsyncOperationResult {
      * @param default list to store when [block] throws
      * @param block suspending lambda that produces the primary list
      */
-    fun <R : Base> addListWithDefault(key: String, default: List<R>, block: suspend () -> List<R>): AsyncOperationResult = also {
+    fun <R : Base> addListWithDefault(key: String, default: Collection<R>, block: suspend () -> Collection<R>): AsyncOperationResult = also {
+        val defaultList = default.toList()
         registerNode(key, TaskNode.Independent(key) {
             try {
-                block()
+                block().toList()
             } catch (e: BaseServerResponseException) {
                 logger.warn("FHIRMason.async | task='{}' | using default list: {}", key, e.message)
-                default
+                defaultList
             } catch (e: Exception) {
                 logger.warn("FHIRMason.async | task='{}' | using default list: {}", key, e.message)
-                default
+                defaultList
             }
         })
     }
@@ -808,7 +820,7 @@ class AsyncOperationResult {
      * Registers an independent list-producing DAG task via [addList] only when [condition] is `true`.
      * When [condition] is `false`, returns `this` unchanged. See [addIf] for full contract.
      */
-    fun <R : Base> addListIf(condition: Boolean, key: String, block: suspend () -> List<R>): AsyncOperationResult =
+    fun <R : Base> addListIf(condition: Boolean, key: String, block: suspend () -> Collection<R>): AsyncOperationResult =
         if (condition) addList(key, block) else this
 
     // ── DAG composition ──────────────────────────────────────────────────────

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -239,13 +239,14 @@ class OperationResult<T> private constructor(
         return copyWith(value)
     }
 
-    private fun <R : Base> storeListAndCopy(name: String?, values: List<R>, durationMs: Long): OperationResult<List<R>> {
-        addToParameters(values, name)
-        val key = name ?: values.firstOrNull()?.fhirType()?.lowercase() ?: "list"
-        val typeDesc = "${values.firstOrNull()?.fhirType() ?: "Empty"}[${values.size}]"
+    private fun <R : Base> storeListAndCopy(name: String?, values: Collection<R>, durationMs: Long): OperationResult<List<R>> {
+        val list = values.toList()
+        addToParameters(list, name)
+        val key = name ?: list.firstOrNull()?.fhirType()?.lowercase() ?: "list"
+        val typeDesc = "${list.firstOrNull()?.fhirType() ?: "Empty"}[${list.size}]"
         recordMetric(key, typeDesc, durationMs, true)
         logStep(key, typeDesc, durationMs)
-        return copyWith(values)
+        return copyWith(list)
     }
 
 
@@ -290,15 +291,18 @@ class OperationResult<T> private constructor(
     ): OperationResult<R> = addFromFiltered(name, type.kotlin, predicate, builder)
 
     /**
-     * Like [addFromFiltered] but [builder] returns a `List<R>`, making the new
+     * Like [addFromFiltered] but [builder] returns a `Collection<R>`, making the new
      * pipeline head `List<R>`.
+     *
+     * Accepts any [Collection] return (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
+     * always stored as a [List].
      */
     @JvmOverloads
     fun <I : Base, R : Base> addAllFromFiltered(
         name: String? = null,
         type: KClass<I>,
         predicate: (I) -> Boolean,
-        builder: (List<I>) -> List<R>
+        builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = runBuilderStep(name) {
         val (values, duration) = measureTimedValue {
             builder(parameters.values.flatten().filterIsInstance(type.java).filter(predicate))
@@ -310,7 +314,7 @@ class OperationResult<T> private constructor(
     inline fun <reified I : Base, R : Base> addAllFromFiltered(
         name: String? = null,
         noinline predicate: (I) -> Boolean,
-        noinline builder: (List<I>) -> List<R>
+        noinline builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = addAllFromFiltered(name, I::class, predicate, builder)
 
     /** Java-friendly overload of [addAllFromFiltered] — accepts [Class] instead of [KClass]. */
@@ -319,7 +323,7 @@ class OperationResult<T> private constructor(
         name: String? = null,
         type: Class<I>,
         predicate: (I) -> Boolean,
-        builder: (List<I>) -> List<R>
+        builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = addAllFromFiltered(name, type.kotlin, predicate, builder)
 
     // Builder methods — filter all accumulated parameters by type and FHIRPath expression
@@ -364,16 +368,19 @@ class OperationResult<T> private constructor(
     ): OperationResult<R> = addFromMatching(name, type, expression.build(), builder)
 
     /**
-     * Like [addFromMatching] but [builder] returns a `List<R>`.
+     * Like [addFromMatching] but [builder] returns a `Collection<R>`.
      * When [name] is `null`, the output key defaults to the first element's [Base.fhirType]
      * (lowercase) — consistent with [addAll].
+     *
+     * Accepts any [Collection] return (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
+     * always stored as a [List].
      */
     @JvmOverloads
     fun <I : Base, R : Base> addAllFromMatching(
         name: String? = null,
         type: KClass<I>,
         expression: String,
-        builder: (List<I>) -> List<R>
+        builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> {
         return runBuilderStep(name) {
             val (values, duration) = measureTimedValue { builder(collectByPath(type, expression)) }
@@ -387,7 +394,7 @@ class OperationResult<T> private constructor(
         name: String? = null,
         type: KClass<I>,
         expression: FhirPath,
-        builder: (List<I>) -> List<R>
+        builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = addAllFromMatching(name, type, expression.build(), builder)
 
     /** Reified overload of [addFromMatching] — no [KClass] argument needed at call sites. */
@@ -408,14 +415,14 @@ class OperationResult<T> private constructor(
     inline fun <reified I : Base, R : Base> addAllFromMatching(
         name: String? = null,
         expression: String,
-        noinline builder: (List<I>) -> List<R>
+        noinline builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = addAllFromMatching(name, I::class, expression, builder)
 
     /** [FhirPath] reified overload of [addAllFromMatching]. */
     inline fun <reified I : Base, R : Base> addAllFromMatching(
         name: String? = null,
         expression: FhirPath,
-        noinline builder: (List<I>) -> List<R>
+        noinline builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = addAllFromMatching(name, I::class, expression.build(), builder)
 
     // Builder methods - single item
@@ -452,14 +459,17 @@ class OperationResult<T> private constructor(
     // to retrieve the typed list without casting.
 
     /**
-     * Invokes [builder] to produce a list of FHIR resources, stores each element under [name]
-     * (or each element's [Base.fhirType] lowercase when [name] is `null`), and returns a new
-     * [OperationResult] with `List<R>` as the pipeline head.
+     * Invokes [builder] to produce a collection of FHIR resources, stores each element under
+     * [name] (or each element's [Base.fhirType] lowercase when [name] is `null`), and returns a
+     * new [OperationResult] with `List<R>` as the pipeline head.
+     *
+     * Accepts any [Collection] (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
+     * always stored as a [List].
      *
      * Error handling follows Pattern A.
      */
     @JvmOverloads
-    fun <R : Base> addAll(name: String? = null, builder: () -> List<R>): OperationResult<List<R>> =
+    fun <R : Base> addAll(name: String? = null, builder: () -> Collection<R>): OperationResult<List<R>> =
         runBuilderStep(name) {
             val (values, duration) = measureTimedValue { builder() }
             storeListAndCopy(name, values, duration.inWholeMilliseconds)
@@ -468,10 +478,13 @@ class OperationResult<T> private constructor(
     /**
      * Like [addAll] but [builder] receives the current pipeline head value [T].
      *
+     * Accepts any [Collection] (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
+     * always stored as a [List].
+     *
      * Error handling follows Pattern A.
      */
     @JvmOverloads
-    fun <R : Base> addAllUsing(name: String? = null, builder: (T) -> List<R>): OperationResult<List<R>> =
+    fun <R : Base> addAllUsing(name: String? = null, builder: (T) -> Collection<R>): OperationResult<List<R>> =
         runBuilderStep(name) {
             val (values, duration) = measureTimedValue { builder(getResult()) }
             storeListAndCopy(name, values, duration.inWholeMilliseconds)
@@ -496,11 +509,14 @@ class OperationResult<T> private constructor(
         }
 
     /**
-     * Like [addFrom] but [builder] returns a `List<R>`. The pipeline head becomes `List<R>`.
+     * Like [addFrom] but [builder] returns a `Collection<R>`. The pipeline head becomes `List<R>`.
+     *
+     * Accepts any [Collection] return (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
+     * always stored as a [List].
      *
      * Error handling follows Pattern A.
      */
-    fun <I : Base, R : Base> addAllFrom(name: String, type: KClass<I>, builder: (List<I>) -> List<R>): OperationResult<List<R>> =
+    fun <I : Base, R : Base> addAllFrom(name: String, type: KClass<I>, builder: (List<I>) -> Collection<R>): OperationResult<List<R>> =
         runBuilderStep(name) {
             val (values, duration) = measureTimedValue {
                 val filtered = parameters[name]?.filterIsInstance(type.java) ?: emptyList()
@@ -1559,7 +1575,7 @@ class OperationResult<T> private constructor(
 
     // Private helpers
 
-    private fun addToParameters(values: List<Base>, name: String?) {
+    private fun addToParameters(values: Collection<Base>, name: String?) {
         values.forEach { value ->
             val key = name ?: value.fhirType().lowercase()
             parameters.getOrPut(key) { mutableListOf() }.add(value)
@@ -1602,14 +1618,18 @@ class OperationResult<T> private constructor(
          * the initial parameter-map entries. Each element is stored under [name] (or the element's
          * [Base.fhirType] lowercase when [name] is `null`).
          *
+         * Accepts any [Collection] (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
+         * always stored as a [List].
+         *
          * @param errorStrategy controls how subsequent steps behave when an error is recorded
          */
         @JvmStatic
         @JvmOverloads
-        fun <T : Base> of(values: List<T>, name: String? = null, errorStrategy: ErrorStrategy = ErrorStrategy.FAIL_FAST): OperationResult<List<T>> {
+        fun <T : Base> of(values: Collection<T>, name: String? = null, errorStrategy: ErrorStrategy = ErrorStrategy.FAIL_FAST): OperationResult<List<T>> {
+            val list = values.toList()
             val params = mutableMapOf<String, MutableList<Base>>()
-            val instance = OperationResult(params, values, mutableListOf(), errorStrategy, mutableMapOf())
-            instance.addToParameters(values, name)
+            val instance = OperationResult(params, list, mutableListOf(), errorStrategy, mutableMapOf())
+            instance.addToParameters(list, name)
             return instance
         }
 

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultTest.kt
@@ -474,6 +474,48 @@ class AsyncOperationResultTest {
         }
     }
 
+    // ── Collection inputs ─────────────────────────────────────────────────────
+
+    @Test
+    fun `addList block returning a Set stores all elements`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addList("appointments") {
+                setOf(
+                    Appointment().apply { id = "a1" },
+                    Appointment().apply { id = "a2" }
+                )
+            }
+            .run()
+
+        assertThat(result.count("appointments"), `is`(2))
+    }
+
+    @Test
+    fun `addListWithDefault default as Set is used on failure`() = runBlocking {
+        val default = setOf(Appointment().apply { id = "fallback" })
+        val result = AsyncOperationResult()
+            .addListWithDefault("appointments", default) { throw RuntimeException("fail") }
+            .run()
+
+        assertThat(result.count("appointments"), `is`(1))
+        val stored = result.getAll("appointments").first() as Appointment
+        assertThat(stored.id, `is`("fallback"))
+    }
+
+    @Test
+    fun `addListIf block returning a Set registers correctly`() = runBlocking {
+        val result = AsyncOperationResult()
+            .addListIf(true, "appointments") {
+                setOf(
+                    Appointment().apply { id = "a1" },
+                    Appointment().apply { id = "a2" }
+                )
+            }
+            .run()
+
+        assertThat(result.count("appointments"), `is`(2))
+    }
+
     @Test
     fun `withExecutor does not affect result correctness`() = runBlocking {
         val executor = java.util.concurrent.Executors.newFixedThreadPool(2)

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultTest.kt
@@ -239,6 +239,47 @@ class OperationResultTest {
         assertEquals("count=0", appt.participantFirstRep.actor.display)
     }
 
+    // ── Collection inputs ─────────────────────────────────────────────────────
+
+    @Test
+    fun `of accepts a Set and stores all elements`() {
+        val p1 = patient()
+        val p2 = patient()
+        val result = OperationResult.of(setOf(p1, p2))
+
+        assertEquals(2, result.count("patient"))
+        assertThat(result.getResultList(), hasSize(2))
+    }
+
+    @Test
+    fun `addAll builder returning a Set stores all elements`() {
+        val result = OperationResult.of(patient())
+            .addAll { setOf(patient(), appointment()) }
+
+        assertEquals(2, result.count("patient"))
+        assertEquals(1, result.count("appointment"))
+    }
+
+    @Test
+    fun `addAllUsing builder returning a LinkedHashSet stores all elements`() {
+        val items = linkedSetOf(appointment(), appointment())
+        val result = OperationResult.of(patient())
+            .addAllUsing { _ -> items }
+
+        assertEquals(2, result.count("appointment"))
+    }
+
+    @Test
+    fun `addAllFrom builder returning a Set stores all elements`() {
+        val result = OperationResult.of(listOf(patient(), patient()), "patients")
+            .addAllFrom("patients", Patient::class) { patients ->
+                patients.map { OperationOutcome() }.toSet()
+            }
+
+        assertThat(result.getResultList(), hasSize(2))
+        assertThat(result.getByType<OperationOutcome>(), hasSize(2))
+    }
+
     // ── addAllFrom ────────────────────────────────────────────────────────────
 
     @Test
@@ -1176,7 +1217,7 @@ class OperationResultTest {
         // getResultList() extension only exists on OperationResult<List<R>>
         val retrieved: List<Appointment> = result.getResultList()
         assertEquals(2, retrieved.size)
-        assertThat(retrieved, sameInstance(appts))
+        assertThat(retrieved, containsInAnyOrder(*appts.toTypedArray()))
     }
 
     @Test


### PR DESCRIPTION
All public API entry points where the caller supplies a collection — either as
a direct parameter or as the return type of a builder/block lambda — now accept
any Collection (List, Set, LinkedHashSet, etc.) instead of requiring a List.

Changes in OperationResult (R4 + DSTU3):
- of(values: Collection<T>, ...) factory
- addAll(builder: () -> Collection<R>)
- addAllUsing(builder: (T) -> Collection<R>)
- addAllFrom(builder: (List<I>) -> Collection<R>)
- addAllFromFiltered(builder: (List<I>) -> Collection<R>) — all 3 overloads
- addAllFromMatching(builder: (List<I>) -> Collection<R>) — all 4 overloads
- Private helpers storeListAndCopy / addToParameters updated to accept Collection
  and convert to List internally; pipeline head type remains List<R>

Changes in AsyncOperationResult (R4 + DSTU3):
- addList(block: suspend () -> Collection<R>)
- addListAfter(block: ... -> Collection<R>) — all overloads
- addListAfterAll(block: suspend (List<T>) -> Collection<R>)
- addListWithTimeout / addListAfterWithTimeout / addListAfterAllWithTimeout
- addListAfterWithRetry / addListAfterAllWithRetry
- addListWithDefault(default: Collection<R>, block: ... -> Collection<R>)
- addListIf(block: suspend () -> Collection<R>)
TaskNode internal signatures remain List<Base>; .toList() called at wrap site.

Lambda input types (what the library passes to callers, e.g. addFrom, addAfterAll)
remain List<I> / List<T> — callers benefit from index access on the pre-filtered list.
Getter return types (getAll, getAllParameters, getMetrics, getResultList, etc.) are
unchanged; the internal MutableMap<String, MutableList<Base>> is unchanged.

Tests: added Collection-variant tests in all four test files demonstrating Set and
LinkedHashSet inputs. Updated one sameInstance assertion (addAll identity equality
no longer holds after the .toList() normalisation) to containsInAnyOrder.