### PR TITLE
feat: add mapStored — element-wise in-place transformation of stored values

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,31 @@ result.remove("coverage")             // new OperationResult without the "covera
 result.rename("old", "new")           // move all values from "old" to "new"
 ```
 
+#### In-place value transformation (mapStored)
+
+Applies a function to values already stored in the parameter map without changing the pipeline head type.
+
+```kotlin
+// Named overload — transform every Patient stored under "patient"
+val updated = result.mapStored<Patient, Patient>("patient") { p ->
+    p.copy().apply { addName().family = p.nameFirstRep.family.uppercase() }
+}
+
+// Named overload, explicit KClass
+val updated = result.mapStored("patient", Patient::class) { p -> transform(p) }
+
+// Unkeyed overload — transform every Patient across ALL stored keys
+val updated = result.mapStored<Patient, Patient> { p -> transform(p) }
+
+// Unkeyed overload, explicit KClass
+val updated = result.mapStored(Patient::class) { p -> transform(p) }
+```
+
+- Values that do not match the given type are passed through unchanged.
+- Named: if the key is absent the result is returned unchanged (no-op).
+- Unkeyed: if no stored value matches the type all values pass through unchanged.
+- On exception inside the transform: a WARNING `OperationOutcome` is recorded and the **original** parameter map is preserved (Pattern B — head-preserving).
+
 #### Side effects (peek)
 
 ```kotlin
@@ -1595,6 +1620,10 @@ val first: Base?           = result.takeFirst("patient")
 // Remove a key (no-op if absent) or rename a key
 val trimmed  = result.remove("draft")
 val renamed  = result.rename("old", "new")
+
+// mapStored — transform stored values element-wise; head type T is always preserved
+val updated = result.mapStored<Patient, Patient>("patient") { p -> transform(p) }  // named key
+val updated = result.mapStored<Patient, Patient> { p -> transform(p) }              // all keys
 
 // Merge two pipelines — overlapping keys accumulate
 val merged = resultA.merge(resultB)

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
@@ -59,7 +59,7 @@ import kotlin.time.measureTimedValue
  * | Nested params | `addPart` |
  * | Extension support | `addWithExtension` |
  * | Query | `getAllParameters`, `getAll`, `getByType`, `containsKey`, `getKeys`, `count`, `totalCount`, `isEmpty`, `isNotEmpty` |
- * | Transformations | `filterByType`, `filterByName`, `flatMap`, `mapHead`, `mapHeadUsing`, `merge`, `remove`, `rename`, `peek` |
+ * | Transformations | `filterByType`, `filterByName`, `flatMap`, `mapHead`, `mapHeadUsing`, `merge`, `remove`, `rename`, `mapStored`, `peek` |
  * | Conditional chaining | `whenTrue`, `ifPresent`, `guardFalse`, `whenPath`, `guardPath` |
  * | FHIRPath extraction | `selectByPath` |
  * | Extraction | `takeFirst`, `takeFirstTyped`, `extractParam`, `extractParamList` |
@@ -1084,6 +1084,110 @@ class OperationResult<T> private constructor(
         newParams.remove(oldName)?.let { newParams.getOrPut(newName) { mutableListOf() }.addAll(it) }
         return copyWith(result, params = newParams, extensions = shallowCopyExtensions())
     }
