### PR TITLE
Add PROPAGATE error strategy, useErrorStrategy(), and consistent error outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ val result = AsyncOperationResult()
 // From a single value — name defaults to fhirType().lowercase() when omitted
 OperationResult.of(patient)
 OperationResult.of(patient, "myPatient")
-OperationResult.of(patient, errorStrategy = ErrorStrategy.ACCUMULATE)
+OperationResult.of(patient).useErrorStrategy(ErrorStrategy.ACCUMULATE)
 
 // From a list — each item keyed by its fhirType() unless a shared name is given
 OperationResult.of(listOf(patient, appointment))
@@ -98,7 +98,6 @@ OperationResult.fromBundle(bundle) { entry -> entry.fullUrl }   // custom key st
 
 // Empty — no values, no typed head; useful for conditional pipelines or merge targets
 OperationResult.empty()
-OperationResult.empty(errorStrategy = ErrorStrategy.ACCUMULATE)
 ```
 
 ```kotlin
@@ -612,11 +611,21 @@ Extensions on dot-delimited (nested) keys work correctly — `buildParameterComp
 |---|---|
 | `FAIL_FAST` (default) | Records the error `OperationOutcome` and skips all subsequent builder steps |
 | `ACCUMULATE` | Records the error and continues executing subsequent steps |
+| `PROPAGATE` | Exception bubbles to the caller unchanged — not wrapped as an `OperationOutcome` |
+
+Call `useErrorStrategy(strategy)` anywhere in the chain to set or change the strategy:
 
 ```kotlin
-val result = OperationResult.of(patient, errorStrategy = ErrorStrategy.ACCUMULATE)
+// Switch to ACCUMULATE so all steps run even after a failure
+val result = OperationResult.of(patient)
+    .useErrorStrategy(ErrorStrategy.ACCUMULATE)
     .add { riskyStep() }      // failure recorded but next step still runs
     .add { anotherStep() }
+
+// Switch to PROPAGATE when your infrastructure already handles exceptions
+val result = OperationResult.of(patient)
+    .useErrorStrategy(ErrorStrategy.PROPAGATE)
+    .add { riskyStep() }      // throws directly — no OperationOutcome created
 
 result.hasErrors()            // true if any step failed
 result.isSuccessful()         // true if no failures
@@ -806,6 +815,16 @@ FHIRMason | state: {patient=1, coverage=1}
 FHIRMason | step='risky' | WARN: connection timed out
 ```
 
+#### Error strategy (`useErrorStrategy()`)
+
+Call `useErrorStrategy(strategy)` anywhere in the chain to set or change the active [ErrorStrategy]. Changes take effect from that step onwards.
+
+```kotlin
+val result = OperationResult.of(patient)
+    .useErrorStrategy(ErrorStrategy.PROPAGATE)  // exceptions propagate unchanged from here
+    .add("coverage") { fetchCoverage() }
+```
+
 #### Per-step metrics (`timed()` / `getMetrics()`)
 
 Call `timed()` anywhere in the chain to enable `StepMetrics` collection. When disabled (the default), `getMetrics()` returns an empty list — zero overhead.
@@ -891,15 +910,16 @@ val result = OperationResult.of(patient)
 
 ### Error Handling
 
-Every builder step (`add`, `addAll`, `addUsing`, etc.) catches exceptions internally. When an exception is thrown:
+Every builder step (`add`, `addAll`, `addUsing`, etc.) catches exceptions internally unless `PROPAGATE` is active. When an exception is thrown:
 
-- The exception is converted to an `OperationOutcome` with `ERROR` severity and added to the outcome list.
+- The exception is converted to an `OperationOutcome` with `ERROR` severity and added to the outcome list (`FAIL_FAST` / `ACCUMULATE`), or propagated unchanged to the caller (`PROPAGATE`).
 - If the caught exception is a HAPI FHIR `BaseServerResponseException` that already carries an embedded `OperationOutcome`, **that outcome is preserved** rather than replaced with a generic one. Rich diagnostic information from upstream FHIR servers or clients survives the pipeline intact.
 - In `FAIL_FAST` mode subsequent steps are skipped; in `ACCUMULATE` mode they continue.
 
 ```kotlin
 // Embedded OperationOutcome from HAPI FHIR exceptions is preserved in full
-val result = OperationResult.of(patient, errorStrategy = ErrorStrategy.ACCUMULATE)
+val result = OperationResult.of(patient)
+    .useErrorStrategy(ErrorStrategy.ACCUMULATE)
     .add("encounter") { fhirClient.read(Encounter::class.java, encounterId) }  // may throw BaseServerResponseException
     .add("coverage")  { fhirClient.read(Coverage::class.java, coverageId) }
 
@@ -977,13 +997,15 @@ result.throwIfErrors()  // returns this unchanged, or throws InternalErrorExcept
 // From a Parameters resource
 val result = OperationResult.fromParameters(parameters)
 
-// Typed head — getResult() returns a Patient without casting
+// Typed head — getResult() returns a Patient without casting.
+// If no value of the expected type exists under primaryKey, returns a pipeline
+// with hasErrors() == true and a null head (consistent with Pattern A steps).
 val result = OperationResult.fromParametersTyped<Patient>(parameters, primaryKey = "patient")
 
 // From a Bundle — keys default to fhirType().lowercase()
 val result = OperationResult.fromBundle(bundle)
 
-// Typed head — getResult() returns a Patient without casting
+// Typed head — same error-outcome behaviour as fromParametersTyped when key/type is absent.
 val result = OperationResult.fromBundleTyped<Patient>(bundle, primaryKey = "patient")
 
 // Custom key strategy
@@ -998,7 +1020,7 @@ After loading a `Parameters` resource with `fromParameters`, use `extractParam` 
 
 | Method | Signature | Behaviour on missing / wrong type |
 |---|---|---|
-| `extractParam` | `extractParam<R>(name)` | Throws `IllegalArgumentException` |
+| `extractParam` | `extractParam<R>(name)` | Records ERROR outcome, skips head (Pattern A) |
 | `extractParamList` | `extractParamList<R>(name)` | Returns empty list |
 
 ```kotlin
@@ -1539,7 +1561,8 @@ result.getByType<Claim>()   // [the derived Claim]
 ### 5. Resilient pipeline with error accumulation
 
 ```kotlin
-val result = OperationResult.of(patient, errorStrategy = ErrorStrategy.ACCUMULATE)
+val result = OperationResult.of(patient)
+    .useErrorStrategy(ErrorStrategy.ACCUMULATE)
     .add("coverage") { fetchCoverage() }      // may throw
     .addOrSkip("score") { computeScore() }    // failure → warning, pipeline continues
 
@@ -1733,7 +1756,7 @@ mvn clean install       # build, test, and install to local repo
 fhirmason-api/
 ├── src/main/java/dev/ratkay/operation/
 │   ├── IOperationResult.kt             # Version-agnostic interface (R4 + DSTU3 both implement)
-│   ├── ErrorStrategy.kt                # FAIL_FAST / ACCUMULATE enum
+│   ├── ErrorStrategy.kt                # FAIL_FAST / ACCUMULATE / PROPAGATE enum
 │   ├── StepMetrics.kt                  # Per-step timing and outcome data
 │   ├── DateTimeInput.kt                # Sealed wrapper for date/time values (collapses overloads)
 │   └── FhirPath.kt                     # Fluent FHIRPath expression builder (version-agnostic)
@@ -1868,7 +1891,7 @@ When `fhirmason-spring` is on the classpath in a Spring Boot application, a `Fhi
 
 ```yaml
 fhirmason:
