### PR TITLE
fix: complete KDoc coverage and 100% unit test coverage

### DIFF
--- a/fhirmason-api/src/main/java/dev/ratkay/operation/FhirPath.kt
+++ b/fhirmason-api/src/main/java/dev/ratkay/operation/FhirPath.kt
@@ -231,14 +231,22 @@ class FhirPath private constructor(private val expr: String) {
     /** Greater-than-or-equal comparison with a decimal literal: `expr >= value`. */
     fun ge(value: Double): FhirPath = FhirPath("$expr >= $value")
 
-    /** FHIRPath equivalence (`~`): matches regardless of insignificant whitespace, case, etc. */
+    /** FHIRPath equivalence (`~`): matches regardless of insignificant whitespace, case, etc. String values are auto-quoted. */
     fun equiv(value: String): FhirPath = FhirPath("$expr ~ '$value'")
+
+    /** Equivalence comparison with an integer literal: `expr ~ value`. */
     fun equiv(value: Int): FhirPath = FhirPath("$expr ~ $value")
+
+    /** Equivalence comparison with a decimal literal: `expr ~ value`. */
     fun equiv(value: Double): FhirPath = FhirPath("$expr ~ $value")
 
-    /** FHIRPath non-equivalence (`!~`). */
+    /** FHIRPath non-equivalence (`!~`). String values are auto-quoted. */
     fun notEquiv(value: String): FhirPath = FhirPath("$expr !~ '$value'")
+
+    /** Non-equivalence comparison with an integer literal: `expr !~ value`. */
     fun notEquiv(value: Int): FhirPath = FhirPath("$expr !~ $value")
+
+    /** Non-equivalence comparison with a decimal literal: `expr !~ value`. */
     fun notEquiv(value: Double): FhirPath = FhirPath("$expr !~ $value")
 
     /** FHIRPath `contains` membership: `expr contains value`. [value] is auto-quoted as a string literal. */

--- a/fhirmason-api/src/test/java/dev/ratkay/operation/FhirPathTest.kt
+++ b/fhirmason-api/src/test/java/dev/ratkay/operation/FhirPathTest.kt
@@ -282,6 +282,11 @@ class FhirPathTest {
     }
 
     @Test
+    fun `ne with Double emits literal`() {
+        assertThat(FhirPath.from("score").ne(0.0).build(), `is`("score != 0.0"))
+    }
+
+    @Test
     fun `lt with Int emits literal`() {
         assertThat(FhirPath.from("age").lt(18).build(), `is`("age < 18"))
     }
@@ -312,6 +317,11 @@ class FhirPathTest {
     }
 
     @Test
+    fun `le with String auto-quotes`() {
+        assertThat(FhirPath.from("name").le("M").build(), `is`("name <= 'M'"))
+    }
+
+    @Test
     fun `le with Int emits literal`() {
         assertThat(FhirPath.from("age").le(17).build(), `is`("age <= 17"))
     }
@@ -319,6 +329,11 @@ class FhirPathTest {
     @Test
     fun `le with Double emits literal`() {
         assertThat(FhirPath.from("score").le(1.0).build(), `is`("score <= 1.0"))
+    }
+
+    @Test
+    fun `ge with String auto-quotes`() {
+        assertThat(FhirPath.from("name").ge("M").build(), `is`("name >= 'M'"))
     }
 
     @Test
@@ -342,6 +357,11 @@ class FhirPathTest {
     }
 
     @Test
+    fun `equiv with Double emits literal`() {
+        assertThat(FhirPath.from("value").equiv(1.5).build(), `is`("value ~ 1.5"))
+    }
+
+    @Test
     fun `notEquiv produces bang-tilde expression with auto-quoted string`() {
         assertThat(FhirPath.from("name").notEquiv("Smith").build(), `is`("name !~ 'Smith'"))
     }
@@ -349,6 +369,11 @@ class FhirPathTest {
     @Test
     fun `notEquiv with Int emits literal`() {
         assertThat(FhirPath.from("value").notEquiv(0).build(), `is`("value !~ 0"))
+    }
+
+    @Test
+    fun `notEquiv with Double emits literal`() {
+        assertThat(FhirPath.from("value").notEquiv(0.0).build(), `is`("value !~ 0.0"))
     }
 
     @Test

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationOutcomeExtensions.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationOutcomeExtensions.kt
@@ -3,6 +3,13 @@ package dev.ratkay.operation.dstu3
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException
 import org.hl7.fhir.dstu3.model.OperationOutcome
 
+/**
+ * Creates a generic ERROR-severity [OperationOutcome] from this exception, using the
+ * exception message (or the class name when the message is `null`) as the diagnostics.
+ *
+ * Prefer [BaseServerResponseException.toOperationOutcome] when the exception is a HAPI
+ * server/client exception — it extracts any embedded rich outcome rather than discarding it.
+ */
 fun Exception.toOperationOutcome(): OperationOutcome = OperationOutcome().apply {
     addIssue().apply {
         severity = OperationOutcome.IssueSeverity.ERROR

--- a/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
+++ b/fhirmason-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
@@ -106,6 +106,13 @@ class OperationResult<T> private constructor(
         }
     }
 
+    /**
+     * Throws an [ca.uhn.fhir.rest.server.exceptions.InternalErrorException] containing the
+     * merged [OperationOutcome] if [hasErrors] is `true`; otherwise returns this result unchanged.
+     *
+     * The exception message is taken from the first issue's `diagnostics` field, falling back to
+     * `"Pipeline completed with errors"` when no diagnostic text is present.
+     */
     override fun throwIfErrors(): OperationResult<T> {
         if (hasErrors()) {
             val outcome = toOperationOutcome()

--- a/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/FhirDateTimeConverterTest.kt
+++ b/fhirmason-dstu3/src/test/java/dev/ratkay/operation/dstu3/FhirDateTimeConverterTest.kt
@@ -1,5 +1,6 @@
 package dev.ratkay.operation.dstu3
 
+import dev.ratkay.operation.DateTimeInput
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.instanceOf
 import org.hl7.fhir.dstu3.model.DateTimeType
@@ -7,6 +8,7 @@ import org.hl7.fhir.dstu3.model.DateType
 import org.hl7.fhir.dstu3.model.InstantType
 import org.hl7.fhir.dstu3.model.TimeType
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -201,5 +203,73 @@ class FhirDateTimeConverterTest {
         val result = FhirDateTimeConverter.toFhirTime(time)
         assertThat(result, instanceOf(TimeType::class.java))
         assertEquals("00:00", result.valueAsString)
+    }
+
+    // ── toFhirDate(DateTimeInput) dispatch ────────────────────────────────────
+
+    @Test
+    fun `toFhirDate dispatch with OfLocalDateTime extracts date part`() {
+        val ldt = LocalDateTime.of(2024, 3, 15, 22, 45, 0)
+        val result = FhirDateTimeConverter.toFhirDate(DateTimeInput.of(ldt))
+        assertThat(result, instanceOf(DateType::class.java))
+        assertEquals("2024-03-15", result.valueAsString)
+    }
+
+    @Test
+    fun `toFhirDate dispatch with OfZonedDateTime extracts date part`() {
+        val zdt = ZonedDateTime.of(2024, 3, 15, 22, 45, 0, 0, ZoneOffset.ofHours(5))
+        val result = FhirDateTimeConverter.toFhirDate(DateTimeInput.of(zdt))
+        assertThat(result, instanceOf(DateType::class.java))
+        assertEquals("2024-03-15", result.valueAsString)
+    }
+
+    @Test
+    fun `toFhirDate dispatch with OfOffsetDateTime extracts date part`() {
+        val odt = OffsetDateTime.of(2024, 3, 15, 22, 45, 0, 0, ZoneOffset.ofHours(5))
+        val result = FhirDateTimeConverter.toFhirDate(DateTimeInput.of(odt))
+        assertThat(result, instanceOf(DateType::class.java))
+        assertEquals("2024-03-15", result.valueAsString)
+    }
+
+    @Test
+    fun `toFhirDate dispatch throws for unsupported type`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            FhirDateTimeConverter.toFhirDate(DateTimeInput.of(Instant.now()))
+        }
+    }
+
+    // ── toFhirDateTime(DateTimeInput) dispatch ────────────────────────────────
+
+    @Test
+    fun `toFhirDateTime dispatch with OfInstant produces DateTimeType`() {
+        val instant = Instant.parse("2024-03-15T10:30:00.000Z")
+        val result = FhirDateTimeConverter.toFhirDateTime(DateTimeInput.of(instant))
+        assertThat(result, instanceOf(DateTimeType::class.java))
+        assertTrue(result.valueAsString.contains("2024-03-15"))
+    }
+
+    @Test
+    fun `toFhirDateTime dispatch throws for unsupported type`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            FhirDateTimeConverter.toFhirDateTime(DateTimeInput.of(LocalDate.of(2024, 1, 1)))
+        }
+    }
+
+    // ── toFhirInstant(DateTimeInput) dispatch ─────────────────────────────────
+
+    @Test
+    fun `toFhirInstant dispatch throws for unsupported type`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            FhirDateTimeConverter.toFhirInstant(DateTimeInput.of(LocalDate.of(2024, 1, 1)))
+        }
+    }
+
+    // ── toFhirTime(DateTimeInput) dispatch ────────────────────────────────────
+
+    @Test
+    fun `toFhirTime dispatch throws for unsupported type`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            FhirDateTimeConverter.toFhirTime(DateTimeInput.of(LocalDate.of(2024, 1, 1)))
+        }
     }
 }

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationOutcomeExtensions.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationOutcomeExtensions.kt
@@ -3,6 +3,13 @@ package dev.ratkay.operation.r4
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException
 import org.hl7.fhir.r4.model.OperationOutcome
 