+
+    /**
+     * Applies [transform] to every value stored under [name] that is an instance of [type],
+     * replacing each matching value with the result of [transform]. Values that are not
+     * instances of [type] are passed through unchanged.
+     *
+     * If [name] is absent from the parameter map the result is returned unchanged (no-op).
+     * The pipeline head type [T] is always preserved.
+     *
+     * On exception inside [transform]: a WARNING-severity [OperationOutcome] is recorded and
+     * the original parameter map is preserved unchanged (Pattern B — head-preserving).
+     * Respects [ErrorStrategy.FAIL_FAST]: returns immediately when the pipeline has errors.
+     *
+     * @param name the key whose values to transform.
+     * @param type the [KClass] of values to match; non-matching values pass through.
+     * @param transform element-wise mapping function applied to each matching value.
+     */
+    fun <I : Base, R : Base> mapStored(name: String, type: KClass<I>, transform: (I) -> R): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val (outcome, duration) = measureTimedValue {
+            runCatching {
+                val newParams = shallowCopyParams()
+                val existing = newParams[name]
+                if (existing != null) {
+                    newParams[name] = existing.map {
+                        if (type.java.isInstance(it)) transform(type.java.cast(it)) else it
+                    }.toMutableList()
+                }
+                newParams
+            }
+        }
+        val durationMs = duration.inWholeMilliseconds
+        return outcome.fold(
+            onSuccess = { newParams ->
+                recordMetric(name, "mapStored", durationMs, true)
+                copyWith(result, params = newParams, extensions = shallowCopyExtensions())
+            },
+            onFailure = { t ->
+                if (t !is Exception) throw t
+                logger.warn("FHIRMason | step='mapStored' | WARN: {}", t.message)
+                recordMetric(name, "", durationMs, false)
+                outcomes.add(warningOutcome(t))
+                copyWith(result)
+            }
+        )
+    }
+
+    /** Java-friendly [Class] overload of [mapStored] — targets values under [name]. */
+    fun <I : Base, R : Base> mapStored(name: String, type: Class<I>, transform: (I) -> R): OperationResult<T> =
+        mapStored(name, type.kotlin, transform)
+
+    /** Reified overload — no [KClass] argument needed at call sites. Targets values under [name]. */
+    inline fun <reified I : Base, R : Base> mapStored(name: String, noinline transform: (I) -> R): OperationResult<T> =
+        mapStored(name, I::class, transform)
+
+    /**
+     * Applies [transform] to every value across all stored keys that is an instance of [type],
+     * replacing each matching value with the result of [transform]. Values that are not instances
+     * of [type] are passed through unchanged. All keys are visited.
+     *
+     * If no stored value matches [type] the result is returned unchanged (no-op).
+     * The pipeline head type [T] is always preserved.
+     *
+     * On exception inside [transform]: a WARNING-severity [OperationOutcome] is recorded and
+     * the original parameter map is preserved unchanged (Pattern B — head-preserving).
+     * Respects [ErrorStrategy.FAIL_FAST]: returns immediately when the pipeline has errors.
+     *
+     * @param type the [KClass] of values to match; non-matching values pass through.
+     * @param transform element-wise mapping function applied to each matching value.
+     */
+    fun <I : Base, R : Base> mapStored(type: KClass<I>, transform: (I) -> R): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val (outcome, duration) = measureTimedValue {
+            runCatching {
+                val newParams = shallowCopyParams()
+                newParams.replaceAll { _, values ->
+                    values.map { if (type.java.isInstance(it)) transform(type.java.cast(it)) else it }.toMutableList()
+                }
+                newParams
+            }
+        }
+        val durationMs = duration.inWholeMilliseconds
+        return outcome.fold(
+            onSuccess = { newParams ->
+                recordMetric("mapStored", "mapStored", durationMs, true)
+                copyWith(result, params = newParams, extensions = shallowCopyExtensions())
+            },
+            onFailure = { t ->
+                if (t !is Exception) throw t
+                logger.warn("FHIRMason | step='mapStored' | WARN: {}", t.message)
+                recordMetric("mapStored", "", durationMs, false)
+                outcomes.add(warningOutcome(t))
+                copyWith(result)
+            }
+        )
+    }
+
+    /** Java-friendly [Class] overload of [mapStored] — targets all stored values of [type] across all keys. */
+    fun <I : Base, R : Base> mapStored(type: Class<I>, transform: (I) -> R): OperationResult<T> =
+        mapStored(type.kotlin, transform)
+
+    /** Reified overload — no [KClass] argument needed at call sites. Targets all stored values of the type across all keys. */
+    inline fun <reified I : Base, R : Base> mapStored(noinline transform: (I) -> R): OperationResult<T> =
+        mapStored(I::class, transform)
 
     /**
      * Invokes [block] with a snapshot of the current parameter map for side-effects (logging,

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultTest.kt
@@ -1428,6 +1428,184 @@ class OperationResultTest {
         assertEquals(2, result.count("target"))
     }
 
+    // ── mapStored (named overload) ────────────────────────────────────────────
+
+    @Test
+    fun `mapStored named transforms matching values under the key`() {
+        val original = patient()
+        val replacement = patient().apply { addName().family = "Smith" }
+        val result = OperationResult.of(original, "patient")
+            .mapStored("patient", Patient::class) { replacement }
+
+        assertThat(result.getAll("patient").first(), sameInstance(replacement))
+    }
+
+    @Test
+    fun `mapStored named leaves non-matching types under the same key unchanged`() {
+        val appt = appointment()
+        val result = OperationResult.of(patient(), "mixed")
+            .add("mixed") { appt }
+            .mapStored("mixed", Patient::class) { patient().apply { addName().family = "Transformed" } }
+
+        assertTrue(result.getAll("mixed").any { it is Appointment && it === appt })
+    }
+
+    @Test
+    fun `mapStored named key absent is a no-op`() {
+        val p = patient()
+        val result = OperationResult.of(p, "patient")
+            .mapStored("other", Patient::class) { patient() }
+
+        assertThat(result.getAll("patient").first(), sameInstance(p))
+        assertFalse(result.containsKey("other"))
+    }
+
+    @Test
+    fun `mapStored named head is unchanged`() {
+        val original = patient()
+        val result = OperationResult.of(original, "patient")
+            .mapStored("patient", Patient::class) { patient() }
+
+        assertThat(result.getResult(), sameInstance(original))
+    }
+
+    @Test
+    fun `mapStored named other keys are not affected`() {
+        val appt = appointment()
+        val result = OperationResult.of(patient(), "patient")
+            .add("appt") { appt }
+            .mapStored("patient", Patient::class) { patient() }
+
+        assertThat(result.getAll("appt").first(), sameInstance(appt))
+    }
+
+    @Test
+    fun `mapStored named transform throws records WARNING outcome and preserves original`() {
+        val original = patient()
+        val result = OperationResult.of(original, "patient")
+            .mapStored("patient", Patient::class) { throw RuntimeException("boom") }
+
+        assertTrue(result.hasErrors())
+        assertThat(
+            result.getOutcomes().first().issueFirstRep.severity,
+            `is`(OperationOutcome.IssueSeverity.WARNING)
+        )
+        assertThat(result.getAll("patient").first(), sameInstance(original))
+    }
+
+    @Test
+    fun `mapStored named respects FAIL_FAST and returns immediately`() {
+        val original = patient()
+        var called = false
+        val result = OperationResult.of(original, "patient", ErrorStrategy.FAIL_FAST)
+            .add { throw RuntimeException("first") }
+            .mapStored("patient", Patient::class) { called = true; patient() }
+
+        assertFalse(called)
+        assertThat(result.getAll("patient").first(), sameInstance(original))
+    }
+
+    @Test
+    fun `mapStored named reified overload works without explicit KClass`() {
+        val replacement = patient().apply { addName().family = "Reified" }
+        val result = OperationResult.of(patient(), "patient")
+            .mapStored<Patient, Patient>("patient") { replacement }
+
+        assertThat(result.getAll("patient").first(), sameInstance(replacement))
+    }
+
+    @Test
+    fun `mapStored named Class overload produces same result as KClass overload`() {
+        val replacement = patient().apply { addName().family = "Java" }
+        val viaKClass = OperationResult.of(patient(), "patient")
+            .mapStored("patient", Patient::class) { replacement }
+        val viaClass = OperationResult.of(patient(), "patient")
+            .mapStored("patient", Patient::class.java) { replacement }
+
+        assertEquals(1, viaKClass.count("patient"))
+        assertEquals(1, viaClass.count("patient"))
+        assertThat(viaKClass.getAll("patient").first(), instanceOf(Patient::class.java))
+        assertThat(viaClass.getAll("patient").first(), instanceOf(Patient::class.java))
+    }
+
+    // ── mapStored (unkeyed overload) ──────────────────────────────────────────
+
+    @Test
+    fun `mapStored unkeyed transforms matching values across multiple keys`() {
+        val p1 = patient()
+        val p2 = patient()
+        val replacement = patient().apply { addName().family = "Transformed" }
+        val result = OperationResult.of(p1, "key1")
+            .add("key2") { p2 }
+            .mapStored(Patient::class) { replacement }
+
+        assertTrue(result.getAll("key1").all { it === replacement })
+        assertTrue(result.getAll("key2").all { it === replacement })
+    }
+
+    @Test
+    fun `mapStored unkeyed leaves non-matching types across all keys unchanged`() {
+        val appt = appointment()
+        val result = OperationResult.of(patient(), "patient")
+            .add("appt") { appt }
+            .mapStored(Patient::class) { patient().apply { addName().family = "X" } }
+
+        assertThat(result.getAll("appt").first(), sameInstance(appt))
+    }
+
+    @Test
+    fun `mapStored unkeyed no matching values is a no-op`() {
+        val appt = appointment()
+        val result = OperationResult.of(appt, "appt")
+            .mapStored(Patient::class) { patient() }
+
+        assertThat(result.getAll("appt").first(), sameInstance(appt))
+    }
+
+    @Test
+    fun `mapStored unkeyed head is unchanged`() {
+        val original = patient()
+        val result = OperationResult.of(original, "patient")
+            .mapStored(Patient::class) { patient() }
+
+        assertThat(result.getResult(), sameInstance(original))
+    }
+
+    @Test
+    fun `mapStored unkeyed transform throws records WARNING outcome and preserves original`() {
+        val original = patient()
+        val result = OperationResult.of(original, "patient")
+            .mapStored(Patient::class) { throw RuntimeException("boom") }
+
+        assertTrue(result.hasErrors())
+        assertThat(
+            result.getOutcomes().first().issueFirstRep.severity,
+            `is`(OperationOutcome.IssueSeverity.WARNING)
+        )
+        assertThat(result.getAll("patient").first(), sameInstance(original))
+    }
+
+    @Test
+    fun `mapStored unkeyed respects FAIL_FAST and returns immediately`() {
+        val original = patient()
+        var called = false
+        val result = OperationResult.of(original, "patient", ErrorStrategy.FAIL_FAST)
+            .add { throw RuntimeException("first") }
+            .mapStored(Patient::class) { called = true; patient() }
+
+        assertFalse(called)
+        assertThat(result.getAll("patient").first(), sameInstance(original))
+    }
+
+    @Test
+    fun `mapStored unkeyed reified overload works without explicit KClass`() {
+        val replacement = patient().apply { addName().family = "Reified" }
+        val result = OperationResult.of(patient(), "patient")
+            .mapStored<Patient, Patient> { replacement }
+
+        assertThat(result.getAll("patient").first(), sameInstance(replacement))
+    }
+
     // ── peek ─────────────────────────────────────────────────────────────────
 
     @Test

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -60,7 +60,7 @@ import kotlin.time.measureTimedValue
  * | Nested params | `addPart` |
  * | Extension support | `addWithExtension` |
  * | Query | `getAllParameters`, `getAll`, `getByType`, `containsKey`, `getKeys`, `count`, `totalCount`, `isEmpty`, `isNotEmpty` |
- * | Transformations | `filterByType`, `filterByName`, `flatMap`, `mapHead`, `mapHeadUsing`, `merge`, `remove`, `rename`, `peek` |
+ * | Transformations | `filterByType`, `filterByName`, `flatMap`, `mapHead`, `mapHeadUsing`, `merge`, `remove`, `rename`, `mapStored`, `peek` |
  * | Conditional chaining | `whenTrue`, `ifPresent`, `guardFalse`, `whenPath`, `guardPath` |
  * | FHIRPath extraction | `selectByPath` |
  * | Extraction | `takeFirst`, `takeFirstTyped`, `extractParam`, `extractParamList` |
@@ -1091,6 +1091,110 @@ class OperationResult<T> private constructor(
         newParams.remove(oldName)?.let { newParams.getOrPut(newName) { mutableListOf() }.addAll(it) }
         return copyWith(result, params = newParams, extensions = shallowCopyExtensions())
     }
+
+    /**
+     * Applies [transform] to every value stored under [name] that is an instance of [type],
+     * replacing each matching value with the result of [transform]. Values that are not
+     * instances of [type] are passed through unchanged.
+     *
+     * If [name] is absent from the parameter map the result is returned unchanged (no-op).
+     * The pipeline head type [T] is always preserved.
+     *
+     * On exception inside [transform]: a WARNING-severity [OperationOutcome] is recorded and
+     * the original parameter map is preserved unchanged (Pattern B — head-preserving).
+     * Respects [ErrorStrategy.FAIL_FAST]: returns immediately when the pipeline has errors.
+     *
+     * @param name the key whose values to transform.
+     * @param type the [KClass] of values to match; non-matching values pass through.
+     * @param transform element-wise mapping function applied to each matching value.
+     */
+    fun <I : Base, R : Base> mapStored(name: String, type: KClass<I>, transform: (I) -> R): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val (outcome, duration) = measureTimedValue {
+            runCatching {
+                val newParams = shallowCopyParams()
+                val existing = newParams[name]
+                if (existing != null) {
+                    newParams[name] = existing.map {
+                        if (type.java.isInstance(it)) transform(type.java.cast(it)) else it
+                    }.toMutableList()
+                }
+                newParams
+            }
+        }
+        val durationMs = duration.inWholeMilliseconds
+        return outcome.fold(
+            onSuccess = { newParams ->
+                recordMetric(name, "mapStored", durationMs, true)
+                copyWith(result, params = newParams, extensions = shallowCopyExtensions())
+            },
+            onFailure = { t ->
+                if (t !is Exception) throw t
+                logger.warn("FHIRMason | step='mapStored' | WARN: {}", t.message)
+                recordMetric(name, "", durationMs, false)
+                outcomes.add(warningOutcome(t))
+                copyWith(result)
+            }
+        )
+    }
+
+    /** Java-friendly [Class] overload of [mapStored] — targets values under [name]. */
+    fun <I : Base, R : Base> mapStored(name: String, type: Class<I>, transform: (I) -> R): OperationResult<T> =
+        mapStored(name, type.kotlin, transform)
+
+    /** Reified overload — no [KClass] argument needed at call sites. Targets values under [name]. */
+    inline fun <reified I : Base, R : Base> mapStored(name: String, noinline transform: (I) -> R): OperationResult<T> =
+        mapStored(name, I::class, transform)
+
+    /**
+     * Applies [transform] to every value across all stored keys that is an instance of [type],
+     * replacing each matching value with the result of [transform]. Values that are not instances
+     * of [type] are passed through unchanged. All keys are visited.
+     *
+     * If no stored value matches [type] the result is returned unchanged (no-op).
+     * The pipeline head type [T] is always preserved.
+     *
+     * On exception inside [transform]: a WARNING-severity [OperationOutcome] is recorded and
+     * the original parameter map is preserved unchanged (Pattern B — head-preserving).
+     * Respects [ErrorStrategy.FAIL_FAST]: returns immediately when the pipeline has errors.
+     *
+     * @param type the [KClass] of values to match; non-matching values pass through.
+     * @param transform element-wise mapping function applied to each matching value.
+     */
+    fun <I : Base, R : Base> mapStored(type: KClass<I>, transform: (I) -> R): OperationResult<T> {
+        if (shouldSkip()) return copyWith(result)
+        val (outcome, duration) = measureTimedValue {
+            runCatching {
+                val newParams = shallowCopyParams()
+                newParams.replaceAll { _, values ->
+                    values.map { if (type.java.isInstance(it)) transform(type.java.cast(it)) else it }.toMutableList()
+                }
+                newParams
+            }
+        }
+        val durationMs = duration.inWholeMilliseconds
+        return outcome.fold(
+            onSuccess = { newParams ->
+                recordMetric("mapStored", "mapStored", durationMs, true)
+                copyWith(result, params = newParams, extensions = shallowCopyExtensions())
+            },
+            onFailure = { t ->
+                if (t !is Exception) throw t
+                logger.warn("FHIRMason | step='mapStored' | WARN: {}", t.message)
+                recordMetric("mapStored", "", durationMs, false)
+                outcomes.add(warningOutcome(t))
+                copyWith(result)
+            }
+        )
+    }
+
+    /** Java-friendly [Class] overload of [mapStored] — targets all stored values of [type] across all keys. */
+    fun <I : Base, R : Base> mapStored(type: Class<I>, transform: (I) -> R): OperationResult<T> =
+        mapStored(type.kotlin, transform)
+
+    /** Reified overload — no [KClass] argument needed at call sites. Targets all stored values of the type across all keys. */
+    inline fun <reified I : Base, R : Base> mapStored(noinline transform: (I) -> R): OperationResult<T> =
+        mapStored(I::class, transform)
 
     /**
      * Invokes [block] with a snapshot of the current parameter map for side-effects (logging,

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultTest.kt
@@ -1426,6 +1426,185 @@ class OperationResultTest {
         assertEquals(2, result.count("target"))
     }
 
+    // ── mapStored (named overload) ────────────────────────────────────────────
+
+    @Test
+    fun `mapStored named transforms matching values under the key`() {
+        val original = patient()
+        val replacement = patient().apply { addName().family = "Smith" }
+        val result = OperationResult.of(original, "patient")
+            .mapStored("patient", Patient::class) { replacement }
+
+        assertThat(result.getAll("patient").first(), sameInstance(replacement))
+    }
+
+    @Test
+    fun `mapStored named leaves non-matching types under the same key unchanged`() {
+        val appt = appointment()
+        val result = OperationResult.of(patient(), "mixed")
+            .add("mixed") { appt }
+            .mapStored("mixed", Patient::class) { patient().apply { addName().family = "Transformed" } }
+
+        // appointment is non-matching — should still be present
+        assertTrue(result.getAll("mixed").any { it is Appointment && it === appt })
+    }
+
+    @Test
+    fun `mapStored named key absent is a no-op`() {
+        val p = patient()
+        val result = OperationResult.of(p, "patient")
+            .mapStored("other", Patient::class) { patient() }
+
+        assertThat(result.getAll("patient").first(), sameInstance(p))
+        assertFalse(result.containsKey("other"))
+    }
+
+    @Test
+    fun `mapStored named head is unchanged`() {
+        val original = patient()
+        val result = OperationResult.of(original, "patient")
+            .mapStored("patient", Patient::class) { patient() }
+
+        assertThat(result.getResult(), sameInstance(original))
+    }
+
+    @Test
+    fun `mapStored named other keys are not affected`() {
+        val appt = appointment()
+        val result = OperationResult.of(patient(), "patient")
+            .add("appt") { appt }
+            .mapStored("patient", Patient::class) { patient() }
+
+        assertThat(result.getAll("appt").first(), sameInstance(appt))
+    }
+
+    @Test
+    fun `mapStored named transform throws records WARNING outcome and preserves original`() {
+        val original = patient()
+        val result = OperationResult.of(original, "patient")
+            .mapStored("patient", Patient::class) { throw RuntimeException("boom") }
+
+        assertTrue(result.hasErrors())
+        assertThat(
+            result.getOutcomes().first().issueFirstRep.severity,
+            `is`(OperationOutcome.IssueSeverity.WARNING)
+        )
+        assertThat(result.getAll("patient").first(), sameInstance(original))
+    }
+
+    @Test
+    fun `mapStored named respects FAIL_FAST and returns immediately`() {
+        val original = patient()
+        var called = false
+        val result = OperationResult.of(original, "patient", ErrorStrategy.FAIL_FAST)
+            .add { throw RuntimeException("first") }
+            .mapStored("patient", Patient::class) { called = true; patient() }
+
+        assertFalse(called)
+        assertThat(result.getAll("patient").first(), sameInstance(original))
+    }
+
+    @Test
+    fun `mapStored named reified overload works without explicit KClass`() {
+        val replacement = patient().apply { addName().family = "Reified" }
+        val result = OperationResult.of(patient(), "patient")
+            .mapStored<Patient, Patient>("patient") { replacement }
+
+        assertThat(result.getAll("patient").first(), sameInstance(replacement))
+    }
+
+    @Test
+    fun `mapStored named Class overload produces same result as KClass overload`() {
+        val replacement = patient().apply { addName().family = "Java" }
+        val viaKClass = OperationResult.of(patient(), "patient")
+            .mapStored("patient", Patient::class) { replacement }
+        val viaClass = OperationResult.of(patient(), "patient")
+            .mapStored("patient", Patient::class.java) { replacement }
+
+        assertEquals(1, viaKClass.count("patient"))
+        assertEquals(1, viaClass.count("patient"))
+        assertThat(viaKClass.getAll("patient").first(), instanceOf(Patient::class.java))
+        assertThat(viaClass.getAll("patient").first(), instanceOf(Patient::class.java))
+    }
+
+    // ── mapStored (unkeyed overload) ──────────────────────────────────────────
+
+    @Test
+    fun `mapStored unkeyed transforms matching values across multiple keys`() {
+        val p1 = patient()
+        val p2 = patient()
+        val replacement = patient().apply { addName().family = "Transformed" }
+        val result = OperationResult.of(p1, "key1")
+            .add("key2") { p2 }
+            .mapStored(Patient::class) { replacement }
+
+        assertTrue(result.getAll("key1").all { it === replacement })
+        assertTrue(result.getAll("key2").all { it === replacement })
+    }
+
+    @Test
+    fun `mapStored unkeyed leaves non-matching types across all keys unchanged`() {
+        val appt = appointment()
+        val result = OperationResult.of(patient(), "patient")
+            .add("appt") { appt }
+            .mapStored(Patient::class) { patient().apply { addName().family = "X" } }
+
+        assertThat(result.getAll("appt").first(), sameInstance(appt))
+    }
+
+    @Test
+    fun `mapStored unkeyed no matching values is a no-op`() {
+        val appt = appointment()
+        val result = OperationResult.of(appt, "appt")
+            .mapStored(Patient::class) { patient() }
+
+        assertThat(result.getAll("appt").first(), sameInstance(appt))
+    }
+
+    @Test
+    fun `mapStored unkeyed head is unchanged`() {
+        val original = patient()
+        val result = OperationResult.of(original, "patient")
+            .mapStored(Patient::class) { patient() }
+
+        assertThat(result.getResult(), sameInstance(original))
+    }
+
+    @Test
+    fun `mapStored unkeyed transform throws records WARNING outcome and preserves original`() {
+        val original = patient()
+        val result = OperationResult.of(original, "patient")
+            .mapStored(Patient::class) { throw RuntimeException("boom") }
+
+        assertTrue(result.hasErrors())
+        assertThat(
+            result.getOutcomes().first().issueFirstRep.severity,
+            `is`(OperationOutcome.IssueSeverity.WARNING)
+        )
+        assertThat(result.getAll("patient").first(), sameInstance(original))
+    }
+
+    @Test
+    fun `mapStored unkeyed respects FAIL_FAST and returns immediately`() {
+        val original = patient()
+        var called = false
+        val result = OperationResult.of(original, "patient", ErrorStrategy.FAIL_FAST)
+            .add { throw RuntimeException("first") }
+            .mapStored(Patient::class) { called = true; patient() }
+
+        assertFalse(called)
+        assertThat(result.getAll("patient").first(), sameInstance(original))
+    }
+
+    @Test
+    fun `mapStored unkeyed reified overload works without explicit KClass`() {
+        val replacement = patient().apply { addName().family = "Reified" }
+        val result = OperationResult.of(patient(), "patient")
+            .mapStored<Patient, Patient> { replacement }
+
+        assertThat(result.getAll("patient").first(), sameInstance(replacement))
+    }
+
     // ── peek ─────────────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Two overloads with KClass, Class, and reified variants each:

- mapStored(name, type, transform) — transforms every value stored under
  the named key that is an instance of type; non-matching values pass
  through unchanged; absent key is a no-op.

- mapStored(type, transform) — same but visits every key in the parameter
  map; non-matching types pass through unchanged.

Both overloads are head-preserving (Pattern B): the pipeline head type T
is never changed. On exception inside the transform lambda a
WARNING-severity OperationOutcome is recorded and the original parameter
map is restored unchanged. FAIL_FAST is respected.

17 tests added in R4 and mirrored in DSTU3. README updated with usage
examples and in-line description. KDoc written for all six public overloads.