-  error-strategy: ACCUMULATE   # FAIL_FAST | ACCUMULATE (default: ACCUMULATE)
+  error-strategy: ACCUMULATE   # FAIL_FAST | ACCUMULATE | PROPAGATE (default: ACCUMULATE)
   metrics:
     enabled: true               # enable per-step timing (default: false)
 ```
@@ -1948,12 +1971,12 @@ FHIRMason is fully usable from Java with an unbroken fluent chain.
 // Single resource — name defaults to fhirType().lowercase()
 OperationResult<Patient> result = OperationResult.of(patient);
 
-// Single resource with explicit name and error strategy
-OperationResult<Patient> result = OperationResult.of(patient, "patient", ErrorStrategy.ACCUMULATE);
+// Single resource with explicit name; switch to ACCUMULATE via fluent method
+OperationResult<Patient> result = OperationResult.of(patient, "patient")
+    .useErrorStrategy(ErrorStrategy.ACCUMULATE);
 
 // Empty pipeline
 OperationResult<Base> empty = OperationResult.empty();
-OperationResult<Base> accumulating = OperationResult.empty(ErrorStrategy.ACCUMULATE);
 
 // From existing FHIR resources
 OperationResult<Base> fromParams = OperationResult.fromParameters(parameters);

--- a/fhirmason-api/src/main/java/dev/ratkay/operation/ErrorStrategy.kt
+++ b/fhirmason-api/src/main/java/dev/ratkay/operation/ErrorStrategy.kt
@@ -7,8 +7,13 @@ package dev.ratkay.operation
  *   the pipeline short-circuits and only the error outcomes are accumulated.
  * - [ACCUMULATE]: every step is attempted regardless of prior errors; all outcomes
  *   (successes and failures) are collected before the caller inspects the result.
+ * - [PROPAGATE]: lambda exceptions bubble to the caller unchanged, without being wrapped
+ *   as [dev.ratkay.operation.IOperationResult] outcomes. Useful when the caller's
+ *   infrastructure (e.g. Spring `@ControllerAdvice`) already handles exceptions and needs
+ *   the original exception type, stack trace, and message fidelity intact.
  */
 enum class ErrorStrategy {
     FAIL_FAST,
-    ACCUMULATE
+    ACCUMULATE,
+    PROPAGATE
 }

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationOutcomeExtensions.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationOutcomeExtensions.kt
@@ -36,3 +36,15 @@ internal fun warningOutcome(e: Exception): OperationOutcome =
     errorOutcome(e).also { outcome ->
         outcome.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
     }
+
+/**
+ * Builds an ERROR-severity [OperationOutcome] with [IssueType.NOTFOUND] code from a plain
+ * diagnostic message string.  Used by factory methods that detect a missing primary resource.
+ */
+internal fun messageOutcome(diagnostics: String): OperationOutcome = OperationOutcome().apply {
+    addIssue().apply {
+        severity = OperationOutcome.IssueSeverity.ERROR
+        code = OperationOutcome.IssueType.NOTFOUND
+        this.diagnostics = diagnostics
+    }
+}

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
@@ -125,7 +125,8 @@ class OperationResult<T> private constructor(
         result: R?,
         params: MutableMap<String, MutableList<Base>> = parameters,
         timingEnabled: Boolean = this.timingEnabled,
-        extensions: MutableMap<String, MutableMap<Base, List<Extension>>> = this.extensions
+        extensions: MutableMap<String, MutableMap<Base, List<Extension>>> = this.extensions,
+        errorStrategy: ErrorStrategy = this.errorStrategy
     ): OperationResult<R> = OperationResult(params, result, outcomes, errorStrategy, failedTasks, timingEnabled, metrics, extensions)
 
     private fun shallowCopyParams(): MutableMap<String, MutableList<Base>> =
@@ -146,6 +147,17 @@ class OperationResult<T> private constructor(
 
     /** Returns a snapshot of [StepMetrics] collected so far. Empty when [timed] was not called. */
     override fun getMetrics(): List<StepMetrics> = metrics.toList()
+
+    /**
+     * Returns a new pipeline with [strategy] applied to all subsequent steps.
+     *
+     * Can be called at any point in the chain — changes take effect from that step onwards.
+     * The default strategy is [ErrorStrategy.FAIL_FAST]; call this method to switch to
+     * [ErrorStrategy.ACCUMULATE] or [ErrorStrategy.PROPAGATE] mid-chain.
+     *
+     * @param strategy the [ErrorStrategy] to apply from this point in the pipeline onwards.
+     */
+    fun useErrorStrategy(strategy: ErrorStrategy): OperationResult<T> = copyWith(result, errorStrategy = strategy)
 
     // Private logging/metrics helpers
 
@@ -174,6 +186,7 @@ class OperationResult<T> private constructor(
         block: () -> OperationResult<R>
     ): OperationResult<R> {
         if (shouldSkip()) return onSkip()
+        if (errorStrategy == ErrorStrategy.PROPAGATE) return block()
         val (result, duration) = measureTimedValue { runCatching { block() } }
         val durationMs = duration.inWholeMilliseconds
         return result.fold(
@@ -1471,17 +1484,21 @@ class OperationResult<T> private constructor(
 
     /**
      * Extracts the first value of type [R] stored under [name] and sets it as the pipeline head.
-     * Throws [IllegalArgumentException] if no value of [R] exists under [name].
+     *
+     * Follows Pattern A: when no value of [R] exists under [name], records an ERROR-severity
+     * [OperationOutcome] and returns a skipped (null-head) result. The pipeline head type changes
+     * from [T] to [R] on success, and the active [ErrorStrategy] is respected (FAIL_FAST will skip
+     * all subsequent steps, ACCUMULATE will continue).
+     *
+     * @param name the parameter-map key to look up.
+     * @param type the expected [KClass] of the stored resource.
      */
-    fun <R : Base> extractParam(name: String, type: KClass<R>): OperationResult<R> {
-        val value = parameters[name]
-            ?.filterIsInstance(type.java)
-            ?.firstOrNull()
-            ?: throw IllegalArgumentException(
-                "No value of type '${type.simpleName}' found under key '$name'"
-            )
-        return copyWith(value)
-    }
+    fun <R : Base> extractParam(name: String, type: KClass<R>): OperationResult<R> =
+        runBuilderStep(name) {
+            val value = parameters[name]?.filterIsInstance(type.java)?.firstOrNull()
+                ?: error("No value of type '${type.simpleName}' found under key '$name'")
+            copyWith(value)
+        }
 
     /** Reified overload — no [KClass] argument needed at call sites. */
     inline fun <reified R : Base> extractParam(name: String): OperationResult<R> =
@@ -1713,15 +1730,15 @@ class OperationResult<T> private constructor(
          * parameter-map entry, stored under [name] (or [value]'s [Base.fhirType] lowercase when
          * [name] is `null`).
          *
-         * @param errorStrategy controls how subsequent steps behave when an error is recorded
+         * The pipeline starts with [ErrorStrategy.FAIL_FAST]; call [useErrorStrategy] to change it.
          */
         @JvmStatic
         @JvmOverloads
-        fun <T : Base> of(value: T, name: String? = null, errorStrategy: ErrorStrategy = ErrorStrategy.FAIL_FAST): OperationResult<T> {
+        fun <T : Base> of(value: T, name: String? = null): OperationResult<T> {
             val key = name ?: value.fhirType().lowercase()
             val params = mutableMapOf<String, MutableList<Base>>()
             params.getOrPut(key) { mutableListOf() }.add(value)
-            return OperationResult(params, value, mutableListOf(), errorStrategy, mutableMapOf())
+            return OperationResult(params, value, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
         }
 
         /**
@@ -1732,14 +1749,14 @@ class OperationResult<T> private constructor(
          * Accepts any [Collection] (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
          * always stored as a [List].
          *
-         * @param errorStrategy controls how subsequent steps behave when an error is recorded
+         * The pipeline starts with [ErrorStrategy.FAIL_FAST]; call [useErrorStrategy] to change it.
          */
         @JvmStatic
         @JvmOverloads
-        fun <T : Base> of(values: Collection<T>, name: String? = null, errorStrategy: ErrorStrategy = ErrorStrategy.FAIL_FAST): OperationResult<List<T>> {
+        fun <T : Base> of(values: Collection<T>, name: String? = null): OperationResult<List<T>> {
             val list = values.toList()
             val params = mutableMapOf<String, MutableList<Base>>()
-            val instance = OperationResult(params, list, mutableListOf(), errorStrategy, mutableMapOf())
+            val instance = OperationResult(params, list, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
             instance.addToParameters(list, name)
             return instance
         }
@@ -1768,7 +1785,12 @@ class OperationResult<T> private constructor(
          * Like [fromParameters] but also sets the typed pipeline head to the first value stored
          * under [primaryKey] that is an instance of [type].
          *
-         * @throws IllegalArgumentException if no value of [type] exists under [primaryKey].
+         * When no value of [type] is found under [primaryKey], returns a pipeline with
+         * [hasErrors] `== true` and a null head (consistent with Pattern A mid-pipeline steps).
+         * Call [useErrorStrategy] on the returned result to change the strategy if needed.
+         *
+         * @param primaryKey the parameter-map key whose value should become the pipeline head.
+         * @param type the expected [KClass] of the primary resource.
          */
         @JvmStatic
         fun <T : Base> fromParametersTyped(
@@ -1777,13 +1799,13 @@ class OperationResult<T> private constructor(
             type: KClass<T>
         ): OperationResult<T> {
             val (params, exts) = ParameterMapSerializer.flatten(parameters)
-            val primary = params[primaryKey]
-                ?.filterIsInstance(type.java)
-                ?.firstOrNull()
-                ?: throw IllegalArgumentException(
-                    "No value of type '${type.simpleName}' found under key '$primaryKey'"
-                )
-            return OperationResult(params, primary, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf(), extensions = exts)
+            val primary = params[primaryKey]?.filterIsInstance(type.java)?.firstOrNull()
+            return if (primary != null) {
+                OperationResult(params, primary, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf(), extensions = exts)
+            } else {
+                val outcome = messageOutcome("No value of type '${type.simpleName}' found under key '$primaryKey'")
+                OperationResult(params, null, mutableListOf(outcome), ErrorStrategy.FAIL_FAST, mutableMapOf(), extensions = exts)
+            }
         }
 
         /** Reified overload of [fromParametersTyped] — no [KClass] argument needed at call sites. */
@@ -1796,7 +1818,8 @@ class OperationResult<T> private constructor(
          * Java-friendly overload of [fromParametersTyped] — accepts a [Class] instead of a [KClass]
          * so Java callers can write `fromParametersTyped(params, "patient", Patient.class)`.
          *
-         * @throws IllegalArgumentException if no value of [type] exists under [primaryKey].
+         * When no value of [type] is found under [primaryKey], returns a pipeline with
+         * [hasErrors] `== true` and a null head.
          */
         @JvmStatic
         fun <T : Base> fromParametersTyped(
@@ -1858,7 +1881,11 @@ class OperationResult<T> private constructor(
          * [fromBundle] overload).  All resources are loaded into the parameter map; only the
          * head is narrowed to [T].
          *
-         * @throws IllegalArgumentException if no resource of [type] exists under [primaryKey].
+         * When no resource of [type] is found under [primaryKey], returns a pipeline with
+         * [hasErrors] `== true` and a null head (consistent with Pattern A mid-pipeline steps).
+         *
+         * @param primaryKey the parameter-map key whose value should become the pipeline head.
+         * @param type the expected [KClass] of the primary resource.
          */
         @JvmStatic
         fun <T : Resource> fromBundleTyped(
@@ -1873,16 +1900,21 @@ class OperationResult<T> private constructor(
                     val key = entry.resource.fhirType().lowercase()
                     params.getOrPut(key) { mutableListOf() }.add(entry.resource)
                 }
-            val primary = params[primaryKey]
-                ?.filterIsInstance(type.java)
-                ?.firstOrNull()
-                ?: throw IllegalArgumentException(
-                    "No value of type '${type.simpleName}' found under key '$primaryKey'"
-                )
-            return OperationResult(params, primary, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
+            val primary = params[primaryKey]?.filterIsInstance(type.java)?.firstOrNull()
+            return if (primary != null) {
+                OperationResult(params, primary, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
+            } else {
+                val outcome = messageOutcome("No value of type '${type.simpleName}' found under key '$primaryKey'")
+                OperationResult(params, null, mutableListOf(outcome), ErrorStrategy.FAIL_FAST, mutableMapOf())
+            }
         }
 
-        /** Java-friendly overload of [fromBundleTyped] — accepts [Class] instead of [KClass]. */
+        /**
+         * Java-friendly overload of [fromBundleTyped] — accepts [Class] instead of [KClass].
+         *
+         * When no resource of [type] is found under [primaryKey], returns a pipeline with
+         * [hasErrors] `== true` and a null head.
+         */
         @JvmStatic
         fun <T : Resource> fromBundleTyped(
             bundle: Bundle,
@@ -1906,15 +1938,16 @@ class OperationResult<T> private constructor(
          *
          * [getResult] will throw [IllegalStateException] until a value is added via [add] or similar.
          * [toParameters] returns a valid empty [Parameters] resource.
+         *
+         * The pipeline starts with [ErrorStrategy.FAIL_FAST]; call [useErrorStrategy] to change it.
          */
         @JvmStatic
-        @JvmOverloads
-        fun empty(errorStrategy: ErrorStrategy = ErrorStrategy.FAIL_FAST): OperationResult<Base> =
+        fun empty(): OperationResult<Base> =
             OperationResult(
                 mutableMapOf(),
                 null,
                 mutableListOf(),
-                errorStrategy,
+                ErrorStrategy.FAIL_FAST,
                 mutableMapOf()
             )
 

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultComplexTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultComplexTest.kt
@@ -69,7 +69,7 @@ class OperationResultComplexTest {
 
     @Test
     fun `ACCUMULATE strategy collects all errors while successful steps still produce values`() {
-        val result = OperationResult.of(patient("p1"), "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient("p1"), "patient").useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .add("step1") { Observation().apply { id = "obs1" } }
             .add("step2") { error("step2 failed") }
             .add("step3") { Encounter().apply { id = "enc1" } }
@@ -180,7 +180,7 @@ class OperationResultComplexTest {
     fun `guardFalse records WARNING and pipeline continues in ACCUMULATE after conditional skip`() {
         val inactivePatient = patient("p2").apply { active = false }
 
-        val result = OperationResult.of(inactivePatient, "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(inactivePatient, "patient").useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .whenTrue(inactivePatient.active) {
                 addString("status", "active") // must not run
             }
@@ -298,10 +298,10 @@ class OperationResultComplexTest {
     @Test
     fun `merging two results with distinct keys combines parameter maps and accumulates outcomes`() {
         // Both pipelines have a warning (Pattern B step failure)
-        val a = OperationResult.of(patient("p1"), "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+        val a = OperationResult.of(patient("p1"), "patient").useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .addOrSkip<Observation>("obs") { error("optional obs failed") }
 
-        val b = OperationResult.of(encounter("e1"), "encounter", errorStrategy = ErrorStrategy.ACCUMULATE)
+        val b = OperationResult.of(encounter("e1"), "encounter").useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .addString("status", "finished")
 
         val merged = a.merge(b)

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultConditionalTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultConditionalTest.kt
@@ -75,7 +75,7 @@ class OperationResultConditionalTest {
 
     @Test
     fun `whenTrue - merges inner outcomes into outer result`() {
-        val result = OperationResult.of(patient(), "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient(), "patient").useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .whenTrue(true) {
                 add("appt") { appointment() }
                     .add { error("inner error") }
@@ -241,7 +241,7 @@ class OperationResultConditionalTest {
     @Test
     fun `guardFalse - pipeline continues and accumulates resources after guard`() {
         val appt = appointment()
-        val result = OperationResult.of(patient(), "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient(), "patient").useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .guardFalse(false, "inactive")
             .add("appt") { appt }
 

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFhirErrorHandlingTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFhirErrorHandlingTest.kt
@@ -11,9 +11,11 @@ import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.not
+import org.hl7.fhir.dstu3.model.Bundle
 import org.hl7.fhir.dstu3.model.Coverage
 import org.hl7.fhir.dstu3.model.Encounter
 import org.hl7.fhir.dstu3.model.OperationOutcome
+import org.hl7.fhir.dstu3.model.Parameters
 import org.hl7.fhir.dstu3.model.Patient
 import org.hl7.fhir.dstu3.model.Resource
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -99,7 +101,7 @@ class OperationResultFhirErrorHandlingTest {
     fun `add - BaseServerResponseException stops pipeline in FAIL_FAST mode`() {
         var secondStepExecuted = false
 
-        OperationResult.of(patient(), errorStrategy = ErrorStrategy.FAIL_FAST)
+        OperationResult.of(patient())
             .add("enc") { throw InvalidRequestException("server error") }
             .add("cov") { secondStepExecuted = true; Coverage() }
 
@@ -110,7 +112,7 @@ class OperationResultFhirErrorHandlingTest {
     fun `add - BaseServerResponseException continues pipeline in ACCUMULATE mode`() {
         var secondStepExecuted = false
 
-        val result = OperationResult.of(patient(), errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .add("enc") { throw InvalidRequestException("server error") }
             .add("cov") { secondStepExecuted = true; Coverage() }
 
@@ -280,6 +282,157 @@ class OperationResultFhirErrorHandlingTest {
         assertThat(merged.issue, hasSize(1))
         assertThat(merged.issue[0].extension, hasSize(1))
         assertThat(merged.issue[0].extension[0].url, equalTo("http://example.org/ext"))
+    }
+
+    // ── PROPAGATE strategy ───────────────────────────────────────────────────
+
+    @Test
+    fun `add with PROPAGATE strategy - exception propagates raw, not wrapped as outcome`() {
+        val pipeline = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.PROPAGATE)
+        assertThrows<RuntimeException> {
+            pipeline.add("coverage") { throw RuntimeException("boom") }
+        }
+    }
+
+    @Test
+    fun `addAll with PROPAGATE strategy - exception propagates raw`() {
+        val pipeline = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.PROPAGATE)
+        assertThrows<IllegalStateException> {
+            pipeline.addAll<Patient>("coverage") { throw IllegalStateException("addAll boom") }
+        }
+    }
+
+    @Test
+    fun `addFrom with PROPAGATE strategy - exception propagates raw`() {
+        val pipeline = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.PROPAGATE)
+        assertThrows<RuntimeException> {
+            pipeline.addFrom<Patient, Patient>("test", Patient::class) { throw RuntimeException("addFrom boom") }
+        }
+    }
+
+    @Test
+    fun `flatMap with PROPAGATE strategy - exception propagates raw`() {
+        val pipeline = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.PROPAGATE)
+        assertThrows<RuntimeException> {
+            pipeline.flatMap<Patient> { throw RuntimeException("flatMap boom") }
+        }
+    }
+
+    @Test
+    fun `PROPAGATE - no outcomes accumulated after propagation (outcomes list stays empty)`() {
+        val pipeline = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.PROPAGATE)
+        assertThrows<RuntimeException> {
+            pipeline.add("coverage") { throw RuntimeException("boom") }
+        }
+        assertTrue(pipeline.isSuccessful())
+        assertThat(pipeline.getOutcomes(), hasSize(0))
+    }
+
+    @Test
+    fun `PROPAGATE - successful steps complete normally and accumulate results`() {
+        val result = OperationResult.of(patient())
+            .useErrorStrategy(ErrorStrategy.PROPAGATE)
+            .add("encounter") { Encounter().apply { setId("e1") } }
+
+        assertTrue(result.isSuccessful())
+        assertNotNull(result.getResult())
+    }
+
+    @Test
+    fun `useErrorStrategy - mid-chain switch from FAIL_FAST to PROPAGATE takes effect from next step`() {
+        val result = OperationResult.of(patient())
+            .add("encounter") { throw RuntimeException("step1 fails") }
+            .useErrorStrategy(ErrorStrategy.PROPAGATE)
+
+        assertTrue(result.hasErrors())
+        assertThrows<RuntimeException> {
+            result.add("coverage") { throw RuntimeException("step2 propagates") }
+        }
+    }
+
+    @Test
+    fun `useErrorStrategy - mid-chain switch from ACCUMULATE to FAIL_FAST skips subsequent steps`() {
+        var step2Ran = false
+        val result = OperationResult.of(patient())
+            .useErrorStrategy(ErrorStrategy.ACCUMULATE)
+            .add("enc") { throw RuntimeException("step1 fails") }
+            .useErrorStrategy(ErrorStrategy.FAIL_FAST)
+            .add("cov") { step2Ran = true; Coverage() }
+
+        assertTrue(result.hasErrors())
+        assertFalse(step2Ran)
+    }
+
+    // ── fromParametersTyped error outcomes ───────────────────────────────────
+
+    @Test
+    fun `fromParametersTyped - missing key returns hasErrors true and null head`() {
+        val result = OperationResult.fromParametersTyped(Parameters(), "patient", Patient::class)
+        assertTrue(result.hasErrors())
+    }
+
+    @Test
+    fun `fromParametersTyped - missing key outcome has NOTFOUND code`() {
+        val result = OperationResult.fromParametersTyped(Parameters(), "patient", Patient::class)
+        assertThat(result.getOutcomes(), hasSize(1))
+        assertThat(result.getOutcomes()[0].issueFirstRep.severity, equalTo(OperationOutcome.IssueSeverity.ERROR))
+        assertThat(result.getOutcomes()[0].issueFirstRep.code, equalTo(OperationOutcome.IssueType.NOTFOUND))
+    }
+
+    @Test
+    fun `fromParametersTyped - found key returns isSuccessful true with correct typed head`() {
+        val p = Patient().apply { setId("p1") }
+        val params = Parameters().apply { addParameter().apply { name = "patient"; resource = p } }
+        val result = OperationResult.fromParametersTyped(params, "patient", Patient::class)
+        assertTrue(result.isSuccessful())
+        assertThat(result.getResult().idElement.idPart, equalTo("p1"))
+    }
+
+    // ── fromBundleTyped error outcomes ───────────────────────────────────────
+
+    @Test
+    fun `fromBundleTyped - missing key returns hasErrors true and null head`() {
+        val result = OperationResult.fromBundleTyped(Bundle(), "patient", Patient::class)
+        assertTrue(result.hasErrors())
+    }
+
+    @Test
+    fun `fromBundleTyped - found resource returns isSuccessful true`() {
+        val p = Patient().apply { setId("p1") }
+        val bundle = Bundle().apply { addEntry().resource = p }
+        val result = OperationResult.fromBundleTyped(bundle, "patient", Patient::class)
+        assertTrue(result.isSuccessful())
+        assertThat(result.getResult().idElement.idPart, equalTo("p1"))
+    }
+
+    // ── extractParam Pattern A ───────────────────────────────────────────────
+
+    @Test
+    fun `extractParam - missing key adds ERROR outcome and skips (Pattern A)`() {
+        val result = OperationResult.of(patient())
+            .extractParam("missing", Coverage::class)
+        assertTrue(result.hasErrors())
+        assertThat(result.getOutcomes(), hasSize(1))
+        assertThat(result.getOutcomes()[0].issueFirstRep.severity, equalTo(OperationOutcome.IssueSeverity.ERROR))
+    }
+
+    @Test
+    fun `extractParam - found key changes head and leaves no error`() {
+        val p = patient()
+        val result = OperationResult.of(p)
+            .extractParam("patient", Patient::class)
+        assertTrue(result.isSuccessful())
+        assertSame(p, result.getResult())
+    }
+
+    @Test
+    fun `extractParam - missing key with FAIL_FAST skips subsequent steps`() {
+        var step2Ran = false
+        val result = OperationResult.of(patient())
+            .extractParam("missing", Coverage::class)
+            .add("enc") { step2Ran = true; Encounter() }
+        assertTrue(result.hasErrors())
+        assertFalse(step2Ran)
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFhirPathTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFhirPathTest.kt
@@ -272,7 +272,7 @@ class OperationResultFhirPathTest {
     fun `guardPath preserves head and pipeline continues in ACCUMULATE mode`() {
         val patient = Patient().apply { active = false }
 
-        val result = OperationResult.of(patient, errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient).useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .guardPath("active = true", "not active")
             .add("note") { StringType("after-guard") }
 

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFromTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFromTest.kt
@@ -330,25 +330,23 @@ class OperationResultFromTest {
     }
 
     @Test
-    fun `fromParametersTyped - throws when primary key is absent`() {
+    fun `fromParametersTyped - returns error outcome when primary key is absent`() {
         val fhirParams = Parameters().apply {
             addParameter().apply { name = "appt"; resource = appointment() }
         }
 
-        assertThrows<IllegalArgumentException> {
-            OperationResult.fromParametersTyped<Patient>(fhirParams, "patient")
-        }
+        val result = OperationResult.fromParametersTyped<Patient>(fhirParams, "patient")
+        assertTrue(result.hasErrors())
     }
 
     @Test
-    fun `fromParametersTyped - throws when key exists but type does not match`() {
+    fun `fromParametersTyped - returns error outcome when key exists but type does not match`() {
         val fhirParams = Parameters().apply {
             addParameter().apply { name = "patient"; resource = appointment() } // wrong type
         }
 
-        assertThrows<IllegalArgumentException> {
-            OperationResult.fromParametersTyped<Patient>(fhirParams, "patient")
-        }
+        val result = OperationResult.fromParametersTyped<Patient>(fhirParams, "patient")
+        assertTrue(result.hasErrors())
     }
 
     @Test
@@ -582,27 +580,25 @@ class OperationResultFromTest {
     }
 
     @Test
-    fun `fromBundleTyped - throws when primary key is absent`() {
+    fun `fromBundleTyped - returns error outcome when primary key is absent`() {
         val bundle = Bundle().apply {
             type = Bundle.BundleType.COLLECTION
             addEntry().resource = appointment()
         }
 
-        assertThrows<IllegalArgumentException> {
-            OperationResult.fromBundleTyped<Patient>(bundle, "patient")
-        }
+        val result = OperationResult.fromBundleTyped<Patient>(bundle, "patient")
+        assertTrue(result.hasErrors())
     }
 
     @Test
-    fun `fromBundleTyped - throws when key exists but type does not match`() {
+    fun `fromBundleTyped - returns error outcome when key exists but type does not match`() {
         val bundle = Bundle().apply {
             type = Bundle.BundleType.COLLECTION
             addEntry().resource = appointment()
         }
 
-        assertThrows<IllegalArgumentException> {
-            OperationResult.fromBundleTyped<Patient>(bundle, "appointment")
-        }
+        val result = OperationResult.fromBundleTyped<Patient>(bundle, "appointment")
+        assertTrue(result.hasErrors())
     }
 
     // ── extractParam / extractParamList ──────────────────────────────────────
@@ -632,25 +628,23 @@ class OperationResultFromTest {
     }
 
     @Test
-    fun `extractParam throws when key does not exist`() {
+    fun `extractParam returns error outcome when key does not exist`() {
         val params = Parameters()
-        val or = OperationResult.fromParameters(params)
+        val result = OperationResult.fromParameters(params)
+            .extractParam<Patient>("patient")
 
-        assertThrows<IllegalArgumentException> {
-            or.extractParam<Patient>("patient")
-        }
+        assertTrue(result.hasErrors())
     }
 
     @Test
-    fun `extractParam throws when key exists but type does not match`() {
+    fun `extractParam returns error outcome when key exists but type does not match`() {
         val params = Parameters().apply {
             addParameter().apply { name = "patient"; resource = appointment() }
         }
-        val or = OperationResult.fromParameters(params)
+        val result = OperationResult.fromParameters(params)
+            .extractParam<Patient>("patient")
 
-        assertThrows<IllegalArgumentException> {
-            or.extractParam<Patient>("patient")
-        }
+        assertTrue(result.hasErrors())
     }
 
     @Test

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultIdentifierTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultIdentifierTest.kt
@@ -112,7 +112,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifierWithSystem respects FAIL_FAST and skips when already errored`() {
         var builderCalled = false
-        val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients", ErrorStrategy.FAIL_FAST)
+        val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
                 throw RuntimeException("first failure")
             }

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultMapHeadTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultMapHeadTest.kt
@@ -167,7 +167,7 @@ class OperationResultMapHeadTest {
 
         // Use addOrSkip (Pattern B) so the head is preserved after the failure,
         // allowing mapHead to receive it in ACCUMULATE mode.
-        OperationResult.of(patient(), "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+        OperationResult.of(patient(), "patient").useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .addOrSkip("extra") { error("earlier warning") }
             .mapHead { p ->
                 transformCalled = true

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultMetaTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultMetaTest.kt
@@ -82,7 +82,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTagWithSystem respects FAIL_FAST`() {
         var builderCalled = false
-        val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients", ErrorStrategy.FAIL_FAST)
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
                 throw RuntimeException("first failure")
             }
@@ -464,7 +464,7 @@ class OperationResultMetaTest {
     fun `addFromHavingMetaProfile respects FAIL_FAST`() {
         var builderCalled = false
         val url = "http://hl7.org/fhir/StructureDefinition/us-core-patient"
-        val result = OperationResult.of(patientWithProfile(url), "patients", ErrorStrategy.FAIL_FAST)
+        val result = OperationResult.of(patientWithProfile(url), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile(url)) { _ -> throw RuntimeException("first failure") }
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile(url)) { _ -> builderCalled = true; OperationOutcome() }
 

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultRetryTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultRetryTest.kt
@@ -207,7 +207,7 @@ class OperationResultRetryTest {
     @Test
     fun `addWithRetry works in ACCUMULATE mode after prior error`() {
         var attempts = 0
-        val result = OperationResult.of(patient(), errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .add("enc") { throw RuntimeException("non-fatal") }
             .addWithRetry("enc2", maxAttempts = 3, initialDelayMs = 0) {
                 attempts++
@@ -316,7 +316,7 @@ class OperationResultRetryTest {
     fun `addWithRetryUsing does not retry when head is null in ACCUMULATE mode`() {
         var builderCalls = 0
         // First add fails → head becomes null. addWithRetryUsing should record Pattern A once, not maxAttempts times.
-        val result = OperationResult.of(patient(), errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .add("enc") { throw RuntimeException("step 1 fails") }
             .addWithRetryUsing("obs", maxAttempts = 5, initialDelayMs = 0) { _ ->
                 builderCalls++

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultTest.kt
@@ -901,7 +901,7 @@ class OperationResultTest {
 
     @Test
     fun `add - exception in ACCUMULATE continues pipeline and collects outcome`() {
-        val result = OperationResult.of(patient(), errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .add { error("step 1 failed") }
             .add { appointment() }
 
@@ -912,7 +912,7 @@ class OperationResultTest {
 
     @Test
     fun `ACCUMULATE - multiple failing steps collect all outcomes`() {
-        val result = OperationResult.of(patient(), errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .add { error("step 1 failed") }
             .add { error("step 2 failed") }
             .add { appointment() }
@@ -995,7 +995,7 @@ class OperationResultTest {
 
     @Test
     fun `toOperationOutcome - merges all collected issues into single OperationOutcome`() {
-        val result = OperationResult.of(patient(), errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .add { error("step 1 failed") }
             .add { error("step 2 failed") }
 
@@ -1497,7 +1497,7 @@ class OperationResultTest {
     fun `mapStored named respects FAIL_FAST and returns immediately`() {
         val original = patient()
         var called = false
-        val result = OperationResult.of(original, "patient", ErrorStrategy.FAIL_FAST)
+        val result = OperationResult.of(original, "patient")
             .add { throw RuntimeException("first") }
             .mapStored("patient", Patient::class) { called = true; patient() }
 
@@ -1589,7 +1589,7 @@ class OperationResultTest {
     fun `mapStored unkeyed respects FAIL_FAST and returns immediately`() {
         val original = patient()
         var called = false
-        val result = OperationResult.of(original, "patient", ErrorStrategy.FAIL_FAST)
+        val result = OperationResult.of(original, "patient")
             .add { throw RuntimeException("first") }
             .mapStored(Patient::class) { called = true; patient() }
 
@@ -2155,7 +2155,7 @@ class OperationResultTest {
     @Test
     fun `addString - pipeline continues in ACCUMULATE after exception and head is preserved`() {
         val patient = patient()
-        val result = OperationResult.of(patient, errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient).useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .addStringUsing("label") { error("boom") }
             .addString("other", "ok")
 
@@ -2390,7 +2390,7 @@ class OperationResultTest {
 
     @Test
     fun `addPart is skipped when pipeline has errors in FAIL_FAST`() {
-        val result = OperationResult.of(patient(), errorStrategy = ErrorStrategy.FAIL_FAST)
+        val result = OperationResult.of(patient())
             .add { throw RuntimeException("induced failure") }
             .addPart("address") { addString("city", "Springfield") }
 
@@ -2455,7 +2455,7 @@ class OperationResultTest {
 
     @Test
     fun `empty with ACCUMULATE error strategy`() {
-        val result = OperationResult.empty(ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.empty().useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .add { throw RuntimeException("induced failure") }
             .add("patient") { patient() }
 

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationOutcomeExtensions.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationOutcomeExtensions.kt
@@ -48,3 +48,15 @@ internal fun warningOutcome(e: Exception): OperationOutcome =
     errorOutcome(e).also { outcome ->
         outcome.issue.forEach { it.severity = OperationOutcome.IssueSeverity.WARNING }
     }
+
+/**
+ * Builds an ERROR-severity [OperationOutcome] with [IssueType.NOTFOUND] code from a plain
+ * diagnostic message string.  Used by factory methods that detect a missing primary resource.
+ */
+internal fun messageOutcome(diagnostics: String): OperationOutcome = OperationOutcome().apply {
+    addIssue().apply {
+        severity = OperationOutcome.IssueSeverity.ERROR
+        code = OperationOutcome.IssueType.NOTFOUND
+        this.diagnostics = diagnostics
+    }
+}

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -126,7 +126,8 @@ class OperationResult<T> private constructor(
         result: R?,
         params: MutableMap<String, MutableList<Base>> = parameters,
         timingEnabled: Boolean = this.timingEnabled,
-        extensions: MutableMap<String, MutableMap<Base, List<Extension>>> = this.extensions
+        extensions: MutableMap<String, MutableMap<Base, List<Extension>>> = this.extensions,
+        errorStrategy: ErrorStrategy = this.errorStrategy
     ): OperationResult<R> = OperationResult(params, result, outcomes, errorStrategy, failedTasks, timingEnabled, metrics, extensions)
 
     private fun shallowCopyParams(): MutableMap<String, MutableList<Base>> =
@@ -147,6 +148,17 @@ class OperationResult<T> private constructor(
 
     /** Returns a snapshot of [StepMetrics] collected so far. Empty when [timed] was not called. */
     override fun getMetrics(): List<StepMetrics> = metrics.toList()
+
+    /**
+     * Returns a new pipeline with [strategy] applied to all subsequent steps.
+     *
+     * Can be called at any point in the chain — changes take effect from that step onwards.
+     * The default strategy is [ErrorStrategy.FAIL_FAST]; call this method to switch to
+     * [ErrorStrategy.ACCUMULATE] or [ErrorStrategy.PROPAGATE] mid-chain.
+     *
+     * @param strategy the [ErrorStrategy] to apply from this point in the pipeline onwards.
+     */
+    fun useErrorStrategy(strategy: ErrorStrategy): OperationResult<T> = copyWith(result, errorStrategy = strategy)
 
     // Private logging/metrics helpers
 
@@ -175,6 +187,7 @@ class OperationResult<T> private constructor(
         block: () -> OperationResult<R>
     ): OperationResult<R> {
         if (shouldSkip()) return onSkip()
+        if (errorStrategy == ErrorStrategy.PROPAGATE) return block()
         val (result, duration) = measureTimedValue { runCatching { block() } }
         val durationMs = duration.inWholeMilliseconds
         return result.fold(
@@ -1478,17 +1491,21 @@ class OperationResult<T> private constructor(
 
     /**
      * Extracts the first value of type [R] stored under [name] and sets it as the pipeline head.
-     * Throws [IllegalArgumentException] if no value of [R] exists under [name].
+     *
+     * Follows Pattern A: when no value of [R] exists under [name], records an ERROR-severity
+     * [OperationOutcome] and returns a skipped (null-head) result. The pipeline head type changes
+     * from [T] to [R] on success, and the active [ErrorStrategy] is respected (FAIL_FAST will skip
+     * all subsequent steps, ACCUMULATE will continue).
+     *
+     * @param name the parameter-map key to look up.
+     * @param type the expected [KClass] of the stored resource.
      */
-    fun <R : Base> extractParam(name: String, type: KClass<R>): OperationResult<R> {
-        val value = parameters[name]
-            ?.filterIsInstance(type.java)
-            ?.firstOrNull()
-            ?: throw IllegalArgumentException(
-                "No value of type '${type.simpleName}' found under key '$name'"
-            )
-        return copyWith(value)
-    }
+    fun <R : Base> extractParam(name: String, type: KClass<R>): OperationResult<R> =
+        runBuilderStep(name) {
+            val value = parameters[name]?.filterIsInstance(type.java)?.firstOrNull()
+                ?: error("No value of type '${type.simpleName}' found under key '$name'")
+            copyWith(value)
+        }
 
     /** Reified overload — no [KClass] argument needed at call sites. */
     inline fun <reified R : Base> extractParam(name: String): OperationResult<R> =
@@ -1720,15 +1737,15 @@ class OperationResult<T> private constructor(
          * parameter-map entry, stored under [name] (or [value]'s [Base.fhirType] lowercase when
          * [name] is `null`).
          *
-         * @param errorStrategy controls how subsequent steps behave when an error is recorded
+         * The pipeline starts with [ErrorStrategy.FAIL_FAST]; call [useErrorStrategy] to change it.
          */
         @JvmStatic
         @JvmOverloads
-        fun <T : Base> of(value: T, name: String? = null, errorStrategy: ErrorStrategy = ErrorStrategy.FAIL_FAST): OperationResult<T> {
+        fun <T : Base> of(value: T, name: String? = null): OperationResult<T> {
             val key = name ?: value.fhirType().lowercase()
             val params = mutableMapOf<String, MutableList<Base>>()
             params.getOrPut(key) { mutableListOf() }.add(value)
-            return OperationResult(params, value, mutableListOf(), errorStrategy, mutableMapOf())
+            return OperationResult(params, value, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
         }
 
         /**
@@ -1739,14 +1756,14 @@ class OperationResult<T> private constructor(
          * Accepts any [Collection] (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
          * always stored as a [List].
          *
-         * @param errorStrategy controls how subsequent steps behave when an error is recorded
+         * The pipeline starts with [ErrorStrategy.FAIL_FAST]; call [useErrorStrategy] to change it.
          */
         @JvmStatic
         @JvmOverloads
-        fun <T : Base> of(values: Collection<T>, name: String? = null, errorStrategy: ErrorStrategy = ErrorStrategy.FAIL_FAST): OperationResult<List<T>> {
+        fun <T : Base> of(values: Collection<T>, name: String? = null): OperationResult<List<T>> {
             val list = values.toList()
             val params = mutableMapOf<String, MutableList<Base>>()
-            val instance = OperationResult(params, list, mutableListOf(), errorStrategy, mutableMapOf())
+            val instance = OperationResult(params, list, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
             instance.addToParameters(list, name)
             return instance
         }
@@ -1775,7 +1792,12 @@ class OperationResult<T> private constructor(
          * Like [fromParameters] but also sets the typed pipeline head to the first value stored
          * under [primaryKey] that is an instance of [type].
          *
-         * @throws IllegalArgumentException if no value of [type] exists under [primaryKey].
+         * When no value of [type] is found under [primaryKey], returns a pipeline with
+         * [hasErrors] `== true` and a null head (consistent with Pattern A mid-pipeline steps).
+         * Call [useErrorStrategy] on the returned result to change the strategy if needed.
+         *
+         * @param primaryKey the parameter-map key whose value should become the pipeline head.
+         * @param type the expected [KClass] of the primary resource.
          */
         @JvmStatic
         fun <T : Base> fromParametersTyped(
@@ -1784,13 +1806,13 @@ class OperationResult<T> private constructor(
             type: KClass<T>
         ): OperationResult<T> {
             val (params, exts) = ParameterMapSerializer.flatten(parameters)
-            val primary = params[primaryKey]
-                ?.filterIsInstance(type.java)
-                ?.firstOrNull()
-                ?: throw IllegalArgumentException(
-                    "No value of type '${type.simpleName}' found under key '$primaryKey'"
-                )
-            return OperationResult(params, primary, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf(), extensions = exts)
+            val primary = params[primaryKey]?.filterIsInstance(type.java)?.firstOrNull()
+            return if (primary != null) {
+                OperationResult(params, primary, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf(), extensions = exts)
+            } else {
+                val outcome = messageOutcome("No value of type '${type.simpleName}' found under key '$primaryKey'")
+                OperationResult(params, null, mutableListOf(outcome), ErrorStrategy.FAIL_FAST, mutableMapOf(), extensions = exts)
+            }
         }
 
         /** Reified overload of [fromParametersTyped] — no [KClass] argument needed at call sites. */
@@ -1803,7 +1825,8 @@ class OperationResult<T> private constructor(
          * Java-friendly overload of [fromParametersTyped] — accepts a [Class] instead of a [KClass]
          * so Java callers can write `fromParametersTyped(params, "patient", Patient.class)`.
          *
-         * @throws IllegalArgumentException if no value of [type] exists under [primaryKey].
+         * When no value of [type] is found under [primaryKey], returns a pipeline with
+         * [hasErrors] `== true` and a null head.
          */
         @JvmStatic
         fun <T : Base> fromParametersTyped(
@@ -1865,7 +1888,11 @@ class OperationResult<T> private constructor(
          * [fromBundle] overload).  All resources are loaded into the parameter map; only the
          * head is narrowed to [T].
          *
-         * @throws IllegalArgumentException if no resource of [type] exists under [primaryKey].
+         * When no resource of [type] is found under [primaryKey], returns a pipeline with
+         * [hasErrors] `== true` and a null head (consistent with Pattern A mid-pipeline steps).
+         *
+         * @param primaryKey the parameter-map key whose value should become the pipeline head.
+         * @param type the expected [KClass] of the primary resource.
          */
         @JvmStatic
         fun <T : Resource> fromBundleTyped(
@@ -1880,16 +1907,21 @@ class OperationResult<T> private constructor(
                     val key = entry.resource.fhirType().lowercase()
                     params.getOrPut(key) { mutableListOf() }.add(entry.resource)
                 }
-            val primary = params[primaryKey]
-                ?.filterIsInstance(type.java)
-                ?.firstOrNull()
-                ?: throw IllegalArgumentException(
-                    "No value of type '${type.simpleName}' found under key '$primaryKey'"
-                )
-            return OperationResult(params, primary, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
+            val primary = params[primaryKey]?.filterIsInstance(type.java)?.firstOrNull()
+            return if (primary != null) {
+                OperationResult(params, primary, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
+            } else {
+                val outcome = messageOutcome("No value of type '${type.simpleName}' found under key '$primaryKey'")
+                OperationResult(params, null, mutableListOf(outcome), ErrorStrategy.FAIL_FAST, mutableMapOf())
+            }
         }
 
-        /** Java-friendly overload of [fromBundleTyped] — accepts [Class] instead of [KClass]. */
+        /**
+         * Java-friendly overload of [fromBundleTyped] — accepts [Class] instead of [KClass].
+         *
+         * When no resource of [type] is found under [primaryKey], returns a pipeline with
+         * [hasErrors] `== true` and a null head.
+         */
         @JvmStatic
         fun <T : Resource> fromBundleTyped(
             bundle: Bundle,
@@ -1913,15 +1945,16 @@ class OperationResult<T> private constructor(
          *
          * [getResult] will throw [IllegalStateException] until a value is added via [add] or similar.
          * [toParameters] returns a valid empty [Parameters] resource.
+         *
+         * The pipeline starts with [ErrorStrategy.FAIL_FAST]; call [useErrorStrategy] to change it.
          */
         @JvmStatic
-        @JvmOverloads
-        fun empty(errorStrategy: ErrorStrategy = ErrorStrategy.FAIL_FAST): OperationResult<Base> =
+        fun empty(): OperationResult<Base> =
             OperationResult(
                 mutableMapOf(),
                 null,
                 mutableListOf(),
-                errorStrategy,
+                ErrorStrategy.FAIL_FAST,
                 mutableMapOf()
             )
 

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultComplexTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultComplexTest.kt
@@ -68,7 +68,7 @@ class OperationResultComplexTest {
 
     @Test
     fun `ACCUMULATE strategy collects all errors while successful steps still produce values`() {
-        val result = OperationResult.of(patient("p1"), "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient("p1"), "patient").useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .add("step1") { Observation().apply { id = "obs1" } }
             .add("step2") { error("step2 failed") }
             .add("step3") { Encounter().apply { id = "enc1" } }
@@ -179,7 +179,7 @@ class OperationResultComplexTest {
     fun `guardFalse records WARNING and pipeline continues in ACCUMULATE after conditional skip`() {
         val inactivePatient = patient("p2").apply { active = false }
 
-        val result = OperationResult.of(inactivePatient, "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(inactivePatient, "patient").useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .whenTrue(inactivePatient.active) {
                 addString("status", "active") // must not run
             }
@@ -297,10 +297,10 @@ class OperationResultComplexTest {
     @Test
     fun `merging two results with distinct keys combines parameter maps and accumulates outcomes`() {
         // Both pipelines have a warning (Pattern B step failure)
-        val a = OperationResult.of(patient("p1"), "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+        val a = OperationResult.of(patient("p1"), "patient").useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .addOrSkip<Observation>("obs") { error("optional obs failed") }
 
-        val b = OperationResult.of(encounter("e1"), "encounter", errorStrategy = ErrorStrategy.ACCUMULATE)
+        val b = OperationResult.of(encounter("e1"), "encounter").useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .addString("status", "finished")
 
         val merged = a.merge(b)

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultConditionalTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultConditionalTest.kt
@@ -75,7 +75,7 @@ class OperationResultConditionalTest {
 
     @Test
     fun `whenTrue - merges inner outcomes into outer result`() {
-        val result = OperationResult.of(patient(), "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient(), "patient").useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .whenTrue(true) {
                 add("appt") { appointment() }
                     .add { error("inner error") }
@@ -241,7 +241,7 @@ class OperationResultConditionalTest {
     @Test
     fun `guardFalse - pipeline continues and accumulates resources after guard`() {
         val appt = appointment()
-        val result = OperationResult.of(patient(), "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient(), "patient").useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .guardFalse(false, "inactive")
             .add("appt") { appt }
 

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFhirErrorHandlingTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFhirErrorHandlingTest.kt
@@ -11,9 +11,11 @@ import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.not
+import org.hl7.fhir.r4.model.Bundle
 import org.hl7.fhir.r4.model.Coverage
 import org.hl7.fhir.r4.model.Encounter
 import org.hl7.fhir.r4.model.OperationOutcome
+import org.hl7.fhir.r4.model.Parameters
 import org.hl7.fhir.r4.model.Patient
 import org.hl7.fhir.r4.model.Resource
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -100,7 +102,7 @@ class OperationResultFhirErrorHandlingTest {
     fun `add - BaseServerResponseException stops pipeline in FAIL_FAST mode`() {
         var secondStepExecuted = false
 
-        OperationResult.of(patient(), errorStrategy = ErrorStrategy.FAIL_FAST)
+        OperationResult.of(patient())
             .add("enc") { throw InvalidRequestException("server error") }
             .add("cov") { secondStepExecuted = true; Coverage() }
 
@@ -111,7 +113,7 @@ class OperationResultFhirErrorHandlingTest {
     fun `add - BaseServerResponseException continues pipeline in ACCUMULATE mode`() {
         var secondStepExecuted = false
 
-        val result = OperationResult.of(patient(), errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .add("enc") { throw InvalidRequestException("server error") }
             .add("cov") { secondStepExecuted = true; Coverage() }
 
@@ -319,6 +321,157 @@ class OperationResultFhirErrorHandlingTest {
         assertThat(merged.issue, hasSize(1))
         assertThat(merged.issue[0].extension, hasSize(1))
         assertThat(merged.issue[0].extension[0].url, equalTo("http://example.org/ext"))
+    }
+
+    // ── PROPAGATE strategy ───────────────────────────────────────────────────
+
+    @Test
+    fun `add with PROPAGATE strategy - exception propagates raw, not wrapped as outcome`() {
+        val pipeline = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.PROPAGATE)
+        assertThrows<RuntimeException> {
+            pipeline.add("coverage") { throw RuntimeException("boom") }
+        }
+    }
+
+    @Test
+    fun `addAll with PROPAGATE strategy - exception propagates raw`() {
+        val pipeline = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.PROPAGATE)
+        assertThrows<IllegalStateException> {
+            pipeline.addAll<Patient>("coverage") { throw IllegalStateException("addAll boom") }
+        }
+    }
+
+    @Test
+    fun `addFrom with PROPAGATE strategy - exception propagates raw`() {
+        val pipeline = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.PROPAGATE)
+        assertThrows<RuntimeException> {
+            pipeline.addFrom<Patient, Patient>("test", Patient::class) { throw RuntimeException("addFrom boom") }
+        }
+    }
+
+    @Test
+    fun `flatMap with PROPAGATE strategy - exception propagates raw`() {
+        val pipeline = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.PROPAGATE)
+        assertThrows<RuntimeException> {
+            pipeline.flatMap<Patient> { throw RuntimeException("flatMap boom") }
+        }
+    }
+
+    @Test
+    fun `PROPAGATE - no outcomes accumulated after propagation (outcomes list stays empty)`() {
+        val pipeline = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.PROPAGATE)
+        assertThrows<RuntimeException> {
+            pipeline.add("coverage") { throw RuntimeException("boom") }
+        }
+        assertTrue(pipeline.isSuccessful())
+        assertThat(pipeline.getOutcomes(), hasSize(0))
+    }
+
+    @Test
+    fun `PROPAGATE - successful steps complete normally and accumulate results`() {
+        val result = OperationResult.of(patient())
+            .useErrorStrategy(ErrorStrategy.PROPAGATE)
+            .add("encounter") { Encounter().apply { setId("e1") } }
+
+        assertTrue(result.isSuccessful())
+        assertNotNull(result.getResult())
+    }
+
+    @Test
+    fun `useErrorStrategy - mid-chain switch from FAIL_FAST to PROPAGATE takes effect from next step`() {
+        val result = OperationResult.of(patient())
+            .add("encounter") { throw RuntimeException("step1 fails") }
+            .useErrorStrategy(ErrorStrategy.PROPAGATE)
+
+        assertTrue(result.hasErrors())
+        assertThrows<RuntimeException> {
+            result.add("coverage") { throw RuntimeException("step2 propagates") }
+        }
+    }
+
+    @Test
+    fun `useErrorStrategy - mid-chain switch from ACCUMULATE to FAIL_FAST skips subsequent steps`() {
+        var step2Ran = false
+        val result = OperationResult.of(patient())
+            .useErrorStrategy(ErrorStrategy.ACCUMULATE)
+            .add("enc") { throw RuntimeException("step1 fails") }
+            .useErrorStrategy(ErrorStrategy.FAIL_FAST)
+            .add("cov") { step2Ran = true; Coverage() }
+
+        assertTrue(result.hasErrors())
+        assertFalse(step2Ran)
+    }
+
+    // ── fromParametersTyped error outcomes ───────────────────────────────────
+
+    @Test
+    fun `fromParametersTyped - missing key returns hasErrors true and null head`() {
+        val result = OperationResult.fromParametersTyped(Parameters(), "patient", Patient::class)
+        assertTrue(result.hasErrors())
+    }
+
+    @Test
+    fun `fromParametersTyped - missing key outcome has NOTFOUND code`() {
+        val result = OperationResult.fromParametersTyped(Parameters(), "patient", Patient::class)
+        assertThat(result.getOutcomes(), hasSize(1))
+        assertThat(result.getOutcomes()[0].issueFirstRep.severity, equalTo(OperationOutcome.IssueSeverity.ERROR))
+        assertThat(result.getOutcomes()[0].issueFirstRep.code, equalTo(OperationOutcome.IssueType.NOTFOUND))
+    }
+
+    @Test
+    fun `fromParametersTyped - found key returns isSuccessful true with correct typed head`() {
+        val p = Patient().apply { setId("p1") }
+        val params = Parameters().apply { addParameter().setName("patient").setResource(p) }
+        val result = OperationResult.fromParametersTyped(params, "patient", Patient::class)
+        assertTrue(result.isSuccessful())
+        assertThat(result.getResult().idElement.idPart, equalTo("p1"))
+    }
+
+    // ── fromBundleTyped error outcomes ───────────────────────────────────────
+
+    @Test
+    fun `fromBundleTyped - missing key returns hasErrors true and null head`() {
+        val result = OperationResult.fromBundleTyped(Bundle(), "patient", Patient::class)
+        assertTrue(result.hasErrors())
+    }
+
+    @Test
+    fun `fromBundleTyped - found resource returns isSuccessful true`() {
+        val p = Patient().apply { setId("p1") }
+        val bundle = Bundle().apply { addEntry().resource = p }
+        val result = OperationResult.fromBundleTyped(bundle, "patient", Patient::class)
+        assertTrue(result.isSuccessful())
+        assertThat(result.getResult().idElement.idPart, equalTo("p1"))
+    }
+
+    // ── extractParam Pattern A ───────────────────────────────────────────────
+
+    @Test
+    fun `extractParam - missing key adds ERROR outcome and skips (Pattern A)`() {
+        val result = OperationResult.of(patient())
+            .extractParam("missing", Coverage::class)
+        assertTrue(result.hasErrors())
+        assertThat(result.getOutcomes(), hasSize(1))
+        assertThat(result.getOutcomes()[0].issueFirstRep.severity, equalTo(OperationOutcome.IssueSeverity.ERROR))
+    }
+
+    @Test
+    fun `extractParam - found key changes head and leaves no error`() {
+        val p = patient()
+        val result = OperationResult.of(p)
+            .extractParam("patient", Patient::class)
+        assertTrue(result.isSuccessful())
+        assertSame(p, result.getResult())
+    }
+
+    @Test
+    fun `extractParam - missing key with FAIL_FAST skips subsequent steps`() {
+        var step2Ran = false
+        val result = OperationResult.of(patient())
+            .extractParam("missing", Coverage::class)
+            .add("enc") { step2Ran = true; Encounter() }
+        assertTrue(result.hasErrors())
+        assertFalse(step2Ran)
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFhirPathTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFhirPathTest.kt
@@ -272,7 +272,7 @@ class OperationResultFhirPathTest {
     fun `guardPath preserves head and pipeline continues in ACCUMULATE mode`() {
         val patient = Patient().apply { active = false }
 
-        val result = OperationResult.of(patient, errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient).useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .guardPath("active = true", "not active")
             .add("note") { StringType("after-guard") }
 

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFromTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFromTest.kt
@@ -330,25 +330,23 @@ class OperationResultFromTest {
     }
 
     @Test
-    fun `fromParametersTyped - throws when primary key is absent`() {
+    fun `fromParametersTyped - returns error outcome when primary key is absent`() {
         val fhirParams = Parameters().apply {
             addParameter().apply { name = "appt"; resource = appointment() }
         }
 
-        assertThrows<IllegalArgumentException> {
-            OperationResult.fromParametersTyped<Patient>(fhirParams, "patient")
-        }
+        val result = OperationResult.fromParametersTyped<Patient>(fhirParams, "patient")
+        assertTrue(result.hasErrors())
     }
 
     @Test
-    fun `fromParametersTyped - throws when key exists but type does not match`() {
+    fun `fromParametersTyped - returns error outcome when key exists but type does not match`() {
         val fhirParams = Parameters().apply {
             addParameter().apply { name = "patient"; resource = appointment() } // wrong type
         }
 
-        assertThrows<IllegalArgumentException> {
-            OperationResult.fromParametersTyped<Patient>(fhirParams, "patient")
-        }
+        val result = OperationResult.fromParametersTyped<Patient>(fhirParams, "patient")
+        assertTrue(result.hasErrors())
     }
 
     @Test
@@ -582,27 +580,25 @@ class OperationResultFromTest {
     }
 
     @Test
-    fun `fromBundleTyped - throws when primary key is absent`() {
+    fun `fromBundleTyped - returns error outcome when primary key is absent`() {
         val bundle = Bundle().apply {
             type = Bundle.BundleType.COLLECTION
             addEntry().resource = appointment()
         }
 
-        assertThrows<IllegalArgumentException> {
-            OperationResult.fromBundleTyped<Patient>(bundle, "patient")
-        }
+        val result = OperationResult.fromBundleTyped<Patient>(bundle, "patient")
+        assertTrue(result.hasErrors())
     }
 
     @Test
-    fun `fromBundleTyped - throws when key exists but type does not match`() {
+    fun `fromBundleTyped - returns error outcome when key exists but type does not match`() {
         val bundle = Bundle().apply {
             type = Bundle.BundleType.COLLECTION
             addEntry().resource = appointment()
         }
 
-        assertThrows<IllegalArgumentException> {
-            OperationResult.fromBundleTyped<Patient>(bundle, "appointment")
-        }
+        val result = OperationResult.fromBundleTyped<Patient>(bundle, "appointment")
+        assertTrue(result.hasErrors())
     }
 
     // ── extractParam / extractParamList ──────────────────────────────────────
@@ -632,25 +628,23 @@ class OperationResultFromTest {
     }
 
     @Test
-    fun `extractParam throws when key does not exist`() {
+    fun `extractParam returns error outcome when key does not exist`() {
         val params = Parameters()
-        val or = OperationResult.fromParameters(params)
+        val result = OperationResult.fromParameters(params)
+            .extractParam<Patient>("patient")
 
-        assertThrows<IllegalArgumentException> {
-            or.extractParam<Patient>("patient")
-        }
+        assertTrue(result.hasErrors())
     }
 
     @Test
-    fun `extractParam throws when key exists but type does not match`() {
+    fun `extractParam returns error outcome when key exists but type does not match`() {
         val params = Parameters().apply {
             addParameter().apply { name = "patient"; resource = appointment() }
         }
-        val or = OperationResult.fromParameters(params)
+        val result = OperationResult.fromParameters(params)
+            .extractParam<Patient>("patient")
 
-        assertThrows<IllegalArgumentException> {
-            or.extractParam<Patient>("patient")
-        }
+        assertTrue(result.hasErrors())
     }
 
     @Test

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultIdentifierTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultIdentifierTest.kt
@@ -113,7 +113,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifierWithSystem respects FAIL_FAST and skips when already errored`() {
         var builderCalled = false
-        val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients", ErrorStrategy.FAIL_FAST)
+        val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
                 throw RuntimeException("first failure")
             }

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultMapHeadTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultMapHeadTest.kt
@@ -167,7 +167,7 @@ class OperationResultMapHeadTest {
 
         // Use addOrSkip (Pattern B) so the head is preserved after the failure,
         // allowing mapHead to receive it in ACCUMULATE mode.
-        OperationResult.of(patient(), "patient", errorStrategy = ErrorStrategy.ACCUMULATE)
+        OperationResult.of(patient(), "patient").useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .addOrSkip("extra") { error("earlier warning") }
             .mapHead { p ->
                 transformCalled = true

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultMetaTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultMetaTest.kt
@@ -99,7 +99,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTagWithSystem respects FAIL_FAST and skips when already errored`() {
         var builderCalled = false
-        val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients", ErrorStrategy.FAIL_FAST)
+        val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
                 throw RuntimeException("first failure")
             }
@@ -628,7 +628,7 @@ class OperationResultMetaTest {
     fun `addFromHavingMetaProfile respects FAIL_FAST and skips when already errored`() {
         var builderCalled = false
         val url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-        val result = OperationResult.of(patientWithProfile(url), "patients", ErrorStrategy.FAIL_FAST)
+        val result = OperationResult.of(patientWithProfile(url), "patients")
             .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile(url)) { _ ->
                 throw RuntimeException("first failure")
             }

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultRetryTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultRetryTest.kt
@@ -207,7 +207,7 @@ class OperationResultRetryTest {
     @Test
     fun `addWithRetry works in ACCUMULATE mode after prior error`() {
         var attempts = 0
-        val result = OperationResult.of(patient(), errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .add("enc") { throw RuntimeException("non-fatal") }
             .addWithRetry("enc2", maxAttempts = 3, initialDelayMs = 0) {
                 attempts++
@@ -316,7 +316,7 @@ class OperationResultRetryTest {
     fun `addWithRetryUsing does not retry when head is null in ACCUMULATE mode`() {
         var builderCalls = 0
         // First add fails → head becomes null. addWithRetryUsing should record Pattern A once, not maxAttempts times.
-        val result = OperationResult.of(patient(), errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .add("enc") { throw RuntimeException("step 1 fails") }
             .addWithRetryUsing("obs", maxAttempts = 5, initialDelayMs = 0) { _ ->
                 builderCalls++

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/OperationResultTest.kt
@@ -900,7 +900,7 @@ class OperationResultTest {
 
     @Test
     fun `add - exception in ACCUMULATE continues pipeline and collects outcome`() {
-        val result = OperationResult.of(patient(), errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .add { error("step 1 failed") }
             .add { appointment() }
 
@@ -911,7 +911,7 @@ class OperationResultTest {
 
     @Test
     fun `ACCUMULATE - multiple failing steps collect all outcomes`() {
-        val result = OperationResult.of(patient(), errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .add { error("step 1 failed") }
             .add { error("step 2 failed") }
             .add { appointment() }
@@ -994,7 +994,7 @@ class OperationResultTest {
 
     @Test
     fun `toOperationOutcome - merges all collected issues into single OperationOutcome`() {
-        val result = OperationResult.of(patient(), errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .add { error("step 1 failed") }
             .add { error("step 2 failed") }
 
@@ -1496,7 +1496,7 @@ class OperationResultTest {
     fun `mapStored named respects FAIL_FAST and returns immediately`() {
         val original = patient()
         var called = false
-        val result = OperationResult.of(original, "patient", ErrorStrategy.FAIL_FAST)
+        val result = OperationResult.of(original, "patient")
             .add { throw RuntimeException("first") }
             .mapStored("patient", Patient::class) { called = true; patient() }
 
@@ -1588,7 +1588,7 @@ class OperationResultTest {
     fun `mapStored unkeyed respects FAIL_FAST and returns immediately`() {
         val original = patient()
         var called = false
-        val result = OperationResult.of(original, "patient", ErrorStrategy.FAIL_FAST)
+        val result = OperationResult.of(original, "patient")
             .add { throw RuntimeException("first") }
             .mapStored(Patient::class) { called = true; patient() }
 
@@ -2165,7 +2165,7 @@ class OperationResultTest {
     @Test
     fun `addString - pipeline continues in ACCUMULATE after exception and head is preserved`() {
         val patient = patient()
-        val result = OperationResult.of(patient, errorStrategy = ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.of(patient).useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .addStringUsing("label") { error("boom") }
             .addString("other", "ok")
 
@@ -2400,7 +2400,7 @@ class OperationResultTest {
 
     @Test
     fun `addPart is skipped when pipeline has errors in FAIL_FAST`() {
-        val result = OperationResult.of(patient(), errorStrategy = ErrorStrategy.FAIL_FAST)
+        val result = OperationResult.of(patient())
             .add { throw RuntimeException("induced failure") }
             .addPart("address") { addString("city", "Springfield") }
 
@@ -2465,7 +2465,7 @@ class OperationResultTest {
 
     @Test
     fun `empty with ACCUMULATE error strategy`() {
-        val result = OperationResult.empty(ErrorStrategy.ACCUMULATE)
+        val result = OperationResult.empty().useErrorStrategy(ErrorStrategy.ACCUMULATE)
             .add { throw RuntimeException("induced failure") }
             .add("patient") { patient() }
 

--- a/fhirmason-spring/src/main/java/dev/ratkay/spring/FhirMasonFactory.kt
+++ b/fhirmason-spring/src/main/java/dev/ratkay/spring/FhirMasonFactory.kt
@@ -27,7 +27,7 @@ class FhirMasonFactory(private val properties: FhirMasonProperties) {
      * If `fhirmason.metrics.enabled` is `true` the pipeline will have timing enabled.
      */
     fun <T : Base> pipeline(resource: T): OperationResult<T> {
-        var result = OperationResult.of(resource, errorStrategy = properties.errorStrategy)
+        var result = OperationResult.of(resource).useErrorStrategy(properties.errorStrategy)
         if (properties.metrics.enabled) result = result.timed()
         return result
     }


### PR DESCRIPTION
Three gaps addressed:

1. PROPAGATE strategy: adds ErrorStrategy.PROPAGATE to let lambda exceptions
   bubble to the caller unchanged instead of being wrapped as OperationOutcome
   entries. Useful when the caller's infrastructure (Spring @ControllerAdvice,
   custom try/catch) already handles exceptions and needs the original type and
   stack trace intact.

2. useErrorStrategy(strategy) fluent method: replaces the errorStrategy factory
   parameter on of() / empty(). The method can be called at any point in the
   chain and changes the active strategy from that step onwards — the same
   pattern as timed(). copyWith() gains an optional errorStrategy parameter to
   support this. Factory methods (of, empty, fromParameters*, fromBundle*)
   always start with FAIL_FAST; callers chain .useErrorStrategy() to override.

3. Consistent error outcomes for missing data: fromParametersTyped,
   fromBundleTyped, and extractParam previously threw IllegalArgumentException
   when the expected resource was absent. These are data errors (the input
   doesn't have the expected content), not programmer errors, so they now
   follow Pattern A instead: record an ERROR-severity OperationOutcome with
   NOTFOUND code and return a skipped (null-head) result. A new internal
   messageOutcome() helper (in OperationOutcomeExtensions for both R4 and
   DSTU3) builds these outcomes. extractParam is wrapped in runBuilderStep so
   it respects the active ErrorStrategy (FAIL_FAST skips subsequent steps,
   PROPAGATE re-throws, etc.).

All changes are mirrored to DSTU3. Existing tests updated to use
useErrorStrategy() and to reflect the new non-throwing behaviour.