+/**
+ * Creates a generic ERROR-severity [OperationOutcome] from this exception, using the
+ * exception message (or the class name when the message is `null`) as the diagnostics.
+ *
+ * Prefer [BaseServerResponseException.toOperationOutcome] when the exception is a HAPI
+ * server/client exception — it extracts any embedded rich outcome rather than discarding it.
+ */
 fun Exception.toOperationOutcome(): OperationOutcome = OperationOutcome().apply {
     addIssue().apply {
         severity = OperationOutcome.IssueSeverity.ERROR

--- a/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -107,6 +107,13 @@ class OperationResult<T> private constructor(
         }
     }
 
+    /**
+     * Throws an [ca.uhn.fhir.rest.server.exceptions.InternalErrorException] containing the
+     * merged [OperationOutcome] if [hasErrors] is `true`; otherwise returns this result unchanged.
+     *
+     * The exception message is taken from the first issue's `diagnostics` field, falling back to
+     * `"Pipeline completed with errors"` when no diagnostic text is present.
+     */
     override fun throwIfErrors(): OperationResult<T> {
         if (hasErrors()) {
             val outcome = toOperationOutcome()

--- a/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/FhirDateTimeConverterTest.kt
+++ b/fhirmason-r4/src/test/java/dev/ratkay/operation/r4/FhirDateTimeConverterTest.kt
@@ -1,5 +1,6 @@
 package dev.ratkay.operation.r4
 
+import dev.ratkay.operation.DateTimeInput
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.instanceOf
 import org.hl7.fhir.r4.model.DateTimeType
@@ -7,6 +8,7 @@ import org.hl7.fhir.r4.model.DateType
 import org.hl7.fhir.r4.model.InstantType
 import org.hl7.fhir.r4.model.TimeType
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -201,5 +203,73 @@ class FhirDateTimeConverterTest {
         val result = FhirDateTimeConverter.toFhirTime(time)
         assertThat(result, instanceOf(TimeType::class.java))
         assertEquals("00:00", result.valueAsString)
+    }
+
+    // ── toFhirDate(DateTimeInput) dispatch ────────────────────────────────────
+
+    @Test
+    fun `toFhirDate dispatch with OfLocalDateTime extracts date part`() {
+        val ldt = LocalDateTime.of(2024, 3, 15, 22, 45, 0)
+        val result = FhirDateTimeConverter.toFhirDate(DateTimeInput.of(ldt))
+        assertThat(result, instanceOf(DateType::class.java))
+        assertEquals("2024-03-15", result.valueAsString)
+    }
+
+    @Test
+    fun `toFhirDate dispatch with OfZonedDateTime extracts date part`() {
+        val zdt = ZonedDateTime.of(2024, 3, 15, 22, 45, 0, 0, ZoneOffset.ofHours(5))
+        val result = FhirDateTimeConverter.toFhirDate(DateTimeInput.of(zdt))
+        assertThat(result, instanceOf(DateType::class.java))
+        assertEquals("2024-03-15", result.valueAsString)
+    }
+
+    @Test
+    fun `toFhirDate dispatch with OfOffsetDateTime extracts date part`() {
+        val odt = OffsetDateTime.of(2024, 3, 15, 22, 45, 0, 0, ZoneOffset.ofHours(5))
+        val result = FhirDateTimeConverter.toFhirDate(DateTimeInput.of(odt))
+        assertThat(result, instanceOf(DateType::class.java))
+        assertEquals("2024-03-15", result.valueAsString)
+    }
+
+    @Test
+    fun `toFhirDate dispatch throws for unsupported type`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            FhirDateTimeConverter.toFhirDate(DateTimeInput.of(Instant.now()))
+        }
+    }
+
+    // ── toFhirDateTime(DateTimeInput) dispatch ────────────────────────────────
+
+    @Test
+    fun `toFhirDateTime dispatch with OfInstant produces DateTimeType`() {
+        val instant = Instant.parse("2024-03-15T10:30:00.000Z")
+        val result = FhirDateTimeConverter.toFhirDateTime(DateTimeInput.of(instant))
+        assertThat(result, instanceOf(DateTimeType::class.java))
+        assertTrue(result.valueAsString.contains("2024-03-15"))
+    }
+
+    @Test
+    fun `toFhirDateTime dispatch throws for unsupported type`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            FhirDateTimeConverter.toFhirDateTime(DateTimeInput.of(LocalDate.of(2024, 1, 1)))
+        }
+    }
+
+    // ── toFhirInstant(DateTimeInput) dispatch ─────────────────────────────────
+
+    @Test
+    fun `toFhirInstant dispatch throws for unsupported type`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            FhirDateTimeConverter.toFhirInstant(DateTimeInput.of(LocalDate.of(2024, 1, 1)))
+        }
+    }
+
+    // ── toFhirTime(DateTimeInput) dispatch ────────────────────────────────────
+
+    @Test
+    fun `toFhirTime dispatch throws for unsupported type`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            FhirDateTimeConverter.toFhirTime(DateTimeInput.of(LocalDate.of(2024, 1, 1)))
+        }
     }
 }

