### PR TITLE
fix: toOperationOutcome() now preserves all issue fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - develop
+      - 'claude/**'
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run tests
+        run: mvn --no-transfer-progress --batch-mode test

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/AsyncOperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/AsyncOperationResult.kt
@@ -584,13 +584,26 @@ class AsyncOperationResult {
     fun describe(): String {
         if (nodes.isEmpty()) return "AsyncOperationResult DAG: (empty)"
 
+        // Iterative BFS tier assignment: tier(n) = 1 + max(tier(dep)) for all deps.
+        // Processing nodes in reverse topological order (deps before dependents) avoids
+        // the StackOverflowError that would occur in deep DAGs with recursive computeTier.
         val tierOf = mutableMapOf<String, Int>()
-        fun computeTier(key: String): Int = tierOf.getOrPut(key) {
-            val node = nodes[key]!!
-            if (node.deps.isEmpty()) 1
-            else 1 + node.deps.maxOf { computeTier(it) }
+        val queue = ArrayDeque<String>()
+        nodes.keys.filterTo(queue) { nodes[it]!!.deps.isEmpty() }
+        queue.forEach { tierOf[it] = 1 }
+        while (queue.isNotEmpty()) {
+            val key = queue.removeFirst()
+            val nextTier = tierOf[key]!! + 1
+            nodes.values
+                .filter { key in it.deps }
+                .forEach { dependent ->
+                    val current = tierOf[dependent.key] ?: 0
+                    if (nextTier > current) {
+                        tierOf[dependent.key] = nextTier
+                        queue.addLast(dependent.key)
+                    }
+                }
         }
-        nodes.keys.forEach { computeTier(it) }
 
         val byTier: Map<Int, List<TaskNode>> = nodes.values
             .groupBy { tierOf[it.key]!! }

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/AsyncOperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/AsyncOperationResult.kt
@@ -544,9 +544,6 @@ class AsyncOperationResult {
         registerNode(key, TaskNode.Independent(key) {
             try {
                 listOf(block())
-            } catch (e: BaseServerResponseException) {
-                logger.warn("FHIRMason.async | task='{}' | using default: {}", key, e.message)
-                listOf(default)
             } catch (e: Exception) {
                 logger.warn("FHIRMason.async | task='{}' | using default: {}", key, e.message)
                 listOf(default)
@@ -559,9 +556,6 @@ class AsyncOperationResult {
         registerNode(key, TaskNode.Independent(key) {
             try {
                 block().toList()
-            } catch (e: BaseServerResponseException) {
-                logger.warn("FHIRMason.async | task='{}' | using default list: {}", key, e.message)
-                defaultList
             } catch (e: Exception) {
                 logger.warn("FHIRMason.async | task='{}' | using default list: {}", key, e.message)
                 defaultList

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirExtensionHelper.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirExtensionHelper.kt
@@ -4,6 +4,8 @@ import org.hl7.fhir.dstu3.model.Base
 import org.hl7.fhir.dstu3.model.Extension
 import org.hl7.fhir.dstu3.model.Type
 import org.hl7.fhir.instance.model.api.IBaseHasExtensions
+import java.util.Collections
+import java.util.IdentityHashMap
 import java.util.Optional
 import kotlin.reflect.KClass
 
@@ -34,7 +36,8 @@ object FhirExtensionHelper {
 
     fun getAllByUrl(source: IBaseHasExtensions, url: String): List<Extension> {
         val results = mutableListOf<Extension>()
-        collectDeepByUrl(source as Base, url, results, mutableSetOf())
+        val visited: MutableSet<Base> = Collections.newSetFromMap(IdentityHashMap())
+        collectDeepByUrl(source as Base, url, results, visited)
         return results
     }
 
@@ -86,9 +89,9 @@ object FhirExtensionHelper {
         node: Base,
         url: String,
         results: MutableList<Extension>,
-        visited: MutableSet<Int>
+        visited: MutableSet<Base>
     ) {
-        if (!visited.add(System.identityHashCode(node))) return
+        if (!visited.add(node)) return
 
         if (node is IBaseHasExtensions) {
             results.addAll(node.extension.filterIsInstance<Extension>().filter { it.url == url })

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
@@ -1672,6 +1672,19 @@ class OperationResult<T> private constructor(
         ): OperationResult<T> = fromParametersTyped(parameters, primaryKey, T::class)
 
         /**
+         * Java-friendly overload of [fromParametersTyped] — accepts a [Class] instead of a [KClass]
+         * so Java callers can write `fromParametersTyped(params, "patient", Patient.class)`.
+         *
+         * @throws IllegalArgumentException if no value of [type] exists under [primaryKey].
+         */
+        @JvmStatic
+        fun <T : Base> fromParametersTyped(
+            parameters: Parameters,
+            primaryKey: String,
+            type: Class<T>
+        ): OperationResult<T> = fromParametersTyped(parameters, primaryKey, type.kotlin)
+
+        /**
          * Builds an [OperationResult] from a FHIR [Bundle].
          *
          * Each entry that carries a resource is stored using `resource.fhirType().lowercase()` as

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
@@ -96,16 +96,13 @@ class OperationResult<T> private constructor(
     /**
      * Merges all recorded [OperationOutcome] instances into a single composite
      * [OperationOutcome] whose issues are the union of every individual outcome's issues.
+     *
+     * All issue fields are preserved — `severity`, `code`, `diagnostics`, `location`,
+     * `expression`, `details`, `extension`, etc. — via HAPI's own [Base.copy] mechanism.
      */
     fun toOperationOutcome(): OperationOutcome = OperationOutcome().apply {
         this@OperationResult.outcomes.forEach { oo ->
-            oo.issue.forEach { issue ->
-                addIssue().apply {
-                    severity = issue.severity
-                    code = issue.code
-                    diagnostics = issue.diagnostics
-                }
-            }
+            oo.issue.forEach { issue -> addIssue(issue.copy()) }
         }
     }
 

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
@@ -503,6 +503,12 @@ class OperationResult<T> private constructor(
         }
 
     /**
+     * Java-friendly overload of [addFrom] — accepts a [Class] instead of a [KClass].
+     */
+    fun <I : Base, R : Base> addFrom(name: String, type: Class<I>, builder: (List<I>) -> R): OperationResult<R> =
+        addFrom(name, type.kotlin, builder)
+
+    /**
      * Like [addFrom] but [builder] returns a `Collection<R>`. The pipeline head becomes `List<R>`.
      *
      * Accepts any [Collection] return (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
@@ -518,6 +524,12 @@ class OperationResult<T> private constructor(
             }
             storeListAndCopy(name, values, duration.inWholeMilliseconds)
         }
+
+    /**
+     * Java-friendly overload of [addAllFrom] — accepts a [Class] instead of a [KClass].
+     */
+    fun <I : Base, R : Base> addAllFrom(name: String, type: Class<I>, builder: (List<I>) -> Collection<R>): OperationResult<List<R>> =
+        addAllFrom(name, type.kotlin, builder)
 
     // Builder variants with explicit error handling
 
@@ -944,6 +956,11 @@ class OperationResult<T> private constructor(
     /** Reified overload — no [KClass] argument needed at call sites. */
     inline fun <reified R : Base> getByType(): List<R> = getByType(R::class)
 
+    /**
+     * Java-friendly overload of [getByType] — accepts a [Class] instead of a [KClass].
+     */
+    fun <R : Base> getByType(type: Class<R>): List<R> = getByType(type.kotlin)
+
     override fun containsKey(name: String): Boolean =
         parameters.containsKey(name)
 
@@ -981,6 +998,11 @@ class OperationResult<T> private constructor(
 
     /** Reified overload — no [KClass] argument needed at call sites. */
     inline fun <reified R : Base> filterByType(): OperationResult<T> = filterByType(R::class)
+
+    /**
+     * Java-friendly overload of [filterByType] — accepts a [Class] instead of a [KClass].
+     */
+    fun <R : Base> filterByType(type: Class<R>): OperationResult<T> = filterByType(type.kotlin)
 
     /** Returns a new result containing only the entry for [name]. All other keys are dropped. No-op if [name] is absent. */
     fun filterByName(name: String): OperationResult<T> {
@@ -1374,6 +1396,12 @@ class OperationResult<T> private constructor(
         extractParam(name, R::class)
 
     /**
+     * Java-friendly overload of [extractParam] — accepts a [Class] instead of a [KClass].
+     */
+    fun <R : Base> extractParam(name: String, type: Class<R>): OperationResult<R> =
+        extractParam(name, type.kotlin)
+
+    /**
      * Extracts all values of type [R] stored under [name] and sets the list as the pipeline head.
      * Returns an empty list (not an error) if no values match.
      */
@@ -1387,6 +1415,12 @@ class OperationResult<T> private constructor(
     /** Reified overload — no [KClass] argument needed at call sites. */
     inline fun <reified R : Base> extractParamList(name: String): OperationResult<List<R>> =
         extractParamList(name, R::class)
+
+    /**
+     * Java-friendly overload of [extractParamList] — accepts a [Class] instead of a [KClass].
+     */
+    fun <R : Base> extractParamList(name: String, type: Class<R>): OperationResult<List<R>> =
+        extractParamList(name, type.kotlin)
 
     // Reference linking
 

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
@@ -530,6 +530,7 @@ class OperationResult<T> private constructor(
      */
     @JvmOverloads
     fun <R : Base> addOrSkip(name: String? = null, builder: () -> R): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
         val (builderResult, duration) = measureTimedValue { runCatching { builder() } }
         val durationMs = duration.inWholeMilliseconds
         return builderResult.fold(
@@ -558,6 +559,7 @@ class OperationResult<T> private constructor(
      */
     @JvmOverloads
     fun <R : Base> addOrDefault(name: String? = null, default: R, builder: () -> R): OperationResult<R> {
+        if (shouldSkip()) return skippedResult()
         val (builderResult, duration) = measureTimedValue { runCatching { builder() } }
         val durationMs = duration.inWholeMilliseconds
         return builderResult.fold(

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultDescribeTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultDescribeTest.kt
@@ -208,4 +208,17 @@ class AsyncOperationResultDescribeTest {
         val tierLines = output.lines().filter { it.contains("Tier") }
         assertEquals(3, tierLines.size)
     }
+
+    @Test
+    fun `describe does not throw StackOverflowError on a deep linear chain`() {
+        // A 500-node linear chain would overflow the stack with the old recursive computeTier.
+        var dag = AsyncOperationResult().add("t0") { Patient() }
+        for (i in 1..499) {
+            dag = dag.addAfter("t$i", "t${i - 1}") { Patient() }
+        }
+
+        val output = dag.describe()
+
+        assertThat(output, containsString("Tier 500"))
+    }
 }

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/FhirExtensionHelperTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/FhirExtensionHelperTest.kt
@@ -376,4 +376,24 @@ class FhirExtensionHelperTest {
         }
         assertEquals("nameExt", FhirExtensionHelper.getValueAs<StringType>(name, URL_A)?.value)
     }
+
+    @Test
+    fun `getAllByUrl finds extensions on two structurally equal sibling nodes`() {
+        // Two distinct HumanName instances with the same content — if identity hash codes
+        // were used for cycle detection, a collision between the two could cause one to be
+        // silently skipped. Using an IdentityHashMap-backed set avoids that.
+        val patient = Patient().apply {
+            addName().apply {
+                family = "Smith"
+                addExtension(URL_A, StringType("first"))
+            }
+            addName().apply {
+                family = "Smith"
+                addExtension(URL_A, StringType("second"))
+            }
+        }
+
+        val found = FhirExtensionHelper.getAllByUrl(patient, URL_A)
+        assertThat(found, hasSize(2))
+    }
 }

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultConditionalTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultConditionalTest.kt
@@ -249,6 +249,31 @@ class OperationResultConditionalTest {
         assertTrue(result.hasErrors())
     }
 
+    // ── addOrSkip / addOrDefault respect FAIL_FAST ────────────────────────────
+
+    @Test
+    fun `addOrSkip - respects shouldSkip in FAIL_FAST mode`() {
+        var invoked = false
+        val result = OperationResult.of(patient())
+            .add("enc") { error("trigger error") }
+            .addOrSkip("skipped") { invoked = true; appointment() }
+
+        assertFalse(invoked)
+        assertFalse(result.containsKey("skipped"))
+    }
+
+    @Test
+    fun `addOrDefault - respects shouldSkip in FAIL_FAST mode`() {
+        var invoked = false
+        val default = coverage()
+        val result = OperationResult.of(patient())
+            .add("enc") { error("trigger error") }
+            .addOrDefault("skipped", default) { invoked = true; coverage() }
+
+        assertFalse(invoked)
+        assertFalse(result.containsKey("skipped"))
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private fun patient() = Patient().apply {

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFhirErrorHandlingTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFhirErrorHandlingTest.kt
@@ -225,6 +225,63 @@ class OperationResultFhirErrorHandlingTest {
         assertThat(thrown.message, containsString("specific error message"))
     }
 
+    // ── toOperationOutcome preserves all issue fields ─────────────────────────
+
+    @Test
+    fun `toOperationOutcome preserves location from original issue`() {
+        val embedded = OperationOutcome().apply {
+            addIssue().apply {
+                severity = OperationOutcome.IssueSeverity.ERROR
+                code = OperationOutcome.IssueType.EXCEPTION
+                diagnostics = "error"
+                addLocation("Patient.name")
+            }
+        }
+        val result = OperationResult.of(patient())
+            .add("enc") { throw InternalErrorException("fail", embedded) }
+
+        val merged = result.toOperationOutcome()
+        assertThat(merged.issue, hasSize(1))
+        assertThat(merged.issue[0].location.map { it.value }, equalTo(listOf("Patient.name")))
+    }
+
+    @Test
+    fun `toOperationOutcome preserves diagnostics from original issue`() {
+        val embedded = OperationOutcome().apply {
+            addIssue().apply {
+                severity = OperationOutcome.IssueSeverity.ERROR
+                code = OperationOutcome.IssueType.EXCEPTION
+                diagnostics = "detailed diagnostics"
+                addLocation("Patient.active")
+            }
+        }
+        val result = OperationResult.of(patient())
+            .add("enc") { throw InternalErrorException("fail", embedded) }
+
+        val merged = result.toOperationOutcome()
+        assertThat(merged.issue, hasSize(1))
+        assertThat(merged.issue[0].diagnostics, equalTo("detailed diagnostics"))
+    }
+
+    @Test
+    fun `toOperationOutcome preserves extension from original issue`() {
+        val embedded = OperationOutcome().apply {
+            addIssue().apply {
+                severity = OperationOutcome.IssueSeverity.ERROR
+                code = OperationOutcome.IssueType.EXCEPTION
+                diagnostics = "error"
+                addExtension("http://example.org/ext", org.hl7.fhir.dstu3.model.StringType("val"))
+            }
+        }
+        val result = OperationResult.of(patient())
+            .add("enc") { throw InternalErrorException("fail", embedded) }
+
+        val merged = result.toOperationOutcome()
+        assertThat(merged.issue, hasSize(1))
+        assertThat(merged.issue[0].extension, hasSize(1))
+        assertThat(merged.issue[0].extension[0].url, equalTo("http://example.org/ext"))
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private fun patient() = Patient().apply { setId("p1") }

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFromTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFromTest.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -348,6 +349,19 @@ class OperationResultFromTest {
         assertThrows<IllegalArgumentException> {
             OperationResult.fromParametersTyped<Patient>(fhirParams, "patient")
         }
+    }
+
+    @Test
+    fun `fromParametersTyped - Class overload sets typed head identical to KClass overload`() {
+        val patient = patient()
+        val fhirParams = Parameters().apply {
+            addParameter().apply { name = "patient"; resource = patient }
+        }
+
+        val result = OperationResult.fromParametersTyped(fhirParams, "patient", Patient::class.java)
+
+        assertSame(patient, result.getResult())
+        assertTrue(result.containsKey("patient"))
     }
 
     // ── fromBundle ────────────────────────────────────────────────────────────

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultJavaInteropTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultJavaInteropTest.kt
@@ -1,0 +1,108 @@
+package dev.ratkay.operation.dstu3
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.hl7.fhir.dstu3.model.Appointment
+import org.hl7.fhir.dstu3.model.Coverage
+import org.hl7.fhir.dstu3.model.Patient
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies that the Class<T> overloads added for Java interop produce the same
+ * results as the corresponding KClass / reified overloads.
+ */
+class OperationResultJavaInteropTest {
+
+    // ── getByType ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `getByType - Class overload returns same resources as KClass overload`() {
+        val patient = patient()
+        val result = OperationResult.of(patient, "patient")
+            .add("appt") { appointment() }
+
+        val byClass = result.getByType(Patient::class.java)
+        val byKClass = result.getByType(Patient::class)
+
+        assertThat(byClass, hasSize(1))
+        assertSame(byClass[0], byKClass[0])
+    }
+
+    @Test
+    fun `getByType - Class overload returns empty list when type absent`() {
+        val result = OperationResult.of(patient(), "patient")
+
+        val found = result.getByType(Coverage::class.java)
+
+        assertThat(found, hasSize(0))
+    }
+
+    // ── filterByType ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `filterByType - Class overload keeps only matching type`() {
+        val patient = patient()
+        val result = OperationResult.of(patient, "patient")
+            .add("appt") { appointment() }
+
+        val filtered = result.filterByType(Patient::class.java)
+
+        assertTrue(filtered.containsKey("patient"))
+        assertFalse(filtered.containsKey("appt"))
+    }
+
+    // ── addFrom ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `addFrom - Class overload processes values same as KClass overload`() {
+        val appt = appointment()
+        val result = OperationResult.of(patient(), "patient")
+            .add("appt") { appt }
+            .addFrom("appt", Appointment::class.java) { list -> list.first() }
+
+        assertSame(appt, result.getResult())
+    }
+
+    // ── addAllFrom ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `addAllFrom - Class overload collects values same as KClass overload`() {
+        val result = OperationResult.of(patient(), "patient")
+            .add("appt") { appointment() }
+            .add("appt") { appointment() }
+            .addAllFrom("appt", Appointment::class.java) { list -> list }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    // ── extractParam ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `extractParam - Class overload sets head to first matching value`() {
+        val patient = patient()
+        val result = OperationResult.of(patient, "patient")
+            .extractParam("patient", Patient::class.java)
+
+        assertSame(patient, result.getResult())
+    }
+
+    // ── extractParamList ──────────────────────────────────────────────────────
+
+    @Test
+    fun `extractParamList - Class overload sets head to list of matching values`() {
+        val result = OperationResult.of(patient(), "patient")
+            .add("appt") { appointment() }
+            .add("appt") { appointment() }
+            .extractParamList("appt", Appointment::class.java)
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun patient() = Patient().apply { addName().family = "Doe" }
+    private fun appointment() = Appointment().apply { status = Appointment.AppointmentStatus.BOOKED }
+}

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultTest.kt
@@ -163,7 +163,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addUsing with explicit name`() {
+    fun `addUsing - stores result under explicit name`() {
         val result = OperationResult.of(patient(), "patient")
             .addUsing("appt") { _ -> appointment() }
 
@@ -204,7 +204,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllUsing with explicit name`() {
+    fun `addAllUsing - groups all items under explicit name`() {
         val result = OperationResult.of(patient())
             .addAllUsing("items") { _ -> listOf(appointment(), appointment()) }
 
@@ -298,7 +298,7 @@ class OperationResultTest {
     // ── addFromFiltered (extension filters) ──────────────────────────────────
 
     @Test
-    fun `addFromHavingAllExtensions returns only resources that have the matching extension URL`() {
+    fun `addFromFiltered - returns only resources matching hasAllExtensions predicate`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val notEnrolled = patient()
         val result = OperationResult.of(listOf(enrolled, notEnrolled), "patients")
@@ -312,7 +312,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAllExtensions with multiple URLs requires resource to carry every URL`() {
+    fun `addFromFiltered - hasAllExtensions requires resource to carry every URL when multiple URLs given`() {
         val both = patient().apply {
             addExtension("http://example.org/url1", StringType("a"))
             addExtension("http://example.org/url2", StringType("b"))
@@ -329,7 +329,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAnyExtension returns resources carrying at least one of the URLs`() {
+    fun `addFromFiltered - hasAnyExtension returns resources carrying at least one matching URL`() {
         val hasFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val hasSecond = patient().apply { addExtension("http://example.org/url2", StringType("b")) }
         val hasBoth = patient().apply {
@@ -348,7 +348,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAnyExtension with single URL behaves like addFromHavingAllExtensions`() {
+    fun `addFromFiltered - hasAnyExtension with single URL behaves like hasAllExtensions`() {
         val hasIt = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val hasNot = patient()
         val result = OperationResult.of(listOf(hasIt, hasNot), "patients")
@@ -360,7 +360,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAllExtensions with no extUrls returns all resources of that type`() {
+    fun `addFromFiltered - hasAllExtensions with no URLs returns all resources of the given type`() {
         val result = OperationResult.of(listOf(patient(), patient(), appointment()), "items")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions()) { filtered ->
                 OperationOutcome().apply {
@@ -372,7 +372,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAllExtensions produces empty list when no resources match`() {
+    fun `addFromFiltered - hasAllExtensions predicate produces empty list when no resources match`() {
         val result = OperationResult.of(listOf(patient(), patient()), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/nonexistent")) { filtered ->
                 OperationOutcome().apply {
@@ -384,7 +384,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAnyExtension produces empty list when no resources match any URL`() {
+    fun `addFromFiltered - hasAnyExtension predicate produces empty list when no resources match`() {
         val result = OperationResult.of(listOf(patient(), patient()), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAnyExtension("http://example.org/nonexistent")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
@@ -394,7 +394,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAllExtensions searches across all parameter keys not just one`() {
+    fun `addFromFiltered - hasAllExtensions searches across all parameter keys not just one`() {
         val enrolled1 = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val enrolled2 = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(enrolled1, "group-a")
@@ -409,7 +409,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromHavingAllExtensions returns list result built from AND-filtered input`() {
+    fun `addAllFromFiltered - hasAllExtensions returns list result`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
             .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
@@ -421,7 +421,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromHavingAnyExtension returns list result built from OR-filtered input`() {
+    fun `addAllFromFiltered - hasAnyExtension returns list result`() {
         val hasFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val hasSecond = patient().apply { addExtension("http://example.org/url2", StringType("b")) }
         val result = OperationResult.of(listOf(hasFirst, hasSecond, patient()), "patients")
@@ -433,7 +433,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAllExtensions reified overload works correctly`() {
+    fun `addFromFiltered - hasAllExtensions reified overload filters correctly`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
             .addFromFiltered<Patient, OperationOutcome>(predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
@@ -446,7 +446,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAnyExtension reified overload works correctly`() {
+    fun `addFromFiltered - hasAnyExtension reified overload filters correctly`() {
         val hasFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val hasSecond = patient().apply { addExtension("http://example.org/url2", StringType("b")) }
         val result = OperationResult.of(listOf(hasFirst, hasSecond, patient()), "patients")
@@ -458,7 +458,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAllExtensions records error outcome when builder throws`() {
+    fun `addFromFiltered - records error outcome when builder throws`() {
         val result = OperationResult.of(patient(), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions()) { _ ->
                 throw RuntimeException("builder failed")
@@ -469,7 +469,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAllExtensions unnamed overload stores result under output fhirType not input type`() {
+    fun `addFromFiltered - hasAllExtensions unnamed overload stores result under output fhirType not input type`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { _ ->
@@ -482,7 +482,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAnyExtension unnamed overload stores result under output fhirType not input type`() {
+    fun `addFromFiltered - hasAnyExtension unnamed overload stores result under output fhirType not input type`() {
         val hasExt = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val result = OperationResult.of(listOf(hasExt, patient()), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAnyExtension("http://example.org/url1")) { _ ->
@@ -494,7 +494,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAllExtensions named overload stores result under explicit name`() {
+    fun `addFromFiltered - named overload stores result under explicit name`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
             .addFromFiltered("enrolled-summary", Patient::class, FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
@@ -509,7 +509,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromHavingAllExtensions reified overload returns list result`() {
+    fun `addAllFromFiltered - hasAllExtensions reified overload returns list result`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient(), patient()), "patients")
             .addAllFromFiltered<Patient, OperationOutcome>(predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
@@ -520,7 +520,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromHavingAllExtensions unnamed overload stores results under output fhirType not input type`() {
+    fun `addAllFromFiltered - hasAllExtensions unnamed overload stores results under output fhirType not input type`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
             .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
@@ -532,7 +532,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromHavingAnyExtension unnamed overload stores results under output fhirType not input type`() {
+    fun `addAllFromFiltered - hasAnyExtension unnamed overload stores results under output fhirType not input type`() {
         val hasFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val hasSecond = patient().apply { addExtension("http://example.org/url2", StringType("b")) }
         val result = OperationResult.of(listOf(hasFirst, hasSecond, patient()), "patients")
@@ -547,7 +547,7 @@ class OperationResultTest {
     // ── Extension URL + value-type / value-predicate filters ─────────────────
 
     @Test
-    fun `addFromHavingExtensionWithValueType returns resources where extension at URL has matching value type`() {
+    fun `addFromFiltered - hasExtensionWithValueType returns resources where extension has matching value type`() {
         val withString = patient().apply { addExtension("http://example.org/flag", StringType("active")) }
         val withBoolean = patient().apply { addExtension("http://example.org/flag", BooleanType(true)) }
         val noExtension = patient()
@@ -560,7 +560,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionWithValueType returns empty list when no resources have that value type at URL`() {
+    fun `addFromFiltered - hasExtensionWithValueType produces empty list when no resources match`() {
         val withBoolean = patient().apply { addExtension("http://example.org/flag", BooleanType(false)) }
         val result = OperationResult.of(listOf(withBoolean, patient()), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class)) { filtered ->
@@ -571,7 +571,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionWithValueType named variant stores result under explicit name`() {
+    fun `addFromFiltered - hasExtensionWithValueType named variant stores result under explicit name`() {
         val withString = patient().apply { addExtension("http://example.org/flag", StringType("active")) }
         val result = OperationResult.of(listOf(withString, patient()), "patients")
             .addFromFiltered("flag-summary", Patient::class, FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class)) { filtered ->
@@ -584,7 +584,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromHavingExtensionWithValueType returns list result`() {
+    fun `addAllFromFiltered - hasExtensionWithValueType returns list result`() {
         val withString1 = patient().apply { addExtension("http://example.org/flag", StringType("a")) }
         val withString2 = patient().apply { addExtension("http://example.org/flag", StringType("b")) }
         val withBoolean = patient().apply { addExtension("http://example.org/flag", BooleanType(true)) }
@@ -597,7 +597,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionWithValueType reified overload works correctly`() {
+    fun `addFromFiltered - hasExtensionWithValueType reified overload filters correctly`() {
         val withString = patient().apply { addExtension("http://example.org/flag", StringType("x")) }
         val result = OperationResult.of(listOf(withString, patient()), "patients")
             .addFromFiltered<Patient, OperationOutcome>(predicate = FhirFilter.hasExtensionWithValueType<StringType>("http://example.org/flag")) { filtered ->
@@ -608,7 +608,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionValueMatching returns resources where extension value satisfies predicate`() {
+    fun `addFromFiltered - hasExtensionValueMatching returns resources where extension value satisfies predicate`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val notEnrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("false")) }
         val noExt = patient()
@@ -621,7 +621,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionValueMatching returns empty list when predicate never satisfied`() {
+    fun `addFromFiltered - hasExtensionValueMatching produces empty list when predicate never satisfied`() {
         val patient1 = patient().apply { addExtension("http://example.org/enrolled", StringType("false")) }
         val result = OperationResult.of(listOf(patient1, patient()), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { filtered ->
@@ -632,7 +632,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionValueMatching named variant stores result under explicit name`() {
+    fun `addFromFiltered - hasExtensionValueMatching named variant stores result under explicit name`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
             .addFromFiltered("enrolled-patients", Patient::class, FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { filtered ->
@@ -645,7 +645,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromHavingExtensionValueMatching returns list result`() {
+    fun `addAllFromFiltered - hasExtensionValueMatching returns list result`() {
         val high = patient().apply { addExtension("http://example.org/priority", IntegerType(10)) }
         val low = patient().apply { addExtension("http://example.org/priority", IntegerType(1)) }
         val none = patient()
@@ -658,7 +658,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionValueMatching reified overload works correctly`() {
+    fun `addFromFiltered - hasExtensionValueMatching reified overload filters correctly`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", BooleanType(true)) }
         val notEnrolled = patient().apply { addExtension("http://example.org/enrolled", BooleanType(false)) }
         val result = OperationResult.of(listOf(enrolled, notEnrolled), "patients")
@@ -670,7 +670,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionValueMatching with multiple extensions at same URL — any satisfying match passes`() {
+    fun `addFromFiltered - hasExtensionValueMatching with multiple extensions at same URL — any satisfying match passes`() {
         val multiExt = patient().apply {
             addExtension("http://example.org/role", StringType("admin"))
             addExtension("http://example.org/role", StringType("user"))
@@ -685,7 +685,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionValueMatching unnamed overload stores result under output fhirType not input type`() {
+    fun `addFromFiltered - hasExtensionValueMatching unnamed overload stores result under output fhirType not input type`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { _ ->
@@ -697,7 +697,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromHavingExtensionValueMatching unnamed overload stores results under output fhirType not input type`() {
+    fun `addAllFromFiltered - hasExtensionValueMatching unnamed overload stores results under output fhirType not input type`() {
         val high = patient().apply { addExtension("http://example.org/priority", IntegerType(10)) }
         val result = OperationResult.of(listOf(high, patient()), "patients")
             .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<IntegerType>("http://example.org/priority") { it.value > 5 }) { filtered ->

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/AsyncOperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/AsyncOperationResult.kt
@@ -883,13 +883,26 @@ class AsyncOperationResult {
     fun describe(): String {
         if (nodes.isEmpty()) return "AsyncOperationResult DAG: (empty)"
 
+        // Iterative BFS tier assignment: tier(n) = 1 + max(tier(dep)) for all deps.
+        // Processing nodes in reverse topological order (deps before dependents) avoids
+        // the StackOverflowError that would occur in deep DAGs with recursive computeTier.
         val tierOf = mutableMapOf<String, Int>()
-        fun computeTier(key: String): Int = tierOf.getOrPut(key) {
-            val node = nodes[key]!!
-            if (node.deps.isEmpty()) 1
-            else 1 + node.deps.maxOf { computeTier(it) }
+        val queue = ArrayDeque<String>()
+        nodes.keys.filterTo(queue) { nodes[it]!!.deps.isEmpty() }
+        queue.forEach { tierOf[it] = 1 }
+        while (queue.isNotEmpty()) {
+            val key = queue.removeFirst()
+            val nextTier = tierOf[key]!! + 1
+            nodes.values
+                .filter { key in it.deps }
+                .forEach { dependent ->
+                    val current = tierOf[dependent.key] ?: 0
+                    if (nextTier > current) {
+                        tierOf[dependent.key] = nextTier
+                        queue.addLast(dependent.key)
+                    }
+                }
         }
-        nodes.keys.forEach { computeTier(it) }
 
         val byTier: Map<Int, List<TaskNode>> = nodes.values
             .groupBy { tierOf[it.key]!! }

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/AsyncOperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/AsyncOperationResult.kt
@@ -759,9 +759,6 @@ class AsyncOperationResult {
         registerNode(key, TaskNode.Independent(key) {
             try {
                 listOf(block())
-            } catch (e: BaseServerResponseException) {
-                logger.warn("FHIRMason.async | task='{}' | using default: {}", key, e.message)
-                listOf(default)
             } catch (e: Exception) {
                 logger.warn("FHIRMason.async | task='{}' | using default: {}", key, e.message)
                 listOf(default)
@@ -782,9 +779,6 @@ class AsyncOperationResult {
         registerNode(key, TaskNode.Independent(key) {
             try {
                 block().toList()
-            } catch (e: BaseServerResponseException) {
-                logger.warn("FHIRMason.async | task='{}' | using default list: {}", key, e.message)
-                defaultList
             } catch (e: Exception) {
                 logger.warn("FHIRMason.async | task='{}' | using default list: {}", key, e.message)
                 defaultList

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/FhirExtensionHelper.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/FhirExtensionHelper.kt
@@ -4,6 +4,8 @@ import org.hl7.fhir.instance.model.api.IBaseHasExtensions
 import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.Extension
 import org.hl7.fhir.r4.model.Type
+import java.util.Collections
+import java.util.IdentityHashMap
 import java.util.Optional
 import kotlin.reflect.KClass
 
@@ -77,7 +79,8 @@ object FhirExtensionHelper {
      */
     fun getAllByUrl(source: IBaseHasExtensions, url: String): List<Extension> {
         val results = mutableListOf<Extension>()
-        collectDeepByUrl(source as Base, url, results, mutableSetOf())
+        val visited: MutableSet<Base> = Collections.newSetFromMap(IdentityHashMap())
+        collectDeepByUrl(source as Base, url, results, visited)
         return results
     }
 
@@ -188,9 +191,9 @@ object FhirExtensionHelper {
         node: Base,
         url: String,
         results: MutableList<Extension>,
-        visited: MutableSet<Int>
+        visited: MutableSet<Base>
     ) {
-        if (!visited.add(System.identityHashCode(node))) return
+        if (!visited.add(node)) return
 
         if (node is IBaseHasExtensions) {
             results.addAll(node.extension.filterIsInstance<Extension>().filter { it.url == url })

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -506,6 +506,12 @@ class OperationResult<T> private constructor(
         }
 
     /**
+     * Java-friendly overload of [addFrom] — accepts a [Class] instead of a [KClass].
+     */
+    fun <I : Base, R : Base> addFrom(name: String, type: Class<I>, builder: (List<I>) -> R): OperationResult<R> =
+        addFrom(name, type.kotlin, builder)
+
+    /**
      * Like [addFrom] but [builder] returns a `Collection<R>`. The pipeline head becomes `List<R>`.
      *
      * Accepts any [Collection] return (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
@@ -521,6 +527,12 @@ class OperationResult<T> private constructor(
             }
             storeListAndCopy(name, values, duration.inWholeMilliseconds)
         }
+
+    /**
+     * Java-friendly overload of [addAllFrom] — accepts a [Class] instead of a [KClass].
+     */
+    fun <I : Base, R : Base> addAllFrom(name: String, type: Class<I>, builder: (List<I>) -> Collection<R>): OperationResult<List<R>> =
+        addAllFrom(name, type.kotlin, builder)
 
     // Builder variants with explicit error handling
 
@@ -953,6 +965,11 @@ class OperationResult<T> private constructor(
     /** Reified overload — no [KClass] argument needed at call sites. */
     inline fun <reified R : Base> getByType(): List<R> = getByType(R::class)
 
+    /**
+     * Java-friendly overload of [getByType] — accepts a [Class] instead of a [KClass].
+     */
+    fun <R : Base> getByType(type: Class<R>): List<R> = getByType(type.kotlin)
+
     override fun containsKey(name: String): Boolean =
         parameters.containsKey(name)
 
@@ -990,6 +1007,11 @@ class OperationResult<T> private constructor(
 
     /** Reified overload — no [KClass] argument needed at call sites. */
     inline fun <reified R : Base> filterByType(): OperationResult<T> = filterByType(R::class)
+
+    /**
+     * Java-friendly overload of [filterByType] — accepts a [Class] instead of a [KClass].
+     */
+    fun <R : Base> filterByType(type: Class<R>): OperationResult<T> = filterByType(type.kotlin)
 
     /** Returns a new result containing only the entry for [name]. All other keys are dropped. No-op if [name] is absent. */
     fun filterByName(name: String): OperationResult<T> {
@@ -1383,6 +1405,12 @@ class OperationResult<T> private constructor(
         extractParam(name, R::class)
 
     /**
+     * Java-friendly overload of [extractParam] — accepts a [Class] instead of a [KClass].
+     */
+    fun <R : Base> extractParam(name: String, type: Class<R>): OperationResult<R> =
+        extractParam(name, type.kotlin)
+
+    /**
      * Extracts all values of type [R] stored under [name] and sets the list as the pipeline head.
      * Returns an empty list (not an error) if no values match.
      */
@@ -1396,6 +1424,12 @@ class OperationResult<T> private constructor(
     /** Reified overload — no [KClass] argument needed at call sites. */
     inline fun <reified R : Base> extractParamList(name: String): OperationResult<List<R>> =
         extractParamList(name, R::class)
+
+    /**
+     * Java-friendly overload of [extractParamList] — accepts a [Class] instead of a [KClass].
+     */
+    fun <R : Base> extractParamList(name: String, type: Class<R>): OperationResult<List<R>> =
+        extractParamList(name, type.kotlin)
 
     // Reference linking
 

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -99,16 +99,13 @@ class OperationResult<T> private constructor(
     /**
      * Merges all recorded [OperationOutcome] instances into a single composite
      * [OperationOutcome] whose issues are the union of every individual outcome's issues.
+     *
+     * All issue fields are preserved — `severity`, `code`, `diagnostics`, `location`,
+     * `expression`, `details`, `extension`, etc. — via HAPI's own [Base.copy] mechanism.
      */
     fun toOperationOutcome(): OperationOutcome = OperationOutcome().apply {
         this@OperationResult.outcomes.forEach { oo ->
-            oo.issue.forEach { issue ->
-                addIssue().apply {
-                    severity = issue.severity
-                    code = issue.code
-                    diagnostics = issue.diagnostics
-                }
-            }
+            oo.issue.forEach { issue -> addIssue(issue.copy()) }
         }
     }
 

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -51,8 +51,6 @@ import kotlin.time.measureTimedValue
  * |---------|---------|
  * | Error state | `hasErrors`, `isSuccessful`, `getOutcomes`, `getFailedTasks`, `toOperationOutcome`, `throwIfErrors` |
  * | Metrics & timing | `timed`, `getMetrics` |
- * | Step runners *(private)* | `runStep`, `runBuilderStep`, `runPrimitiveStep` |
- * | Storage helpers *(private)* | `storeAndCopy`, `storeListAndCopy` |
  * | Extension URL filters | `addFromHavingAllExtensions`, `addFromHavingAnyExtension`, `addAllFrom…`, `addFromHavingExtensionWithValueType`, `addFromHavingExtensionValueMatching`, … |
  * | Identifier filters | `addFromHavingIdentifierWithSystem`, `addFromHavingIdentifierWithValue`, `addFromHavingIdentifier`, `addAllFrom…` |
  * | Filtered builders | `addFromFiltered`, `addAllFromFiltered` — pass a [FhirFilter] predicate or any `(I) -> Boolean` |

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -1681,6 +1681,19 @@ class OperationResult<T> private constructor(
         ): OperationResult<T> = fromParametersTyped(parameters, primaryKey, T::class)
 
         /**
+         * Java-friendly overload of [fromParametersTyped] — accepts a [Class] instead of a [KClass]
+         * so Java callers can write `fromParametersTyped(params, "patient", Patient.class)`.
+         *
+         * @throws IllegalArgumentException if no value of [type] exists under [primaryKey].
+         */
+        @JvmStatic
+        fun <T : Base> fromParametersTyped(
+            parameters: Parameters,
+            primaryKey: String,
+            type: Class<T>
+        ): OperationResult<T> = fromParametersTyped(parameters, primaryKey, type.kotlin)
+
+        /**
          * Builds an [OperationResult] from a FHIR [Bundle].
          *
          * Each entry that carries a resource is stored using `resource.fhirType().lowercase()` as

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -533,6 +533,7 @@ class OperationResult<T> private constructor(
      */
     @JvmOverloads
     fun <R : Base> addOrSkip(name: String? = null, builder: () -> R): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
         val (builderResult, duration) = measureTimedValue { runCatching { builder() } }
         val durationMs = duration.inWholeMilliseconds
         return builderResult.fold(
@@ -561,6 +562,7 @@ class OperationResult<T> private constructor(
      */
     @JvmOverloads
     fun <R : Base> addOrDefault(name: String? = null, default: R, builder: () -> R): OperationResult<R> {
+        if (shouldSkip()) return skippedResult()
         val (builderResult, duration) = measureTimedValue { runCatching { builder() } }
         val durationMs = duration.inWholeMilliseconds
         return builderResult.fold(

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultDescribeTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultDescribeTest.kt
@@ -213,4 +213,17 @@ class AsyncOperationResultDescribeTest {
         val tierLines = output.lines().filter { it.contains("Tier") }
         assertEquals(3, tierLines.size)
     }
+
+    @Test
+    fun `describe does not throw StackOverflowError on a deep linear chain`() {
+        // A 500-node linear chain would overflow the stack with the old recursive computeTier.
+        var dag = AsyncOperationResult().add("t0") { Patient() }
+        for (i in 1..499) {
+            dag = dag.addAfter("t$i", "t${i - 1}") { Patient() }
+        }
+
+        val output = dag.describe()
+
+        assertThat(output, containsString("Tier 500"))
+    }
 }

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/FhirExtensionHelperTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/FhirExtensionHelperTest.kt
@@ -376,4 +376,24 @@ class FhirExtensionHelperTest {
         }
         assertEquals("nameExt", FhirExtensionHelper.getValueAs<StringType>(name, URL_A)?.value)
     }
+
+    @Test
+    fun `getAllByUrl finds extensions on two structurally equal sibling nodes`() {
+        // Two distinct HumanName instances with the same content — if identity hash codes
+        // were used for cycle detection, a collision between the two could cause one to be
+        // silently skipped. Using an IdentityHashMap-backed set avoids that.
+        val patient = Patient().apply {
+            addName().apply {
+                family = "Smith"
+                addExtension(URL_A, StringType("first"))
+            }
+            addName().apply {
+                family = "Smith"
+                addExtension(URL_A, StringType("second"))
+            }
+        }
+
+        val found = FhirExtensionHelper.getAllByUrl(patient, URL_A)
+        assertThat(found, hasSize(2))
+    }
 }

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultConditionalTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultConditionalTest.kt
@@ -249,6 +249,31 @@ class OperationResultConditionalTest {
         assertTrue(result.hasErrors())
     }
 
+    // ── addOrSkip / addOrDefault respect FAIL_FAST ────────────────────────────
+
+    @Test
+    fun `addOrSkip - respects shouldSkip in FAIL_FAST mode`() {
+        var invoked = false
+        val result = OperationResult.of(patient())
+            .add("enc") { error("trigger error") }
+            .addOrSkip("skipped") { invoked = true; appointment() }
+
+        assertFalse(invoked)
+        assertFalse(result.containsKey("skipped"))
+    }
+
+    @Test
+    fun `addOrDefault - respects shouldSkip in FAIL_FAST mode`() {
+        var invoked = false
+        val default = coverage()
+        val result = OperationResult.of(patient())
+            .add("enc") { error("trigger error") }
+            .addOrDefault("skipped", default) { invoked = true; coverage() }
+
+        assertFalse(invoked)
+        assertFalse(result.containsKey("skipped"))
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private fun patient() = Patient().apply {

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFhirErrorHandlingTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFhirErrorHandlingTest.kt
@@ -264,6 +264,63 @@ class OperationResultFhirErrorHandlingTest {
         assertThat(encOutcome!!.issue[0].diagnostics, containsString("bad param"))
     }
 
+    // ── toOperationOutcome preserves all issue fields ─────────────────────────
+
+    @Test
+    fun `toOperationOutcome preserves location from original issue`() {
+        val embedded = OperationOutcome().apply {
+            addIssue().apply {
+                severity = OperationOutcome.IssueSeverity.ERROR
+                code = OperationOutcome.IssueType.EXCEPTION
+                diagnostics = "error"
+                addLocation("Patient.name")
+            }
+        }
+        val result = OperationResult.of(patient())
+            .add("enc") { throw InternalErrorException("fail", embedded) }
+
+        val merged = result.toOperationOutcome()
+        assertThat(merged.issue, hasSize(1))
+        assertThat(merged.issue[0].location.map { it.value }, equalTo(listOf("Patient.name")))
+    }
+
+    @Test
+    fun `toOperationOutcome preserves expression from original issue`() {
+        val embedded = OperationOutcome().apply {
+            addIssue().apply {
+                severity = OperationOutcome.IssueSeverity.ERROR
+                code = OperationOutcome.IssueType.EXCEPTION
+                diagnostics = "error"
+                addExpression("Patient.active")
+            }
+        }
+        val result = OperationResult.of(patient())
+            .add("enc") { throw InternalErrorException("fail", embedded) }
+
+        val merged = result.toOperationOutcome()
+        assertThat(merged.issue, hasSize(1))
+        assertThat(merged.issue[0].expression.map { it.value }, equalTo(listOf("Patient.active")))
+    }
+
+    @Test
+    fun `toOperationOutcome preserves extension from original issue`() {
+        val embedded = OperationOutcome().apply {
+            addIssue().apply {
+                severity = OperationOutcome.IssueSeverity.ERROR
+                code = OperationOutcome.IssueType.EXCEPTION
+                diagnostics = "error"
+                addExtension("http://example.org/ext", org.hl7.fhir.r4.model.StringType("val"))
+            }
+        }
+        val result = OperationResult.of(patient())
+            .add("enc") { throw InternalErrorException("fail", embedded) }
+
+        val merged = result.toOperationOutcome()
+        assertThat(merged.issue, hasSize(1))
+        assertThat(merged.issue[0].extension, hasSize(1))
+        assertThat(merged.issue[0].extension[0].url, equalTo("http://example.org/ext"))
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private fun patient() = Patient().apply { setId("p1") }

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFromTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFromTest.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -348,6 +349,19 @@ class OperationResultFromTest {
         assertThrows<IllegalArgumentException> {
             OperationResult.fromParametersTyped<Patient>(fhirParams, "patient")
         }
+    }
+
+    @Test
+    fun `fromParametersTyped - Class overload sets typed head identical to KClass overload`() {
+        val patient = patient()
+        val fhirParams = Parameters().apply {
+            addParameter().apply { name = "patient"; resource = patient }
+        }
+
+        val result = OperationResult.fromParametersTyped(fhirParams, "patient", Patient::class.java)
+
+        assertSame(patient, result.getResult())
+        assertTrue(result.containsKey("patient"))
     }
 
     // ── fromBundle ────────────────────────────────────────────────────────────

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultJavaInteropTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultJavaInteropTest.kt
@@ -1,0 +1,108 @@
+package dev.ratkay.operation.r4
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.hl7.fhir.r4.model.Appointment
+import org.hl7.fhir.r4.model.Coverage
+import org.hl7.fhir.r4.model.Patient
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies that the Class<T> overloads added for Java interop produce the same
+ * results as the corresponding KClass / reified overloads.
+ */
+class OperationResultJavaInteropTest {
+
+    // ── getByType ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `getByType - Class overload returns same resources as KClass overload`() {
+        val patient = patient()
+        val result = OperationResult.of(patient, "patient")
+            .add("appt") { appointment() }
+
+        val byClass = result.getByType(Patient::class.java)
+        val byKClass = result.getByType(Patient::class)
+
+        assertThat(byClass, hasSize(1))
+        assertSame(byClass[0], byKClass[0])
+    }
+
+    @Test
+    fun `getByType - Class overload returns empty list when type absent`() {
+        val result = OperationResult.of(patient(), "patient")
+
+        val found = result.getByType(Coverage::class.java)
+
+        assertThat(found, hasSize(0))
+    }
+
+    // ── filterByType ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `filterByType - Class overload keeps only matching type`() {
+        val patient = patient()
+        val result = OperationResult.of(patient, "patient")
+            .add("appt") { appointment() }
+
+        val filtered = result.filterByType(Patient::class.java)
+
+        assertTrue(filtered.containsKey("patient"))
+        assertFalse(filtered.containsKey("appt"))
+    }
+
+    // ── addFrom ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `addFrom - Class overload processes values same as KClass overload`() {
+        val appt = appointment()
+        val result = OperationResult.of(patient(), "patient")
+            .add("appt") { appt }
+            .addFrom("appt", Appointment::class.java) { list -> list.first() }
+
+        assertSame(appt, result.getResult())
+    }
+
+    // ── addAllFrom ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `addAllFrom - Class overload collects values same as KClass overload`() {
+        val result = OperationResult.of(patient(), "patient")
+            .add("appt") { appointment() }
+            .add("appt") { appointment() }
+            .addAllFrom("appt", Appointment::class.java) { list -> list }
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    // ── extractParam ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `extractParam - Class overload sets head to first matching value`() {
+        val patient = patient()
+        val result = OperationResult.of(patient, "patient")
+            .extractParam("patient", Patient::class.java)
+
+        assertSame(patient, result.getResult())
+    }
+
+    // ── extractParamList ──────────────────────────────────────────────────────
+
+    @Test
+    fun `extractParamList - Class overload sets head to list of matching values`() {
+        val result = OperationResult.of(patient(), "patient")
+            .add("appt") { appointment() }
+            .add("appt") { appointment() }
+            .extractParamList("appt", Appointment::class.java)
+
+        assertThat(result.getResult(), hasSize(2))
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun patient() = Patient().apply { addName().family = "Doe" }
+    private fun appointment() = Appointment().apply { status = Appointment.AppointmentStatus.BOOKED }
+}

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultTest.kt
@@ -162,7 +162,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addUsing with explicit name`() {
+    fun `addUsing - stores result under explicit name`() {
         val result = OperationResult.of(patient(), "patient")
             .addUsing("appt") { _ -> appointment() }
 
@@ -203,7 +203,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllUsing with explicit name`() {
+    fun `addAllUsing - groups all items under explicit name`() {
         val result = OperationResult.of(patient())
             .addAllUsing("items") { _ -> listOf(appointment(), appointment()) }
 
@@ -297,7 +297,7 @@ class OperationResultTest {
     // ── addFromFiltered (extension filters) ──────────────────────────────────
 
     @Test
-    fun `addFromHavingAllExtensions returns only resources that have the matching extension URL`() {
+    fun `addFromFiltered - returns only resources matching hasAllExtensions predicate`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val notEnrolled = patient()
         val result = OperationResult.of(listOf(enrolled, notEnrolled), "patients")
@@ -311,7 +311,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAllExtensions with multiple URLs requires resource to carry every URL`() {
+    fun `addFromFiltered - hasAllExtensions requires resource to carry every URL when multiple URLs given`() {
         val both = patient().apply {
             addExtension("http://example.org/url1", StringType("a"))
             addExtension("http://example.org/url2", StringType("b"))
@@ -328,7 +328,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAnyExtension returns resources carrying at least one of the URLs`() {
+    fun `addFromFiltered - hasAnyExtension returns resources carrying at least one matching URL`() {
         val hasFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val hasSecond = patient().apply { addExtension("http://example.org/url2", StringType("b")) }
         val hasBoth = patient().apply {
@@ -347,7 +347,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAnyExtension with single URL behaves like addFromHavingAllExtensions`() {
+    fun `addFromFiltered - hasAnyExtension with single URL behaves like hasAllExtensions`() {
         val hasIt = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val hasNot = patient()
         val result = OperationResult.of(listOf(hasIt, hasNot), "patients")
@@ -359,7 +359,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAllExtensions with no extUrls returns all resources of that type`() {
+    fun `addFromFiltered - hasAllExtensions with no URLs returns all resources of the given type`() {
         val result = OperationResult.of(listOf(patient(), patient(), appointment()), "items")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions()) { filtered ->
                 OperationOutcome().apply {
@@ -371,7 +371,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAllExtensions produces empty list when no resources match`() {
+    fun `addFromFiltered - hasAllExtensions predicate produces empty list when no resources match`() {
         val result = OperationResult.of(listOf(patient(), patient()), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/nonexistent")) { filtered ->
                 OperationOutcome().apply {
@@ -383,7 +383,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAnyExtension produces empty list when no resources match any URL`() {
+    fun `addFromFiltered - hasAnyExtension predicate produces empty list when no resources match`() {
         val result = OperationResult.of(listOf(patient(), patient()), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAnyExtension("http://example.org/nonexistent")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
@@ -393,7 +393,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAllExtensions searches across all parameter keys not just one`() {
+    fun `addFromFiltered - hasAllExtensions searches across all parameter keys not just one`() {
         val enrolled1 = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val enrolled2 = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(enrolled1, "group-a")
@@ -408,7 +408,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromHavingAllExtensions returns list result built from AND-filtered input`() {
+    fun `addAllFromFiltered - hasAllExtensions returns list result`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
             .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
@@ -420,7 +420,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromHavingAnyExtension returns list result built from OR-filtered input`() {
+    fun `addAllFromFiltered - hasAnyExtension returns list result`() {
         val hasFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val hasSecond = patient().apply { addExtension("http://example.org/url2", StringType("b")) }
         val result = OperationResult.of(listOf(hasFirst, hasSecond, patient()), "patients")
@@ -432,7 +432,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAllExtensions reified overload works correctly`() {
+    fun `addFromFiltered - hasAllExtensions reified overload filters correctly`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
             .addFromFiltered<Patient, OperationOutcome>(predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
@@ -445,7 +445,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAnyExtension reified overload works correctly`() {
+    fun `addFromFiltered - hasAnyExtension reified overload filters correctly`() {
         val hasFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val hasSecond = patient().apply { addExtension("http://example.org/url2", StringType("b")) }
         val result = OperationResult.of(listOf(hasFirst, hasSecond, patient()), "patients")
@@ -457,7 +457,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAllExtensions records error outcome when builder throws`() {
+    fun `addFromFiltered - records error outcome when builder throws`() {
         val result = OperationResult.of(patient(), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions()) { _ ->
                 throw RuntimeException("builder failed")
@@ -468,7 +468,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAllExtensions unnamed overload stores result under output fhirType not input type`() {
+    fun `addFromFiltered - hasAllExtensions unnamed overload stores result under output fhirType not input type`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { _ ->
@@ -481,7 +481,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAnyExtension unnamed overload stores result under output fhirType not input type`() {
+    fun `addFromFiltered - hasAnyExtension unnamed overload stores result under output fhirType not input type`() {
         val hasExt = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val result = OperationResult.of(listOf(hasExt, patient()), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAnyExtension("http://example.org/url1")) { _ ->
@@ -493,7 +493,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingAllExtensions named overload stores result under explicit name`() {
+    fun `addFromFiltered - named overload stores result under explicit name`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
             .addFromFiltered("enrolled-summary", Patient::class, FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
@@ -508,7 +508,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromHavingAllExtensions reified overload returns list result`() {
+    fun `addAllFromFiltered - hasAllExtensions reified overload returns list result`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient(), patient()), "patients")
             .addAllFromFiltered<Patient, OperationOutcome>(predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
@@ -519,7 +519,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromHavingAllExtensions unnamed overload stores results under output fhirType not input type`() {
+    fun `addAllFromFiltered - hasAllExtensions unnamed overload stores results under output fhirType not input type`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
             .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
@@ -531,7 +531,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromHavingAnyExtension unnamed overload stores results under output fhirType not input type`() {
+    fun `addAllFromFiltered - hasAnyExtension unnamed overload stores results under output fhirType not input type`() {
         val hasFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val hasSecond = patient().apply { addExtension("http://example.org/url2", StringType("b")) }
         val result = OperationResult.of(listOf(hasFirst, hasSecond, patient()), "patients")
@@ -546,7 +546,7 @@ class OperationResultTest {
     // ── Extension URL + value-type / value-predicate filters ─────────────────
 
     @Test
-    fun `addFromHavingExtensionWithValueType returns resources where extension at URL has matching value type`() {
+    fun `addFromFiltered - hasExtensionWithValueType returns resources where extension has matching value type`() {
         val withString = patient().apply { addExtension("http://example.org/flag", StringType("active")) }
         val withBoolean = patient().apply { addExtension("http://example.org/flag", BooleanType(true)) }
         val noExtension = patient()
@@ -559,7 +559,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionWithValueType returns empty list when no resources have that value type at URL`() {
+    fun `addFromFiltered - hasExtensionWithValueType produces empty list when no resources match`() {
         val withBoolean = patient().apply { addExtension("http://example.org/flag", BooleanType(false)) }
         val result = OperationResult.of(listOf(withBoolean, patient()), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class)) { filtered ->
@@ -570,7 +570,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionWithValueType named variant stores result under explicit name`() {
+    fun `addFromFiltered - hasExtensionWithValueType named variant stores result under explicit name`() {
         val withString = patient().apply { addExtension("http://example.org/flag", StringType("active")) }
         val result = OperationResult.of(listOf(withString, patient()), "patients")
             .addFromFiltered("flag-summary", Patient::class, FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class)) { filtered ->
@@ -583,7 +583,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromHavingExtensionWithValueType returns list result`() {
+    fun `addAllFromFiltered - hasExtensionWithValueType returns list result`() {
         val withString1 = patient().apply { addExtension("http://example.org/flag", StringType("a")) }
         val withString2 = patient().apply { addExtension("http://example.org/flag", StringType("b")) }
         val withBoolean = patient().apply { addExtension("http://example.org/flag", BooleanType(true)) }
@@ -596,7 +596,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionWithValueType reified overload works correctly`() {
+    fun `addFromFiltered - hasExtensionWithValueType reified overload filters correctly`() {
         val withString = patient().apply { addExtension("http://example.org/flag", StringType("x")) }
         val result = OperationResult.of(listOf(withString, patient()), "patients")
             .addFromFiltered<Patient, OperationOutcome>(predicate = FhirFilter.hasExtensionWithValueType<StringType>("http://example.org/flag")) { filtered ->
@@ -607,7 +607,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionValueMatching returns resources where extension value satisfies predicate`() {
+    fun `addFromFiltered - hasExtensionValueMatching returns resources where extension value satisfies predicate`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val notEnrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("false")) }
         val noExt = patient()
@@ -620,7 +620,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionValueMatching returns empty list when predicate never satisfied`() {
+    fun `addFromFiltered - hasExtensionValueMatching produces empty list when predicate never satisfied`() {
         val patient1 = patient().apply { addExtension("http://example.org/enrolled", StringType("false")) }
         val result = OperationResult.of(listOf(patient1, patient()), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { filtered ->
@@ -631,7 +631,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionValueMatching named variant stores result under explicit name`() {
+    fun `addFromFiltered - hasExtensionValueMatching named variant stores result under explicit name`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
             .addFromFiltered("enrolled-patients", Patient::class, FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { filtered ->
@@ -644,7 +644,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromHavingExtensionValueMatching returns list result`() {
+    fun `addAllFromFiltered - hasExtensionValueMatching returns list result`() {
         val high = patient().apply { addExtension("http://example.org/priority", IntegerType(10)) }
         val low = patient().apply { addExtension("http://example.org/priority", IntegerType(1)) }
         val none = patient()
@@ -657,7 +657,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionValueMatching reified overload works correctly`() {
+    fun `addFromFiltered - hasExtensionValueMatching reified overload filters correctly`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", BooleanType(true)) }
         val notEnrolled = patient().apply { addExtension("http://example.org/enrolled", BooleanType(false)) }
         val result = OperationResult.of(listOf(enrolled, notEnrolled), "patients")
@@ -669,7 +669,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionValueMatching with multiple extensions at same URL — any satisfying match passes`() {
+    fun `addFromFiltered - hasExtensionValueMatching with multiple extensions at same URL — any satisfying match passes`() {
         val multiExt = patient().apply {
             addExtension("http://example.org/role", StringType("admin"))
             addExtension("http://example.org/role", StringType("user"))
@@ -684,7 +684,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addFromHavingExtensionValueMatching unnamed overload stores result under output fhirType not input type`() {
+    fun `addFromFiltered - hasExtensionValueMatching unnamed overload stores result under output fhirType not input type`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { _ ->
@@ -696,7 +696,7 @@ class OperationResultTest {
     }
 
     @Test
-    fun `addAllFromHavingExtensionValueMatching unnamed overload stores results under output fhirType not input type`() {
+    fun `addAllFromFiltered - hasExtensionValueMatching unnamed overload stores results under output fhirType not input type`() {
         val high = patient().apply { addExtension("http://example.org/priority", IntegerType(10)) }
         val result = OperationResult.of(listOf(high, patient()), "patients")
             .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<IntegerType>("http://example.org/priority") { it.value > 5 }) { filtered ->

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
         <approvalcrest.version>0.61.6</approvalcrest.version>
         <hamcrest.version>3.0</hamcrest.version>
         <coroutines.version>1.10.2</coroutines.version>
-        <slf4j.version>1.7.36</slf4j.version>
-        <logback.version>1.2.12</logback.version>
+        <slf4j.version>2.0.17</slf4j.version>
+        <logback.version>1.5.18</logback.version>
         <spring.boot.version>2.7.18</spring.boot.version>
         <dokka.version>1.9.20</dokka.version>
     </properties>


### PR DESCRIPTION
Previously only severity, code, and diagnostics were copied, silently
dropping location, expression, details, extension, and other fields.
Now delegates to HAPI's Base.copy() so every field is preserved.

Tests added for location, expression, and extension survival in both
R4 and DSTU3.