--- a/fhirmason-spring/src/main/java/dev/ratkay/spring/FhirMasonProperties.kt
+++ b/fhirmason-spring/src/main/java/dev/ratkay/spring/FhirMasonProperties.kt
@@ -19,8 +19,10 @@ class FhirMasonProperties {
     /** Controls how pipeline errors are handled. Defaults to [ErrorStrategy.ACCUMULATE]. */
     var errorStrategy: ErrorStrategy = ErrorStrategy.ACCUMULATE
 
+    /** Metrics configuration for FHIRMason pipelines and DAGs. */
     val metrics: MetricsProperties = MetricsProperties()
 
+    /** Configuration properties controlling per-step metrics collection. */
     class MetricsProperties {
         /** When true, every pipeline created by [FhirMasonFactory] will have timing enabled. */
         var enabled: Boolean = false


### PR DESCRIPTION
KDoc additions:
- FhirPath.kt: add KDoc to equiv(Int/Double) and notEquiv(Int/Double) overloads
- R4+DSTU3 OperationOutcomeExtensions.kt: add KDoc to Exception.toOperationOutcome()
- R4+DSTU3 OperationResult.kt: add KDoc to throwIfErrors() override documenting
  InternalErrorException throw behaviour and diagnostics fallback
- FhirMasonProperties.kt: add KDoc to metrics property and MetricsProperties class

Test coverage additions:
- FhirPathTest.kt: add 5 missing tests for ne(Double), le(String), ge(String),
  equiv(Double), notEquiv(Double) overloads
- R4+DSTU3 FhirDateTimeConverterTest.kt: add 8 dispatch-method tests covering
  toFhirDate/DateTime/Instant/Time(DateTimeInput) branches including unsupported-type
  error paths that previously had no coverage