### PR TITLE
feat: improve Java usability — Class<T> as primary type parameter with KClass<T> companions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/test/java/dev/ratkay/operation/
 
 - `OperationResult` is **immutable** — all builder methods return new instances
 - Factory entry points live in `companion object` as `of()` methods
-- Use reified generics (`KClass<R>`) for type-safe resource filtering
+- Use `Class<T>` + `inline fun <reified T>` for type-safe resource filtering (see Java Interop rule below)
 - Receiver-lambda overloads are named `addUsing` / `addAllUsing` (not `add` / `addAll`)
 - If no explicit key name is given, the storage key is always the **output** value's `fhirType().lowercase()` — never the input type's name. For example, a builder that receives `Patient` resources and returns an `OperationOutcome` stores under `"operationoutcome"`, not `"patient"`. This applies to every method with an optional `name` parameter: `add`, `addAll`, `addFrom`, `addAllFrom`, `addFromHavingAllExtensions`, `addFromHavingAnyExtension`, `addAllFrom*`, `addFromHavingExtensionWithValueType`, `addFromHavingExtensionValueMatching`, `addAllFromHavingExtensionValueMatching`, `addFromMatching`, `addAllFromMatching`, and `selectByPath`. Pass `null` (or omit the name) to `storeAndCopy`/`storeListAndCopy` and let them derive the key from the result; never pass a derived input-type name.
 - Test method names use Kotlin backtick syntax: `` `descriptive test name` ``
@@ -69,18 +69,30 @@ Exceptions — do **not** add these annotations to:
 
 ## Java Interop: No Kotlin-specific types in the public API
 
-Java callers must never be required to reference Kotlin-specific types such as `KClass`, `KFunction`, or anything from `kotlin.reflect.*`. If a public method accepts a `KClass<T>` parameter, a `Class<T>` overload **must** exist alongside it. The `Class<T>` overload delegates to the `KClass<T>` variant via `.kotlin`:
+Java callers must never be required to reference Kotlin-specific types such as `KClass`, `KFunction`, or anything from `kotlin.reflect.*`. Public API methods that accept a type parameter must have **exactly two forms**:
+
+1. **`Class<T>` primary** — the Java-friendly form; this is the real implementation. Annotate with `@JvmOverloads` when defaults are present.
+2. **`inline fun <reified T>`** — the Kotlin-convenience form; callers write `addFrom<Patient>(...)` instead of `addFrom(Patient::class.java, ...)`. This overload delegates to the `Class<T>` primary via `T::class.java`.
+
+**`KClass<T>` overloads are not permitted in the public API.** There is no middle tier.
 
 ```kotlin
-@JvmStatic
-fun <V : Type> hasExtensionValueMatching(
-    url: String,
-    valueType: Class<V>,
-    predicate: (V) -> Boolean
-): (Base) -> Boolean = hasExtensionValueMatchingInternal(url, valueType.kotlin, predicate)
+// Primary — Class<T>; @JvmOverloads when defaults are present
+@JvmOverloads
+fun <I : Resource> addFrom(
+    name: String? = null,
+    type: Class<I>
+): OperationResult<I> { /* implementation */ }
+
+// Kotlin convenience — reified, no explicit type arg at call sites
+inline fun <reified I : Resource> addFrom(
+    name: String? = null
+): OperationResult<I> = addFrom(name, I::class.java)
 ```
 
-The same rule applies to any helper or factory object (e.g. `FhirFilter`) whose methods are part of the public API. When adding a new method that takes `KClass`, always add the `Class` sibling in the same commit.
+The only deliberate exception is `ReferenceLinkRule`, whose **primary constructor** keeps `KClass<T>` as a Kotlin-idiomatic API; its companion `.of()` factory accepts `Class<T>` for Java callers. Do not apply this exception elsewhere.
+
+The same rule applies to any helper or factory object (e.g. `FhirFilter`) whose methods are part of the public API.
 
 ## Java Interop: Kotlin function types in the public API
 
@@ -160,7 +172,7 @@ This is a hard requirement for all public API surfaces — no exceptions.
 Rules:
 - **Class-level KDoc is required** on every public class and object.
 - **Method-level KDoc is required** on every `fun` that is `public` (explicitly or by default) — including companion object methods, top-level functions that are part of the public API, and `override` methods that add behaviour beyond what the interface documents.
-- **Single-line `/** … */` is acceptable** for self-evident overloads (e.g. a reified wrapper that only removes the explicit `KClass` argument). Use `/** [FhirPath] overload of [xxx] — builds the expression and delegates. */` or `/** Reified overload — no [KClass] argument needed at call sites. */` as appropriate.
+- **Single-line `/** … */` is acceptable** for self-evident overloads (e.g. a reified wrapper that only removes the explicit `Class` argument). Use `/** [FhirPath] overload of [xxx] — builds the expression and delegates. */` or `/** Reified overload — delegates to [xxx] via [T::class.java]. */` as appropriate.
 - **Multi-line KDoc** is required when a method has non-trivial behaviour, error semantics, or parameters that need explanation (see existing methods for examples).
 - **`@param` tags** are required for every parameter of a public method whose purpose is not fully captured by its name alone.
 - `internal` and `private` members do not require KDoc, but a single-line comment is welcome for non-obvious logic.

--- a/README.md
+++ b/README.md
@@ -164,12 +164,10 @@ val result = OperationResult.of(listOf(patient, appointment), "inputs")
 
 | Method | `type` param | Returns |
 |---|---|---|
-| `addFromFiltered(name?, type, predicate) { list -> R }` | `KClass<I>` | `OperationResult<R>` |
-| `addFromFiltered(name?, type, predicate) { list -> R }` | `Class<I>` *(Java)* | `OperationResult<R>` |
-| `addAllFromFiltered(name?, type, predicate) { list -> List<R> }` | `KClass<I>` | `OperationResult<List<R>>` |
-| `addAllFromFiltered(name?, type, predicate) { list -> List<R> }` | `Class<I>` *(Java)* | `OperationResult<List<R>>` |
+| `addFromFiltered(name?, type, predicate) { list -> R }` | `Class<I>` / `KClass<I>` | `OperationResult<R>` |
+| `addAllFromFiltered(name?, type, predicate) { list -> List<R> }` | `Class<I>` / `KClass<I>` | `OperationResult<List<R>>` |
 
-Both methods have reified Kotlin overloads (omit `type` entirely). `name` defaults to the output value's `fhirType()` when omitted. Error handling follows Pattern A.
+Both methods have reified Kotlin overloads (omit `type` entirely), a `Class<I>` overload for Java callers, and a `KClass<I>` convenience overload for Kotlin. `name` defaults to the output value's `fhirType()` when omitted. Error handling follows Pattern A.
 
 **`FhirFilter` predicate factories**
 
@@ -179,10 +177,12 @@ Both methods have reified Kotlin overloads (omit `type` entirely). `name` defaul
 |---|---|
 | `FhirFilter.hasAllExtensions("url1", "url2")` | Resource carries **every** given extension URL |
 | `FhirFilter.hasAnyExtension("url1", "url2")` | Resource carries **at least one** given URL |
-| `FhirFilter.hasExtensionWithValueType("url", StringType::class)` | Extension value is an instance of the given type |
-| `FhirFilter.hasExtensionWithValueType<StringType>("url")` | Reified form |
-| `FhirFilter.hasExtensionValueMatching("url", BooleanType::class) { it.booleanValue() }` | Extension value satisfies a predicate |
-| `FhirFilter.hasExtensionValueMatching<BooleanType>("url") { it.booleanValue() }` | Reified form |
+| `FhirFilter.hasExtensionWithValueType("url", StringType::class.java)` | Extension value is an instance of the given type (`Class<T>` — Java-friendly primary) |
+| `FhirFilter.hasExtensionWithValueType("url", StringType::class)` | `KClass<T>` overload — Kotlin callers may pass `KClass` directly |
+| `FhirFilter.hasExtensionWithValueType<StringType>("url")` | Reified overload |
+| `FhirFilter.hasExtensionValueMatching("url", BooleanType::class.java) { it.booleanValue() }` | Extension value satisfies a predicate (`Class<T>` — Java-friendly primary) |
+| `FhirFilter.hasExtensionValueMatching("url", BooleanType::class) { it.booleanValue() }` | `KClass<T>` overload — Kotlin callers may pass `KClass` directly |
+| `FhirFilter.hasExtensionValueMatching<BooleanType>("url") { it.booleanValue() }` | Reified overload |
 | `FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")` | Any identifier has the given system |
 | `FhirFilter.hasIdentifierWithValue("MRN-001")` | Any identifier has the given value |
 | `FhirFilter.hasIdentifier("http://example.org/mrn", "MRN-001")` | Exact system + value match |
@@ -286,7 +286,7 @@ val result2 = OperationResult.of(patients, "patients")
         expression = "extension('http://ext/risk').value = 'high' and birthDate < @1960-01-01"
     ) { it }
 
-// Named output key — KClass form (required when you also want an explicit name in Kotlin)
+// Named output key — explicit type form (KClass or Class<T> both work)
 val result3 = OperationResult.of(patients, "patients")
     .addFromMatching("enrolled", Patient::class, "identifier.where(system='http://example.org/mpi').exists()") { filtered ->
         buildEnrolledSummary(filtered)

--- a/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/AsyncOperationResult.kt
+++ b/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/AsyncOperationResult.kt
@@ -21,7 +21,6 @@ import org.hl7.fhir.dstu3.model.Base
 import org.hl7.fhir.dstu3.model.OperationOutcome
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.reflect.KClass
 import kotlin.time.measureTime
 import kotlin.time.measureTimedValue
 
@@ -236,24 +235,20 @@ class AsyncOperationResult {
     fun <T : Base> addAfter(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         block: suspend (T) -> Base
     ): AsyncOperationResult = addAfter(key, dep) { deps ->
-        val value = deps[dep]!!.filterIsInstance(type.java).firstOrNull()
+        val value = deps[dep]!!.filterIsInstance(type).firstOrNull()
             ?: error("No value of type ${type.simpleName} found under dependency '$dep'")
         block(value)
     }
-
-    /** Java-friendly overload of [addAfter] (typed) — accepts [Class] instead of [KClass]. */
-    fun <T : Base> addAfter(key: String, dep: String, type: Class<T>, block: suspend (T) -> Base): AsyncOperationResult =
-        addAfter(key, dep, type.kotlin, block)
 
     /** Java-friendly [Function] overload of [addAfter] (typed). */
     fun <T : Base> addAfter(
         key: String, dep: String, type: Class<T>,
         block: Function<T, out Base>
     ): AsyncOperationResult =
-        addAfter(key, dep, type.kotlin) { block.apply(it) }
+        addAfter(key, dep, type) { block.apply(it) }
 
     /**
      * Type-safe overload of [addListAfter] for a single dependency.
@@ -271,24 +266,20 @@ class AsyncOperationResult {
     fun <T : Base, R : Base> addListAfter(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         block: suspend (T) -> Collection<R>
     ): AsyncOperationResult = addListAfter(key, dep) { deps ->
-        val value = deps[dep]!!.filterIsInstance(type.java).firstOrNull()
+        val value = deps[dep]!!.filterIsInstance(type).firstOrNull()
             ?: error("No value of type ${type.simpleName} found under dependency '$dep'")
         block(value)
     }
-
-    /** Java-friendly overload of [addListAfter] (typed) — accepts [Class] instead of [KClass]. */
-    fun <T : Base, R : Base> addListAfter(key: String, dep: String, type: Class<T>, block: suspend (T) -> Collection<R>): AsyncOperationResult =
-        addListAfter(key, dep, type.kotlin, block)
 
     /** Java-friendly [Function] overload of [addListAfter] (typed). */
     fun <T : Base, R : Base> addListAfter(
         key: String, dep: String, type: Class<T>,
         block: Function<T, out Collection<out R>>
     ): AsyncOperationResult =
-        addListAfter(key, dep, type.kotlin) { block.apply(it) }
+        addListAfter(key, dep, type) { block.apply(it) }
 
     // Type-safe list-injection convenience methods
 
@@ -306,23 +297,19 @@ class AsyncOperationResult {
     fun <T : Base> addAfterAll(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         block: suspend (List<T>) -> Base
     ): AsyncOperationResult = addAfter(key, dep) { deps ->
-        val values = deps[dep]!!.filterIsInstance(type.java)
+        val values = deps[dep]!!.filterIsInstance(type)
         block(values)
     }
-
-    /** Java-friendly overload of [addAfterAll] — accepts [Class] instead of [KClass]. */
-    fun <T : Base> addAfterAll(key: String, dep: String, type: Class<T>, block: suspend (List<T>) -> Base): AsyncOperationResult =
-        addAfterAll(key, dep, type.kotlin, block)
 
     /** Java-friendly [Function] overload of [addAfterAll]. */
     fun <T : Base> addAfterAll(
         key: String, dep: String, type: Class<T>,
         block: Function<List<T>, out Base>
     ): AsyncOperationResult =
-        addAfterAll(key, dep, type.kotlin) { block.apply(it) }
+        addAfterAll(key, dep, type) { block.apply(it) }
 
     /**
      * Like [addAfterAll] but [block] returns a `Collection<R>`.
@@ -338,23 +325,19 @@ class AsyncOperationResult {
     fun <T : Base, R : Base> addListAfterAll(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         block: suspend (List<T>) -> Collection<R>
     ): AsyncOperationResult = addListAfter(key, dep) { deps ->
-        val values = deps[dep]!!.filterIsInstance(type.java)
+        val values = deps[dep]!!.filterIsInstance(type)
         block(values)
     }
-
-    /** Java-friendly overload of [addListAfterAll] — accepts [Class] instead of [KClass]. */
-    fun <T : Base, R : Base> addListAfterAll(key: String, dep: String, type: Class<T>, block: suspend (List<T>) -> Collection<R>): AsyncOperationResult =
-        addListAfterAll(key, dep, type.kotlin, block)
 
     /** Java-friendly [Function] overload of [addListAfterAll]. */
     fun <T : Base, R : Base> addListAfterAll(
         key: String, dep: String, type: Class<T>,
         block: Function<List<T>, out Collection<out R>>
     ): AsyncOperationResult =
-        addListAfterAll(key, dep, type.kotlin) { block.apply(it) }
+        addListAfterAll(key, dep, type) { block.apply(it) }
 
     // ── Retry helper ─────────────────────────────────────────────────────────
 
@@ -488,92 +471,76 @@ class AsyncOperationResult {
     fun <T : Base> addAfterWithTimeout(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         timeoutMs: Long,
         block: suspend (T) -> Base
     ): AsyncOperationResult = addAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
-        val value = deps[dep]!!.filterIsInstance(type.java).firstOrNull()
+        val value = deps[dep]!!.filterIsInstance(type).firstOrNull()
             ?: error("No value of type ${type.simpleName} found under dependency '$dep'")
         block(value)
     }
-
-    /** Java-friendly overload of [addAfterWithTimeout] (typed) — accepts [Class] instead of [KClass]. */
-    fun <T : Base> addAfterWithTimeout(key: String, dep: String, type: Class<T>, timeoutMs: Long, block: suspend (T) -> Base): AsyncOperationResult =
-        addAfterWithTimeout(key, dep, type.kotlin, timeoutMs, block)
 
     /** Java-friendly [Function] overload of [addAfterWithTimeout] (typed). */
     fun <T : Base> addAfterWithTimeout(
         key: String, dep: String, type: Class<T>, timeoutMs: Long,
         block: Function<T, out Base>
     ): AsyncOperationResult =
-        addAfterWithTimeout(key, dep, type.kotlin, timeoutMs) { block.apply(it) }
+        addAfterWithTimeout(key, dep, type, timeoutMs) { block.apply(it) }
 
     fun <T : Base, R : Base> addListAfterWithTimeout(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         timeoutMs: Long,
         block: suspend (T) -> Collection<R>
     ): AsyncOperationResult = addListAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
-        val value = deps[dep]!!.filterIsInstance(type.java).firstOrNull()
+        val value = deps[dep]!!.filterIsInstance(type).firstOrNull()
             ?: error("No value of type ${type.simpleName} found under dependency '$dep'")
         block(value)
     }
-
-    /** Java-friendly overload of [addListAfterWithTimeout] (typed) — accepts [Class] instead of [KClass]. */
-    fun <T : Base, R : Base> addListAfterWithTimeout(key: String, dep: String, type: Class<T>, timeoutMs: Long, block: suspend (T) -> Collection<R>): AsyncOperationResult =
-        addListAfterWithTimeout(key, dep, type.kotlin, timeoutMs, block)
 
     /** Java-friendly [Function] overload of [addListAfterWithTimeout] (typed). */
     fun <T : Base, R : Base> addListAfterWithTimeout(
         key: String, dep: String, type: Class<T>, timeoutMs: Long,
         block: Function<T, out Collection<out R>>
     ): AsyncOperationResult =
-        addListAfterWithTimeout(key, dep, type.kotlin, timeoutMs) { block.apply(it) }
+        addListAfterWithTimeout(key, dep, type, timeoutMs) { block.apply(it) }
 
     fun <T : Base> addAfterAllWithTimeout(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         timeoutMs: Long,
         block: suspend (List<T>) -> Base
     ): AsyncOperationResult = addAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
-        val values = deps[dep]!!.filterIsInstance(type.java)
+        val values = deps[dep]!!.filterIsInstance(type)
         block(values)
     }
-
-    /** Java-friendly overload of [addAfterAllWithTimeout] — accepts [Class] instead of [KClass]. */
-    fun <T : Base> addAfterAllWithTimeout(key: String, dep: String, type: Class<T>, timeoutMs: Long, block: suspend (List<T>) -> Base): AsyncOperationResult =
-        addAfterAllWithTimeout(key, dep, type.kotlin, timeoutMs, block)
 
     /** Java-friendly [Function] overload of [addAfterAllWithTimeout]. */
     fun <T : Base> addAfterAllWithTimeout(
         key: String, dep: String, type: Class<T>, timeoutMs: Long,
         block: Function<List<T>, out Base>
     ): AsyncOperationResult =
-        addAfterAllWithTimeout(key, dep, type.kotlin, timeoutMs) { block.apply(it) }
+        addAfterAllWithTimeout(key, dep, type, timeoutMs) { block.apply(it) }
 
     fun <T : Base, R : Base> addListAfterAllWithTimeout(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         timeoutMs: Long,
         block: suspend (List<T>) -> Collection<R>
     ): AsyncOperationResult = addListAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
-        val values = deps[dep]!!.filterIsInstance(type.java)
+        val values = deps[dep]!!.filterIsInstance(type)
         block(values)
     }
-
-    /** Java-friendly overload of [addListAfterAllWithTimeout] — accepts [Class] instead of [KClass]. */
-    fun <T : Base, R : Base> addListAfterAllWithTimeout(key: String, dep: String, type: Class<T>, timeoutMs: Long, block: suspend (List<T>) -> Collection<R>): AsyncOperationResult =
-        addListAfterAllWithTimeout(key, dep, type.kotlin, timeoutMs, block)
 
     /** Java-friendly [Function] overload of [addListAfterAllWithTimeout]. */
     fun <T : Base, R : Base> addListAfterAllWithTimeout(
         key: String, dep: String, type: Class<T>, timeoutMs: Long,
         block: Function<List<T>, out Collection<out R>>
     ): AsyncOperationResult =
-        addListAfterAllWithTimeout(key, dep, type.kotlin, timeoutMs) { block.apply(it) }
+        addListAfterAllWithTimeout(key, dep, type, timeoutMs) { block.apply(it) }
 
     // ── Dependent task with retry ─────────────────────────────────────────────
 
@@ -649,7 +616,7 @@ class AsyncOperationResult {
     fun <T : Base> addAfterWithRetry(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
@@ -660,19 +627,10 @@ class AsyncOperationResult {
         initialDelayMs = initialDelayMs,
         retryOn = retryOn
     ) { deps ->
-        val value = deps[dep]!!.filterIsInstance(type.java).firstOrNull()
+        val value = deps[dep]!!.filterIsInstance(type).firstOrNull()
             ?: error("No value of type ${type.simpleName} found under dependency '$dep'")
         block(value)
     }
-
-    /** Java-friendly overload of [addAfterWithRetry] (typed) — accepts [Class] instead of [KClass]. */
-    @JvmOverloads
-    fun <T : Base> addAfterWithRetry(
-        key: String, dep: String, type: Class<T>,
-        maxAttempts: Int = 3, initialDelayMs: Long = 500,
-        retryOn: (Exception) -> Boolean = { true },
-        block: suspend (T) -> Base
-    ): AsyncOperationResult = addAfterWithRetry(key, dep, type.kotlin, maxAttempts, initialDelayMs, retryOn, block)
 
     /** Java-friendly [Function]/[Predicate] overload of [addAfterWithRetry] (typed). */
     @JvmOverloads
@@ -683,13 +641,13 @@ class AsyncOperationResult {
         retryOn: Predicate<Exception> = Predicate { true },
         block: Function<T, out Base>
     ): AsyncOperationResult =
-        addAfterWithRetry(key, dep, type.kotlin, maxAttempts, initialDelayMs, retryOn::test) { block.apply(it) }
+        addAfterWithRetry(key, dep, type, maxAttempts, initialDelayMs, retryOn::test) { block.apply(it) }
 
     @JvmOverloads
     fun <T : Base, R : Base> addListAfterWithRetry(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
@@ -700,19 +658,10 @@ class AsyncOperationResult {
         initialDelayMs = initialDelayMs,
         retryOn = retryOn
     ) { deps ->
-        val value = deps[dep]!!.filterIsInstance(type.java).firstOrNull()
+        val value = deps[dep]!!.filterIsInstance(type).firstOrNull()
             ?: error("No value of type ${type.simpleName} found under dependency '$dep'")
         block(value)
     }
-
-    /** Java-friendly overload of [addListAfterWithRetry] (typed) — accepts [Class] instead of [KClass]. */
-    @JvmOverloads
-    fun <T : Base, R : Base> addListAfterWithRetry(
-        key: String, dep: String, type: Class<T>,
-        maxAttempts: Int = 3, initialDelayMs: Long = 500,
-        retryOn: (Exception) -> Boolean = { true },
-        block: suspend (T) -> Collection<R>
-    ): AsyncOperationResult = addListAfterWithRetry(key, dep, type.kotlin, maxAttempts, initialDelayMs, retryOn, block)
 
     /** Java-friendly [Function]/[Predicate] overload of [addListAfterWithRetry] (typed). */
     @JvmOverloads
@@ -723,13 +672,13 @@ class AsyncOperationResult {
         retryOn: Predicate<Exception> = Predicate { true },
         block: Function<T, out Collection<out R>>
     ): AsyncOperationResult =
-        addListAfterWithRetry(key, dep, type.kotlin, maxAttempts, initialDelayMs, retryOn::test) { block.apply(it) }
+        addListAfterWithRetry(key, dep, type, maxAttempts, initialDelayMs, retryOn::test) { block.apply(it) }
 
     @JvmOverloads
     fun <T : Base> addAfterAllWithRetry(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
@@ -740,18 +689,9 @@ class AsyncOperationResult {
         initialDelayMs = initialDelayMs,
         retryOn = retryOn
     ) { deps ->
-        val values = deps[dep]!!.filterIsInstance(type.java)
+        val values = deps[dep]!!.filterIsInstance(type)
         block(values)
     }
-
-    /** Java-friendly overload of [addAfterAllWithRetry] — accepts [Class] instead of [KClass]. */
-    @JvmOverloads
-    fun <T : Base> addAfterAllWithRetry(
-        key: String, dep: String, type: Class<T>,
-        maxAttempts: Int = 3, initialDelayMs: Long = 500,
-        retryOn: (Exception) -> Boolean = { true },
-        block: suspend (List<T>) -> Base
-    ): AsyncOperationResult = addAfterAllWithRetry(key, dep, type.kotlin, maxAttempts, initialDelayMs, retryOn, block)
 
     /** Java-friendly [Function]/[Predicate] overload of [addAfterAllWithRetry]. */
     @JvmOverloads
@@ -762,13 +702,13 @@ class AsyncOperationResult {
         retryOn: Predicate<Exception> = Predicate { true },
         block: Function<List<T>, out Base>
     ): AsyncOperationResult =
-        addAfterAllWithRetry(key, dep, type.kotlin, maxAttempts, initialDelayMs, retryOn::test) { block.apply(it) }
+        addAfterAllWithRetry(key, dep, type, maxAttempts, initialDelayMs, retryOn::test) { block.apply(it) }
 
     @JvmOverloads
     fun <T : Base, R : Base> addListAfterAllWithRetry(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
@@ -779,18 +719,9 @@ class AsyncOperationResult {
         initialDelayMs = initialDelayMs,
         retryOn = retryOn
     ) { deps ->
-        val values = deps[dep]!!.filterIsInstance(type.java)
+        val values = deps[dep]!!.filterIsInstance(type)
         block(values)
     }
-
-    /** Java-friendly overload of [addListAfterAllWithRetry] — accepts [Class] instead of [KClass]. */
-    @JvmOverloads
-    fun <T : Base, R : Base> addListAfterAllWithRetry(
-        key: String, dep: String, type: Class<T>,
-        maxAttempts: Int = 3, initialDelayMs: Long = 500,
-        retryOn: (Exception) -> Boolean = { true },
-        block: suspend (List<T>) -> Collection<R>
-    ): AsyncOperationResult = addListAfterAllWithRetry(key, dep, type.kotlin, maxAttempts, initialDelayMs, retryOn, block)
 
     /** Java-friendly [Function]/[Predicate] overload of [addListAfterAllWithRetry]. */
     @JvmOverloads
@@ -801,7 +732,7 @@ class AsyncOperationResult {
         retryOn: Predicate<Exception> = Predicate { true },
         block: Function<List<T>, out Collection<out R>>
     ): AsyncOperationResult =
-        addListAfterAllWithRetry(key, dep, type.kotlin, maxAttempts, initialDelayMs, retryOn::test) { block.apply(it) }
+        addListAfterAllWithRetry(key, dep, type, maxAttempts, initialDelayMs, retryOn::test) { block.apply(it) }
 
     // ── Independent task with fallback value ─────────────────────────────────
 

--- a/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirExtensionHelper.kt
+++ b/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirExtensionHelper.kt
@@ -7,7 +7,6 @@ import org.hl7.fhir.instance.model.api.IBaseHasExtensions
 import java.util.Collections
 import java.util.IdentityHashMap
 import java.util.Optional
-import kotlin.reflect.KClass
 
 /**
  * Utility object for retrieving FHIR extensions from any object that can carry them.
@@ -109,11 +108,11 @@ object FhirExtensionHelper {
 
 internal fun <I : Base> filterByExtension(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     extUrls: Array<out String>,
     matchAll: Boolean
 ): List<I> {
-    val allOfType = allValues.filterIsInstance(type.java)
+    val allOfType = allValues.filterIsInstance(type)
     return if (extUrls.isEmpty()) allOfType
     else allOfType.filter { resource ->
         resource is IBaseHasExtensions && if (matchAll) {
@@ -126,14 +125,14 @@ internal fun <I : Base> filterByExtension(
 
 internal fun <I : Base, V : Type> filterByExtensionAndValueType(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     url: String,
-    valueType: KClass<V>,
+    valueType: Class<V>,
     predicate: (V) -> Boolean
 ): List<I> =
     allValues
-        .filterIsInstance(type.java)
+        .filterIsInstance(type)
         .filter { resource ->
             resource is IBaseHasExtensions &&
-                FhirExtensionHelper.getAllValuesAs(resource, url, valueType.java).any(predicate)
+                FhirExtensionHelper.getAllValuesAs(resource, url, valueType).any(predicate)
         }

--- a/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirFilter.kt
+++ b/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirFilter.kt
@@ -25,50 +25,47 @@ object FhirFilter {
     /** Returns `true` when the resource has **all** of the given extension URLs. */
     @JvmStatic
     fun hasAllExtensions(vararg urls: String): (Base) -> Boolean =
-        { filterByExtension(listOf(it), Base::class, urls, matchAll = true).isNotEmpty() }
+        { filterByExtension(listOf(it), Base::class.java, urls, matchAll = true).isNotEmpty() }
 
     /** Returns `true` when the resource has **at least one** of the given extension URLs. */
     @JvmStatic
     fun hasAnyExtension(vararg urls: String): (Base) -> Boolean =
-        { filterByExtension(listOf(it), Base::class, urls, matchAll = false).isNotEmpty() }
+        { filterByExtension(listOf(it), Base::class.java, urls, matchAll = false).isNotEmpty() }
 
     /**
      * Returns `true` when the resource has an extension at [url] whose value is an
      * instance of [valueType].
+     *
+     * @param url the extension URL to match
+     * @param valueType the expected Java class of the extension value
      */
     @JvmStatic
-    @Suppress("UNCHECKED_CAST")
-    fun hasExtensionWithValueType(url: String, valueType: KClass<out Type>): (Base) -> Boolean {
-        val typed = valueType as KClass<Type>
-        return { filterByExtensionAndValueType(listOf(it), Base::class, url, typed) { true }.isNotEmpty() }
-    }
-
-    /** Reified overload of [hasExtensionWithValueType]. */
-    inline fun <reified V : Type> hasExtensionWithValueType(url: String): (Base) -> Boolean =
-        hasExtensionWithValueType(url, V::class)
-
-    /** Java-friendly overload of [hasExtensionWithValueType] — accepts [Class] instead of [KClass]. */
-    @JvmStatic
     fun <V : Type> hasExtensionWithValueType(url: String, valueType: Class<V>): (Base) -> Boolean =
-        hasExtensionWithValueType(url, valueType.kotlin)
+        { filterByExtensionAndValueType(listOf(it), Base::class.java, url, valueType) { true }.isNotEmpty() }
+
+    /** Reified overload — no [Class] argument needed at call sites. */
+    inline fun <reified V : Type> hasExtensionWithValueType(url: String): (Base) -> Boolean =
+        hasExtensionWithValueType(url, V::class.java)
+
+    /** [KClass] overload — Kotlin callers may pass [KClass] directly. */
+    fun <V : Type> hasExtensionWithValueType(url: String, valueType: KClass<V>): (Base) -> Boolean =
+        hasExtensionWithValueType(url, valueType.java)
 
     /**
      * Returns `true` when the resource has an extension at [url] whose value is an instance
      * of [valueType] and satisfies [predicate].
      *
-     * Java callers: the [predicate] receives the value cast to [valueType]; use the
-     * reified overload from Kotlin for full type safety.
+     * @param url the extension URL to match
+     * @param valueType the expected Java class of the extension value
+     * @param predicate additional condition the value must satisfy
      */
     @JvmStatic
-    @Suppress("UNCHECKED_CAST")
-    fun hasExtensionValueMatching(
+    fun <V : Type> hasExtensionValueMatching(
         url: String,
-        valueType: KClass<out Type>,
-        predicate: (Type) -> Boolean
-    ): (Base) -> Boolean {
-        val typed = valueType as KClass<Type>
-        return { filterByExtensionAndValueType(listOf(it), Base::class, url, typed, predicate).isNotEmpty() }
-    }
+        valueType: Class<V>,
+        predicate: (V) -> Boolean
+    ): (Base) -> Boolean =
+        hasExtensionValueMatchingInternal(url, valueType, predicate)
 
     /**
      * Reified, fully type-safe overload of [hasExtensionValueMatching].
@@ -79,76 +76,67 @@ object FhirFilter {
         url: String,
         noinline predicate: (V) -> Boolean
     ): (Base) -> Boolean =
-        hasExtensionValueMatchingInternal(url, V::class, predicate)
-
-    /** Java-friendly overload of [hasExtensionValueMatching] — accepts [Class] instead of [KClass]. */
-    @JvmStatic
-    fun <V : Type> hasExtensionValueMatching(
-        url: String,
-        valueType: Class<V>,
-        predicate: (V) -> Boolean
-    ): (Base) -> Boolean =
-        hasExtensionValueMatchingInternal(url, valueType.kotlin, predicate)
+        hasExtensionValueMatchingInternal(url, V::class.java, predicate)
 
     @PublishedApi
     @JvmSynthetic
     internal fun <V : Type> hasExtensionValueMatchingInternal(
         url: String,
-        valueType: KClass<V>,
+        valueType: Class<V>,
         predicate: (V) -> Boolean
     ): (Base) -> Boolean =
-        { filterByExtensionAndValueType(listOf(it), Base::class, url, valueType, predicate).isNotEmpty() }
+        { filterByExtensionAndValueType(listOf(it), Base::class.java, url, valueType, predicate).isNotEmpty() }
 
     // ── Identifier predicates ─────────────────────────────────────────────────
 
     /** Returns `true` when the resource has an identifier with [system]. */
     @JvmStatic
     fun hasIdentifierWithSystem(system: String): (Base) -> Boolean =
-        { filterByIdentifierSystem(listOf(it), Base::class, system).isNotEmpty() }
+        { filterByIdentifierSystem(listOf(it), Base::class.java, system).isNotEmpty() }
 
     /** Returns `true` when the resource has an identifier with [identifierValue]. */
     @JvmStatic
     fun hasIdentifierWithValue(identifierValue: String): (Base) -> Boolean =
-        { filterByIdentifierValue(listOf(it), Base::class, identifierValue).isNotEmpty() }
+        { filterByIdentifierValue(listOf(it), Base::class.java, identifierValue).isNotEmpty() }
 
     /** Returns `true` when the resource has an identifier matching both [system] and [identifierValue]. */
     @JvmStatic
     fun hasIdentifier(system: String, identifierValue: String): (Base) -> Boolean =
-        { filterByIdentifier(listOf(it), Base::class, system, identifierValue).isNotEmpty() }
+        { filterByIdentifier(listOf(it), Base::class.java, system, identifierValue).isNotEmpty() }
 
     // ── Meta tag predicates ───────────────────────────────────────────────────
 
     /** Returns `true` when the resource has a meta.tag with [system]. */
     @JvmStatic
     fun hasMetaTagWithSystem(system: String): (Base) -> Boolean =
-        { filterByMetaTagSystem(listOf(it), Base::class, system).isNotEmpty() }
+        { filterByMetaTagSystem(listOf(it), Base::class.java, system).isNotEmpty() }
 
     /** Returns `true` when the resource has a meta.tag with [code]. */
     @JvmStatic
     fun hasMetaTagWithCode(code: String): (Base) -> Boolean =
-        { filterByMetaTagCode(listOf(it), Base::class, code).isNotEmpty() }
+        { filterByMetaTagCode(listOf(it), Base::class.java, code).isNotEmpty() }
 
     /** Returns `true` when the resource has a meta.tag matching both [system] and [code]. */
     @JvmStatic
     fun hasMetaTag(system: String, code: String): (Base) -> Boolean =
-        { filterByMetaTag(listOf(it), Base::class, system, code).isNotEmpty() }
+        { filterByMetaTag(listOf(it), Base::class.java, system, code).isNotEmpty() }
 
     // ── Meta security predicates ──────────────────────────────────────────────
 
     /** Returns `true` when the resource has a meta.security with [system]. */
     @JvmStatic
     fun hasMetaSecurityWithSystem(system: String): (Base) -> Boolean =
-        { filterByMetaSecuritySystem(listOf(it), Base::class, system).isNotEmpty() }
+        { filterByMetaSecuritySystem(listOf(it), Base::class.java, system).isNotEmpty() }
 
     /** Returns `true` when the resource has a meta.security with [code]. */
     @JvmStatic
     fun hasMetaSecurityWithCode(code: String): (Base) -> Boolean =
-        { filterByMetaSecurityCode(listOf(it), Base::class, code).isNotEmpty() }
+        { filterByMetaSecurityCode(listOf(it), Base::class.java, code).isNotEmpty() }
 
     /** Returns `true` when the resource has a meta.security matching both [system] and [code]. */
     @JvmStatic
     fun hasMetaSecurity(system: String, code: String): (Base) -> Boolean =
-        { filterByMetaSecurity(listOf(it), Base::class, system, code).isNotEmpty() }
+        { filterByMetaSecurity(listOf(it), Base::class.java, system, code).isNotEmpty() }
 
     // ── Combinators ───────────────────────────────────────────────────────────
 
@@ -172,5 +160,5 @@ object FhirFilter {
     /** Returns `true` when the resource has the given [url] in meta.profile. */
     @JvmStatic
     fun hasMetaProfile(url: String): (Base) -> Boolean =
-        { filterByMetaProfile(listOf(it), Base::class, url).isNotEmpty() }
+        { filterByMetaProfile(listOf(it), Base::class.java, url).isNotEmpty() }
 }

--- a/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirFilter.kt
+++ b/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirFilter.kt
@@ -2,7 +2,6 @@ package dev.ratkay.operation.dstu3
 
 import org.hl7.fhir.dstu3.model.Base
 import org.hl7.fhir.dstu3.model.Type
-import kotlin.reflect.KClass
 
 /**
  * Predicate factories for use with [OperationResult.addFromFiltered] and
@@ -47,10 +46,6 @@ object FhirFilter {
     inline fun <reified V : Type> hasExtensionWithValueType(url: String): (Base) -> Boolean =
         hasExtensionWithValueType(url, V::class.java)
 
-    /** [KClass] overload — Kotlin callers may pass [KClass] directly. */
-    fun <V : Type> hasExtensionWithValueType(url: String, valueType: KClass<V>): (Base) -> Boolean =
-        hasExtensionWithValueType(url, valueType.java)
-
     /**
      * Returns `true` when the resource has an extension at [url] whose value is an instance
      * of [valueType] and satisfies [predicate].
@@ -77,14 +72,6 @@ object FhirFilter {
         noinline predicate: (V) -> Boolean
     ): (Base) -> Boolean =
         hasExtensionValueMatchingInternal(url, V::class.java, predicate)
-
-    /** [KClass] overload — Kotlin callers may pass [KClass] directly. */
-    fun <V : Type> hasExtensionValueMatching(
-        url: String,
-        valueType: KClass<V>,
-        predicate: (V) -> Boolean
-    ): (Base) -> Boolean =
-        hasExtensionValueMatchingInternal(url, valueType.java, predicate)
 
     @PublishedApi
     @JvmSynthetic

--- a/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirFilter.kt
+++ b/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirFilter.kt
@@ -78,6 +78,14 @@ object FhirFilter {
     ): (Base) -> Boolean =
         hasExtensionValueMatchingInternal(url, V::class.java, predicate)
 
+    /** [KClass] overload — Kotlin callers may pass [KClass] directly. */
+    fun <V : Type> hasExtensionValueMatching(
+        url: String,
+        valueType: KClass<V>,
+        predicate: (V) -> Boolean
+    ): (Base) -> Boolean =
+        hasExtensionValueMatchingInternal(url, valueType.java, predicate)
+
     @PublishedApi
     @JvmSynthetic
     internal fun <V : Type> hasExtensionValueMatchingInternal(

--- a/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirIdentifierHelper.kt
+++ b/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirIdentifierHelper.kt
@@ -2,7 +2,6 @@ package dev.ratkay.operation.dstu3
 
 import org.hl7.fhir.dstu3.model.Base
 import org.hl7.fhir.dstu3.model.Identifier
-import kotlin.reflect.KClass
 
 internal fun identifiersOf(resource: Base): List<Identifier> =
     resource.children()
@@ -13,24 +12,24 @@ internal fun identifiersOf(resource: Base): List<Identifier> =
 
 internal fun <I : Base> filterByIdentifierSystem(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     system: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> identifiersOf(resource).any { it.system == system } }
 
 internal fun <I : Base> filterByIdentifierValue(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     identifierValue: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> identifiersOf(resource).any { it.value == identifierValue } }
 
 internal fun <I : Base> filterByIdentifier(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     system: String,
     identifierValue: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource ->
         identifiersOf(resource).any { it.system == system && it.value == identifierValue }
     }

--- a/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirMetaHelper.kt
+++ b/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/FhirMetaHelper.kt
@@ -3,7 +3,6 @@ package dev.ratkay.operation.dstu3
 import org.hl7.fhir.dstu3.model.Base
 import org.hl7.fhir.dstu3.model.Coding
 import org.hl7.fhir.dstu3.model.Resource
-import kotlin.reflect.KClass
 
 internal fun metaTagsOf(resource: Base): List<Coding> =
     if (resource is Resource) resource.meta.tag else emptyList()
@@ -16,51 +15,51 @@ internal fun metaProfilesOf(resource: Base): List<String> =
 
 internal fun <I : Base> filterByMetaTagSystem(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     system: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> metaTagsOf(resource).any { it.system == system } }
 
 internal fun <I : Base> filterByMetaTagCode(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     code: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> metaTagsOf(resource).any { it.code == code } }
 
 internal fun <I : Base> filterByMetaTag(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     system: String,
     code: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> metaTagsOf(resource).any { it.system == system && it.code == code } }
 
 internal fun <I : Base> filterByMetaSecuritySystem(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     system: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> metaSecurityOf(resource).any { it.system == system } }
 
 internal fun <I : Base> filterByMetaSecurityCode(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     code: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> metaSecurityOf(resource).any { it.code == code } }
 
 internal fun <I : Base> filterByMetaSecurity(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     system: String,
     code: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> metaSecurityOf(resource).any { it.system == system && it.code == code } }
 
 internal fun <I : Base> filterByMetaProfile(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     url: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> metaProfilesOf(resource).any { it == url } }

--- a/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
+++ b/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/OperationResult.kt
@@ -32,7 +32,6 @@ import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZonedDateTime
 import java.util.IdentityHashMap
-import kotlin.reflect.KClass
 import kotlin.time.measureTime
 import kotlin.time.measureTimedValue
 
@@ -316,31 +315,22 @@ class OperationResult<T> private constructor(
     @JvmOverloads
     fun <I : Base, R : Base> addFromFiltered(
         name: String? = null,
-        type: KClass<I>,
+        type: Class<I>,
         predicate: (I) -> Boolean,
         builder: (List<I>) -> R
     ): OperationResult<R> = runBuilderStep(name) {
         val (value, duration) = measureTimedValue {
-            builder(parameters.values.flatten().filterIsInstance(type.java).filter(predicate))
+            builder(parameters.values.flatten().filterIsInstance(type).filter(predicate))
         }
         storeAndCopy(name, value, duration.inWholeMilliseconds)
     }
 
-    /** Reified overload of [addFromFiltered] — no explicit [KClass] needed. */
+    /** Reified overload of [addFromFiltered] — no explicit [Class] needed. */
     inline fun <reified I : Base, R : Base> addFromFiltered(
         name: String? = null,
         noinline predicate: (I) -> Boolean,
         noinline builder: (List<I>) -> R
-    ): OperationResult<R> = addFromFiltered(name, I::class, predicate, builder)
-
-    /** Java-friendly overload of [addFromFiltered] — accepts [Class] instead of [KClass]. */
-    @JvmOverloads
-    fun <I : Base, R : Base> addFromFiltered(
-        name: String? = null,
-        type: Class<I>,
-        predicate: (I) -> Boolean,
-        builder: (List<I>) -> R
-    ): OperationResult<R> = addFromFiltered(name, type.kotlin, predicate, builder)
+    ): OperationResult<R> = addFromFiltered(name, I::class.java, predicate, builder)
 
     /**
      * Like [addFromFiltered] but [builder] returns a `Collection<R>`, making the new
@@ -352,36 +342,27 @@ class OperationResult<T> private constructor(
     @JvmOverloads
     fun <I : Base, R : Base> addAllFromFiltered(
         name: String? = null,
-        type: KClass<I>,
+        type: Class<I>,
         predicate: (I) -> Boolean,
         builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = runBuilderStep(name) {
         val (values, duration) = measureTimedValue {
-            builder(parameters.values.flatten().filterIsInstance(type.java).filter(predicate))
+            builder(parameters.values.flatten().filterIsInstance(type).filter(predicate))
         }
         storeListAndCopy(name, values, duration.inWholeMilliseconds)
     }
 
-    /** Reified overload of [addAllFromFiltered] — no explicit [KClass] needed. */
+    /** Reified overload of [addAllFromFiltered] — no explicit [Class] needed. */
     inline fun <reified I : Base, R : Base> addAllFromFiltered(
         name: String? = null,
         noinline predicate: (I) -> Boolean,
         noinline builder: (List<I>) -> Collection<R>
-    ): OperationResult<List<R>> = addAllFromFiltered(name, I::class, predicate, builder)
-
-    /** Java-friendly overload of [addAllFromFiltered] — accepts [Class] instead of [KClass]. */
-    @JvmOverloads
-    fun <I : Base, R : Base> addAllFromFiltered(
-        name: String? = null,
-        type: Class<I>,
-        predicate: (I) -> Boolean,
-        builder: (List<I>) -> Collection<R>
-    ): OperationResult<List<R>> = addAllFromFiltered(name, type.kotlin, predicate, builder)
+    ): OperationResult<List<R>> = addAllFromFiltered(name, I::class.java, predicate, builder)
 
     // Builder methods — filter all accumulated parameters by type and FHIRPath expression
 
-    private fun <I : Base> collectByPath(type: KClass<I>, expression: String): List<I> =
-        filterByPath(parameters.values.flatten(), type.java, expression)
+    private fun <I : Base> collectByPath(type: Class<I>, expression: String): List<I> =
+        filterByPath(parameters.values.flatten(), type, expression)
 
     /**
      * Searches **all** accumulated parameters for instances of [type] where [expression]
@@ -400,7 +381,7 @@ class OperationResult<T> private constructor(
     @JvmOverloads
     fun <I : Base, R : Base> addFromMatching(
         name: String? = null,
-        type: KClass<I>,
+        type: Class<I>,
         expression: String,
         builder: (List<I>) -> R
     ): OperationResult<R> {
@@ -414,7 +395,7 @@ class OperationResult<T> private constructor(
     @JvmOverloads
     fun <I : Base, R : Base> addFromMatching(
         name: String? = null,
-        type: KClass<I>,
+        type: Class<I>,
         expression: FhirPath,
         builder: (List<I>) -> R
     ): OperationResult<R> = addFromMatching(name, type, expression.build(), builder)
@@ -430,7 +411,7 @@ class OperationResult<T> private constructor(
     @JvmOverloads
     fun <I : Base, R : Base> addAllFromMatching(
         name: String? = null,
-        type: KClass<I>,
+        type: Class<I>,
         expression: String,
         builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> {
@@ -444,38 +425,38 @@ class OperationResult<T> private constructor(
     @JvmOverloads
     fun <I : Base, R : Base> addAllFromMatching(
         name: String? = null,
-        type: KClass<I>,
+        type: Class<I>,
         expression: FhirPath,
         builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = addAllFromMatching(name, type, expression.build(), builder)
 
-    /** Reified overload of [addFromMatching] — no [KClass] argument needed at call sites. */
+    /** Reified overload of [addFromMatching] — no [Class] argument needed at call sites. */
     inline fun <reified I : Base, R : Base> addFromMatching(
         name: String? = null,
         expression: String,
         noinline builder: (List<I>) -> R
-    ): OperationResult<R> = addFromMatching(name, I::class, expression, builder)
+    ): OperationResult<R> = addFromMatching(name, I::class.java, expression, builder)
 
     /** [FhirPath] reified overload of [addFromMatching]. */
     inline fun <reified I : Base, R : Base> addFromMatching(
         name: String? = null,
         expression: FhirPath,
         noinline builder: (List<I>) -> R
-    ): OperationResult<R> = addFromMatching(name, I::class, expression.build(), builder)
+    ): OperationResult<R> = addFromMatching(name, I::class.java, expression.build(), builder)
 
-    /** Reified overload of [addAllFromMatching] — no [KClass] argument needed at call sites. */
+    /** Reified overload of [addAllFromMatching] — no [Class] argument needed at call sites. */
     inline fun <reified I : Base, R : Base> addAllFromMatching(
         name: String? = null,
         expression: String,
         noinline builder: (List<I>) -> Collection<R>
-    ): OperationResult<List<R>> = addAllFromMatching(name, I::class, expression, builder)
+    ): OperationResult<List<R>> = addAllFromMatching(name, I::class.java, expression, builder)
 
     /** [FhirPath] reified overload of [addAllFromMatching]. */
     inline fun <reified I : Base, R : Base> addAllFromMatching(
         name: String? = null,
         expression: FhirPath,
         noinline builder: (List<I>) -> Collection<R>
-    ): OperationResult<List<R>> = addAllFromMatching(name, I::class, expression.build(), builder)
+    ): OperationResult<List<R>> = addAllFromMatching(name, I::class.java, expression.build(), builder)
 
     // Builder methods - single item
 
@@ -551,20 +532,14 @@ class OperationResult<T> private constructor(
      *
      * Error handling follows Pattern A.
      */
-    fun <I : Base, R : Base> addFrom(name: String, type: KClass<I>, builder: (List<I>) -> R): OperationResult<R> =
+    fun <I : Base, R : Base> addFrom(name: String, type: Class<I>, builder: (List<I>) -> R): OperationResult<R> =
         runBuilderStep(name) {
             val (value, duration) = measureTimedValue {
-                val filtered = parameters[name]?.filterIsInstance(type.java) ?: emptyList()
+                val filtered = parameters[name]?.filterIsInstance(type) ?: emptyList()
                 builder(filtered)
             }
             storeAndCopy(name, value, duration.inWholeMilliseconds)
         }
-
-    /**
-     * Java-friendly overload of [addFrom] — accepts a [Class] instead of a [KClass].
-     */
-    fun <I : Base, R : Base> addFrom(name: String, type: Class<I>, builder: (List<I>) -> R): OperationResult<R> =
-        addFrom(name, type.kotlin, builder)
 
     /**
      * Like [addFrom] but [builder] returns a `Collection<R>`. The pipeline head becomes `List<R>`.
@@ -574,20 +549,14 @@ class OperationResult<T> private constructor(
      *
      * Error handling follows Pattern A.
      */
-    fun <I : Base, R : Base> addAllFrom(name: String, type: KClass<I>, builder: (List<I>) -> Collection<R>): OperationResult<List<R>> =
+    fun <I : Base, R : Base> addAllFrom(name: String, type: Class<I>, builder: (List<I>) -> Collection<R>): OperationResult<List<R>> =
         runBuilderStep(name) {
             val (values, duration) = measureTimedValue {
-                val filtered = parameters[name]?.filterIsInstance(type.java) ?: emptyList()
+                val filtered = parameters[name]?.filterIsInstance(type) ?: emptyList()
                 builder(filtered)
             }
             storeListAndCopy(name, values, duration.inWholeMilliseconds)
         }
-
-    /**
-     * Java-friendly overload of [addAllFrom] — accepts a [Class] instead of a [KClass].
-     */
-    fun <I : Base, R : Base> addAllFrom(name: String, type: Class<I>, builder: (List<I>) -> Collection<R>): OperationResult<List<R>> =
-        addAllFrom(name, type.kotlin, builder)
 
     // Builder variants with explicit error handling
 
@@ -1005,16 +974,11 @@ class OperationResult<T> private constructor(
      * Returns all accumulated values that are instances of [type], across all keys.
      * Prefer the inline reified overload [getByType] where the type can be inferred.
      */
-    fun <R : Base> getByType(type: KClass<R>): List<R> =
-        parameters.values.flatten().filterIsInstance(type.java)
+    fun <R : Base> getByType(type: Class<R>): List<R> =
+        parameters.values.flatten().filterIsInstance(type)
 
-    /** Reified overload — no [KClass] argument needed at call sites. */
-    inline fun <reified R : Base> getByType(): List<R> = getByType(R::class)
-
-    /**
-     * Java-friendly overload of [getByType] — accepts a [Class] instead of a [KClass].
-     */
-    fun <R : Base> getByType(type: Class<R>): List<R> = getByType(type.kotlin)
+    /** Reified overload — no [Class] argument needed at call sites. */
+    inline fun <reified R : Base> getByType(): List<R> = getByType(R::class.java)
 
     override fun containsKey(name: String): Boolean =
         parameters.containsKey(name)
@@ -1040,10 +1004,10 @@ class OperationResult<T> private constructor(
      * Returns a new result containing only entries whose values match [type].
      * Prefer the inline reified overload [filterByType] where the type can be inferred.
      */
-    fun <R : Base> filterByType(type: KClass<R>): OperationResult<T> {
+    fun <R : Base> filterByType(type: Class<R>): OperationResult<T> {
         val filtered = mutableMapOf<String, MutableList<Base>>()
         parameters.forEach { (name, values) ->
-            val matchingValues = values.filterIsInstance(type.java)
+            val matchingValues = values.filterIsInstance(type)
             if (matchingValues.isNotEmpty()) {
                 filtered[name] = matchingValues.toMutableList()
             }
@@ -1051,13 +1015,8 @@ class OperationResult<T> private constructor(
         return copyWith(result, params = filtered)
     }
 
-    /** Reified overload — no [KClass] argument needed at call sites. */
-    inline fun <reified R : Base> filterByType(): OperationResult<T> = filterByType(R::class)
-
-    /**
-     * Java-friendly overload of [filterByType] — accepts a [Class] instead of a [KClass].
-     */
-    fun <R : Base> filterByType(type: Class<R>): OperationResult<T> = filterByType(type.kotlin)
+    /** Reified overload — no [Class] argument needed at call sites. */
+    inline fun <reified R : Base> filterByType(): OperationResult<T> = filterByType(R::class.java)
 
     /** Returns a new result containing only the entry for [name]. All other keys are dropped. No-op if [name] is absent. */
     fun filterByName(name: String): OperationResult<T> {
@@ -1155,10 +1114,10 @@ class OperationResult<T> private constructor(
      * Respects [ErrorStrategy.FAIL_FAST]: returns immediately when the pipeline has errors.
      *
      * @param name the key whose values to transform.
-     * @param type the [KClass] of values to match; non-matching values pass through.
+     * @param type the [Class] of values to match; non-matching values pass through.
      * @param transform element-wise mapping function applied to each matching value.
      */
-    fun <I : Base, R : Base> mapStored(name: String, type: KClass<I>, transform: (I) -> R): OperationResult<T> {
+    fun <I : Base, R : Base> mapStored(name: String, type: Class<I>, transform: (I) -> R): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val (outcome, duration) = measureTimedValue {
             runCatching {
@@ -1166,7 +1125,7 @@ class OperationResult<T> private constructor(
                 val existing = newParams[name]
                 if (existing != null) {
                     newParams[name] = existing.map {
-                        if (type.java.isInstance(it)) transform(type.java.cast(it)) else it
+                        if (type.isInstance(it)) transform(type.cast(it)) else it
                     }.toMutableList()
                 }
                 newParams
@@ -1185,13 +1144,9 @@ class OperationResult<T> private constructor(
         )
     }
 
-    /** Java-friendly [Class] overload of [mapStored] — targets values under [name]. */
-    fun <I : Base, R : Base> mapStored(name: String, type: Class<I>, transform: (I) -> R): OperationResult<T> =
-        mapStored(name, type.kotlin, transform)
-
-    /** Reified overload — no [KClass] argument needed at call sites. Targets values under [name]. */
+    /** Reified overload — no [Class] argument needed at call sites. Targets values under [name]. */
     inline fun <reified I : Base, R : Base> mapStored(name: String, noinline transform: (I) -> R): OperationResult<T> =
-        mapStored(name, I::class, transform)
+        mapStored(name, I::class.java, transform)
 
     /**
      * Applies [transform] to every value across all stored keys that is an instance of [type],
@@ -1205,16 +1160,16 @@ class OperationResult<T> private constructor(
      * the original parameter map is preserved unchanged (Pattern B — head-preserving).
      * Respects [ErrorStrategy.FAIL_FAST]: returns immediately when the pipeline has errors.
      *
-     * @param type the [KClass] of values to match; non-matching values pass through.
+     * @param type the [Class] of values to match; non-matching values pass through.
      * @param transform element-wise mapping function applied to each matching value.
      */
-    fun <I : Base, R : Base> mapStored(type: KClass<I>, transform: (I) -> R): OperationResult<T> {
+    fun <I : Base, R : Base> mapStored(type: Class<I>, transform: (I) -> R): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val (outcome, duration) = measureTimedValue {
             runCatching {
                 val newParams = shallowCopyParams()
                 newParams.replaceAll { _, values ->
-                    values.map { if (type.java.isInstance(it)) transform(type.java.cast(it)) else it }.toMutableList()
+                    values.map { if (type.isInstance(it)) transform(type.cast(it)) else it }.toMutableList()
                 }
                 newParams
             }
@@ -1232,13 +1187,9 @@ class OperationResult<T> private constructor(
         )
     }
 
-    /** Java-friendly [Class] overload of [mapStored] — targets all stored values of [type] across all keys. */
-    fun <I : Base, R : Base> mapStored(type: Class<I>, transform: (I) -> R): OperationResult<T> =
-        mapStored(type.kotlin, transform)
-
-    /** Reified overload — no [KClass] argument needed at call sites. Targets all stored values of the type across all keys. */
+    /** Reified overload — no [Class] argument needed at call sites. Targets all stored values of the type across all keys. */
     inline fun <reified I : Base, R : Base> mapStored(noinline transform: (I) -> R): OperationResult<T> =
-        mapStored(I::class, transform)
+        mapStored(I::class.java, transform)
 
     /**
      * Invokes [block] with a snapshot of the current parameter map for side-effects (logging,
@@ -1465,13 +1416,13 @@ class OperationResult<T> private constructor(
      * `result.selectByPath<HumanName>("name.first()")`
      */
     @JvmOverloads
-    fun <R : Base> selectByPath(type: KClass<R>, expression: String, name: String? = null): OperationResult<R> {
+    fun <R : Base> selectByPath(type: Class<R>, expression: String, name: String? = null): OperationResult<R> {
         val stepName = name ?: expression
         return runBuilderStep(stepName) {
             val head = result
             require(head is Base) { "selectByPath: head value is not a FHIR resource" }
             val (match, duration) = measureTimedValue {
-                FhirPathHelper.evaluateFirst(head as Base, expression, type.java)
+                FhirPathHelper.evaluateFirst(head as Base, expression, type)
                     ?: error("selectByPath: expression '$expression' matched no ${type.simpleName} values")
             }
             storeAndCopy(name, match, duration.inWholeMilliseconds)
@@ -1480,16 +1431,16 @@ class OperationResult<T> private constructor(
 
     /** [FhirPath] overload of [selectByPath] — builds the expression and delegates. */
     @JvmOverloads
-    fun <R : Base> selectByPath(type: KClass<R>, expression: FhirPath, name: String? = null): OperationResult<R> =
+    fun <R : Base> selectByPath(type: Class<R>, expression: FhirPath, name: String? = null): OperationResult<R> =
         selectByPath(type, expression.build(), name)
 
-    /** Reified overload of [selectByPath] — no [KClass] argument needed at call sites. */
+    /** Reified overload of [selectByPath] — no [Class] argument needed at call sites. */
     inline fun <reified R : Base> selectByPath(expression: String, name: String? = null): OperationResult<R> =
-        selectByPath(R::class, expression, name)
+        selectByPath(R::class.java, expression, name)
 
     /** [FhirPath] reified overload of [selectByPath]. */
     inline fun <reified R : Base> selectByPath(expression: FhirPath, name: String? = null): OperationResult<R> =
-        selectByPath(R::class, expression.build(), name)
+        selectByPath(R::class.java, expression.build(), name)
 
     /** Returns the first value stored under [name], or `null` if the key is absent or empty. */
     fun takeFirst(name: String): Base? = parameters[name]?.firstOrNull()
@@ -1498,11 +1449,11 @@ class OperationResult<T> private constructor(
      * Returns the first value stored under [name] that is an instance of [type], or `null`.
      * Prefer the inline reified overload [takeFirstTyped] where the type can be inferred.
      */
-    fun <R : Base> takeFirstTyped(name: String, type: KClass<R>): R? =
-        parameters[name]?.filterIsInstance(type.java)?.firstOrNull()
+    fun <R : Base> takeFirstTyped(name: String, type: Class<R>): R? =
+        parameters[name]?.filterIsInstance(type)?.firstOrNull()
 
-    /** Reified overload — no [KClass] argument needed at call sites. */
-    inline fun <reified R : Base> takeFirstTyped(name: String): R? = takeFirstTyped(name, R::class)
+    /** Reified overload — no [Class] argument needed at call sites. */
+    inline fun <reified R : Base> takeFirstTyped(name: String): R? = takeFirstTyped(name, R::class.java)
 
     /**
      * Extracts the first value of type [R] stored under [name] and sets it as the pipeline head.
@@ -1513,45 +1464,33 @@ class OperationResult<T> private constructor(
      * all subsequent steps, ACCUMULATE will continue).
      *
      * @param name the parameter-map key to look up.
-     * @param type the expected [KClass] of the stored resource.
+     * @param type the expected [Class] of the stored resource.
      */
-    fun <R : Base> extractParam(name: String, type: KClass<R>): OperationResult<R> =
+    fun <R : Base> extractParam(name: String, type: Class<R>): OperationResult<R> =
         runBuilderStep(name) {
-            val value = parameters[name]?.filterIsInstance(type.java)?.firstOrNull()
+            val value = parameters[name]?.filterIsInstance(type)?.firstOrNull()
                 ?: error("No value of type '${type.simpleName}' found under key '$name'")
             copyWith(value)
         }
 
-    /** Reified overload — no [KClass] argument needed at call sites. */
+    /** Reified overload — no [Class] argument needed at call sites. */
     inline fun <reified R : Base> extractParam(name: String): OperationResult<R> =
-        extractParam(name, R::class)
-
-    /**
-     * Java-friendly overload of [extractParam] — accepts a [Class] instead of a [KClass].
-     */
-    fun <R : Base> extractParam(name: String, type: Class<R>): OperationResult<R> =
-        extractParam(name, type.kotlin)
+        extractParam(name, R::class.java)
 
     /**
      * Extracts all values of type [R] stored under [name] and sets the list as the pipeline head.
      * Returns an empty list (not an error) if no values match.
      */
-    fun <R : Base> extractParamList(name: String, type: KClass<R>): OperationResult<List<R>> {
+    fun <R : Base> extractParamList(name: String, type: Class<R>): OperationResult<List<R>> {
         val values = parameters[name]
-            ?.filterIsInstance(type.java)
+            ?.filterIsInstance(type)
             ?: emptyList()
         return copyWith(values)
     }
 
-    /** Reified overload — no [KClass] argument needed at call sites. */
+    /** Reified overload — no [Class] argument needed at call sites. */
     inline fun <reified R : Base> extractParamList(name: String): OperationResult<List<R>> =
-        extractParamList(name, R::class)
-
-    /**
-     * Java-friendly overload of [extractParamList] — accepts a [Class] instead of a [KClass].
-     */
-    fun <R : Base> extractParamList(name: String, type: Class<R>): OperationResult<List<R>> =
-        extractParamList(name, type.kotlin)
+        extractParamList(name, R::class.java)
 
     // Reference linking
 
@@ -1812,16 +1751,16 @@ class OperationResult<T> private constructor(
          * Call [useErrorStrategy] on the returned result to change the strategy if needed.
          *
          * @param primaryKey the parameter-map key whose value should become the pipeline head.
-         * @param type the expected [KClass] of the primary resource.
+         * @param type the expected [Class] of the primary resource.
          */
         @JvmStatic
         fun <T : Base> fromParametersTyped(
             parameters: Parameters,
             primaryKey: String,
-            type: KClass<T>
+            type: Class<T>
         ): OperationResult<T> {
             val (params, exts) = ParameterMapSerializer.flatten(parameters)
-            val primary = params[primaryKey]?.filterIsInstance(type.java)?.firstOrNull()
+            val primary = params[primaryKey]?.filterIsInstance(type)?.firstOrNull()
             return if (primary != null) {
                 OperationResult(params, primary, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf(), extensions = exts)
             } else {
@@ -1830,25 +1769,11 @@ class OperationResult<T> private constructor(
             }
         }
 
-        /** Reified overload of [fromParametersTyped] — no [KClass] argument needed at call sites. */
+        /** Reified overload of [fromParametersTyped] — no [Class] argument needed at call sites. */
         inline fun <reified T : Base> fromParametersTyped(
             parameters: Parameters,
             primaryKey: String
-        ): OperationResult<T> = fromParametersTyped(parameters, primaryKey, T::class)
-
-        /**
-         * Java-friendly overload of [fromParametersTyped] — accepts a [Class] instead of a [KClass]
-         * so Java callers can write `fromParametersTyped(params, "patient", Patient.class)`.
-         *
-         * When no value of [type] is found under [primaryKey], returns a pipeline with
-         * [hasErrors] `== true` and a null head.
-         */
-        @JvmStatic
-        fun <T : Base> fromParametersTyped(
-            parameters: Parameters,
-            primaryKey: String,
-            type: Class<T>
-        ): OperationResult<T> = fromParametersTyped(parameters, primaryKey, type.kotlin)
+        ): OperationResult<T> = fromParametersTyped(parameters, primaryKey, T::class.java)
 
         /**
          * Builds an [OperationResult] from a FHIR [Bundle].
@@ -1907,13 +1832,13 @@ class OperationResult<T> private constructor(
          * [hasErrors] `== true` and a null head (consistent with Pattern A mid-pipeline steps).
          *
          * @param primaryKey the parameter-map key whose value should become the pipeline head.
-         * @param type the expected [KClass] of the primary resource.
+         * @param type the expected [Class] of the primary resource.
          */
         @JvmStatic
         fun <T : Resource> fromBundleTyped(
             bundle: Bundle,
             primaryKey: String,
-            type: KClass<T>
+            type: Class<T>
         ): OperationResult<T> {
             val params = mutableMapOf<String, MutableList<Base>>()
             bundle.entry
@@ -1922,7 +1847,7 @@ class OperationResult<T> private constructor(
                     val key = entry.resource.fhirType().lowercase()
                     params.getOrPut(key) { mutableListOf() }.add(entry.resource)
                 }
-            val primary = params[primaryKey]?.filterIsInstance(type.java)?.firstOrNull()
+            val primary = params[primaryKey]?.filterIsInstance(type)?.firstOrNull()
             return if (primary != null) {
                 OperationResult(params, primary, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
             } else {
@@ -1931,24 +1856,11 @@ class OperationResult<T> private constructor(
             }
         }
 
-        /**
-         * Java-friendly overload of [fromBundleTyped] — accepts [Class] instead of [KClass].
-         *
-         * When no resource of [type] is found under [primaryKey], returns a pipeline with
-         * [hasErrors] `== true` and a null head.
-         */
-        @JvmStatic
-        fun <T : Resource> fromBundleTyped(
-            bundle: Bundle,
-            primaryKey: String,
-            type: Class<T>
-        ): OperationResult<T> = fromBundleTyped(bundle, primaryKey, type.kotlin)
-
-        /** Reified overload of [fromBundleTyped] — no [KClass] argument needed at call sites. */
+        /** Reified overload of [fromBundleTyped] — no [Class] argument needed at call sites. */
         inline fun <reified T : Resource> fromBundleTyped(
             bundle: Bundle,
             primaryKey: String
-        ): OperationResult<T> = fromBundleTyped(bundle, primaryKey, T::class)
+        ): OperationResult<T> = fromBundleTyped(bundle, primaryKey, T::class.java)
 
         /**
          * Creates an empty [OperationResult] with no parameters and no pipeline head.

--- a/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/ReferenceLinkRule.kt
+++ b/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/ReferenceLinkRule.kt
@@ -1,10 +1,33 @@
 package dev.ratkay.operation.dstu3
 
 import org.hl7.fhir.dstu3.model.Resource
+import java.util.function.BiConsumer
 import kotlin.reflect.KClass
 
 /**
  * Describes an explicit reference-linking rule between two FHIR DSTU3 resource types.
+ *
+ * When [OperationResult.linkReferences] is called with a list of rules, each rule is
+ * applied to every matching (source, target) pair found in the accumulated parameters.
+ * The [setter] lambda receives the strongly-typed source and target so callers don't
+ * need to cast.
+ *
+ * Kotlin callers use the primary constructor with `KClass` and a lambda:
+ * ```kotlin
+ * val rule = ReferenceLinkRule(
+ *     sourceType = Encounter::class,
+ *     targetType = Patient::class,
+ *     setter     = { encounter, patient -> encounter.subject = Reference("Patient/${patient.idPart}") }
+ * )
+ * ```
+ *
+ * Java callers use the [of] factory with `Class` and a `BiConsumer`:
+ * ```java
+ * ReferenceLinkRule<Encounter, Patient> rule = ReferenceLinkRule.of(
+ *     Encounter.class, Patient.class,
+ *     (encounter, patient) -> encounter.setSubject(new Reference("Patient/" + patient.getIdPart()))
+ * );
+ * ```
  *
  * @param S the FHIR resource type that holds the reference (the "source")
  * @param T the FHIR resource type being referenced (the "target")
@@ -14,7 +37,40 @@ data class ReferenceLinkRule<S : Resource, T : Resource>(
     val targetType: KClass<T>,
     private val setter: (S, T) -> Unit
 ) {
+    /**
+     * Applies the rule's [setter] to the given [source] and [target] after an unchecked
+     * downcast.  The cast is safe because callers (inside [OperationResult]) only call
+     * this method after verifying that [source] is an instance of [sourceType] and
+     * [target] is an instance of [targetType].
+     */
     @Suppress("UNCHECKED_CAST")
     internal fun applyTo(source: Resource, target: Resource) =
         setter(source as S, target as T)
+
+    companion object {
+        /**
+         * Java-friendly factory for [ReferenceLinkRule] — accepts [Class] and [BiConsumer]
+         * instead of [KClass] and a Kotlin lambda.
+         *
+         * Example:
+         * ```java
+         * ReferenceLinkRule<Encounter, Patient> rule = ReferenceLinkRule.of(
+         *     Encounter.class, Patient.class,
+         *     (encounter, patient) ->
+         *         encounter.setSubject(new Reference("Patient/" + patient.getIdPart()))
+         * );
+         * ```
+         *
+         * @param sourceType the Java [Class] of the resource that holds the reference.
+         * @param targetType the Java [Class] of the resource being referenced.
+         * @param setter [BiConsumer] that wires the reference from [source] to [target].
+         */
+        @JvmStatic
+        fun <S : Resource, T : Resource> of(
+            sourceType: Class<S>,
+            targetType: Class<T>,
+            setter: BiConsumer<S, T>
+        ): ReferenceLinkRule<S, T> =
+            ReferenceLinkRule(sourceType.kotlin, targetType.kotlin) { s, t -> setter.accept(s, t) }
+    }
 }

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultComplexTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultComplexTest.kt
@@ -36,7 +36,7 @@ class AsyncOperationResultComplexTest {
                 val bId = (deps["b"]!!.first() as Practitioner).id
                 Basic().apply { id = "$aId+$bId" }
             }
-            .addAfter("d", "c", Basic::class) { c ->
+            .addAfter("d", "c", Basic::class.java) { c ->
                 Encounter().apply { id = "D-from-${c.id}" }
             }
             .execute()
@@ -111,16 +111,16 @@ class AsyncOperationResultComplexTest {
     fun `five-level linear chain passes data through correctly at every level`() = runBlocking {
         val result = AsyncOperationResult()
             .add("a") { Patient().apply { id = "A" } }
-            .addAfter("b", "a", Patient::class) { a ->
+            .addAfter("b", "a", Patient::class.java) { a ->
                 Patient().apply { id = "${a.id}-B" }
             }
-            .addAfter("c", "b", Patient::class) { b ->
+            .addAfter("c", "b", Patient::class.java) { b ->
                 Patient().apply { id = "${b.id}-C" }
             }
-            .addAfter("d", "c", Patient::class) { c ->
+            .addAfter("d", "c", Patient::class.java) { c ->
                 Patient().apply { id = "${c.id}-D" }
             }
-            .addAfter("e", "d", Patient::class) { d ->
+            .addAfter("e", "d", Patient::class.java) { d ->
                 StringType("${d.id}-E")
             }
             .execute()
@@ -160,8 +160,8 @@ class AsyncOperationResultComplexTest {
         val result = AsyncOperationResult()
             .add("a") { error("a fails") }
             .add("b") { Patient().apply { id = "B" } }
-            .addAfter("c", "a", Patient::class) { Patient().apply { id = "C" } }
-            .addAfter("d", "b", Patient::class) { p ->
+            .addAfter("c", "a", Patient::class.java) { Patient().apply { id = "C" } }
+            .addAfter("d", "b", Patient::class.java) { p ->
                 Encounter().apply { id = "D-${p.id}" }
             }
             .execute()
@@ -212,7 +212,7 @@ class AsyncOperationResultComplexTest {
                 if (attempts < 3) error("transient failure attempt $attempts")
                 Patient().apply { id = "retried-p1" }
             }
-            .addAfter("encounter", "patient", Patient::class) { p ->
+            .addAfter("encounter", "patient", Patient::class.java) { p ->
                 Encounter().apply { id = "enc-${p.id}" }
             }
             .execute()
@@ -236,15 +236,15 @@ class AsyncOperationResultComplexTest {
 
         val result = AsyncOperationResult()
             .add("patient") { Patient().apply { id = "P" } }
-            .addAfter("encounter", "patient", Patient::class) { p ->
+            .addAfter("encounter", "patient", Patient::class.java) { p ->
                 patientReceived = p
                 Encounter().apply { id = "E-from-${p.id}" }
             }
-            .addAfter("observation", "encounter", Encounter::class) { e ->
+            .addAfter("observation", "encounter", Encounter::class.java) { e ->
                 encounterReceived = e
                 Observation().apply { id = "O-from-${e.id}" }
             }
-            .addAfter("outcome", "observation", Observation::class) { obs ->
+            .addAfter("outcome", "observation", Observation::class.java) { obs ->
                 observationReceived = obs
                 OperationOutcome().apply {
                     addIssue().diagnostics = "processed-${obs.id}"

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultDefaultTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultDefaultTest.kt
@@ -127,7 +127,7 @@ class AsyncOperationResultDefaultTest {
 
         val result = AsyncOperationResult()
             .addWithDefault("patient", defaultPatient) { blockPatient }
-            .addAfter("encounter", "patient", Patient::class) { p ->
+            .addAfter("encounter", "patient", Patient::class.java) { p ->
                 Encounter().apply { subject.reference = "Patient/${p.idElement.idPart}" }
             }
             .execute()

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultMergeTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultMergeTest.kt
@@ -54,7 +54,7 @@ class AsyncOperationResultMergeTest {
                 AsyncOperationResult()
                     .add("patient") { Patient().apply { id = "p1" } }
             }
-            .addAfter("encounter", "patient", Patient::class) { patient ->
+            .addAfter("encounter", "patient", Patient::class.java) { patient ->
                 Encounter().apply { id = "enc-${patient.id}" }
             }
             .execute()
@@ -87,7 +87,7 @@ class AsyncOperationResultMergeTest {
             .merge {
                 AsyncOperationResult()
                     .add("base") { Patient().apply { id = "base" } }
-                    .addAfter("derived", "base", Patient::class) { p ->
+                    .addAfter("derived", "base", Patient::class.java) { p ->
                         Coverage().apply { id = "derived-from-${p.id}" }
                     }
             }
@@ -103,10 +103,10 @@ class AsyncOperationResultMergeTest {
             .merge {
                 AsyncOperationResult()
                     .add("a") { Patient().apply { id = "A" } }
-                    .addAfter("b", "a", Patient::class) { a ->
+                    .addAfter("b", "a", Patient::class.java) { a ->
                         Patient().apply { id = "${a.id}-B" }
                     }
-                    .addAfter("c", "b", Patient::class) { b ->
+                    .addAfter("c", "b", Patient::class.java) { b ->
                         Patient().apply { id = "${b.id}-C" }
                     }
             }
@@ -240,10 +240,10 @@ class AsyncOperationResultMergeTest {
                 AsyncOperationResult()
                     .add("patient") { Patient().apply { id = "p1" } }
             }
-            .addAfter("coverage", "patient", Patient::class) { p ->
+            .addAfter("coverage", "patient", Patient::class.java) { p ->
                 Coverage().apply { id = "cov-${p.id}" }
             }
-            .addAfter("claim", "coverage", Coverage::class) { c ->
+            .addAfter("claim", "coverage", Coverage::class.java) { c ->
                 Claim().apply { id = "claim-${c.id}" }
             }
             .execute()

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultMetricsTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultMetricsTest.kt
@@ -138,7 +138,7 @@ class AsyncOperationResultMetricsTest {
         val dag = AsyncOperationResult()
             .timed()
             .add("patient") { patient() }
-            .addAfter("encounter", "patient", Patient::class) { _ -> encounter() }
+            .addAfter("encounter", "patient", Patient::class.java) { _ -> encounter() }
 
         dag.executeBlocking()
 

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultTest.kt
@@ -238,7 +238,7 @@ class AsyncOperationResultTest {
             .add("practitioner") { Practitioner().apply { id = "pr1" } }
             .execute()
 
-        val patients = result.getByType(Patient::class)
+        val patients = result.getByType(Patient::class.java)
         assertThat(patients, hasSize(1))
         assertThat(patients.first().id, `is`("p1"))
     }
@@ -282,7 +282,7 @@ class AsyncOperationResultTest {
     fun `addAfter with type - dependent task receives typed upstream result`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { Patient().apply { id = "p1" } }
-            .addAfter("coverage", "patient", Patient::class) { patient ->
+            .addAfter("coverage", "patient", Patient::class.java) { patient ->
                 Coverage().apply { id = "cov-for-${patient.id}" }
             }
             .execute()
@@ -295,7 +295,7 @@ class AsyncOperationResultTest {
     fun `addAfter with type - captures NoSuchElementException as failed task when upstream has no matching type`() = runBlocking {
         val result = AsyncOperationResult()
             .add("data") { StringType("hello") }
-            .addAfter("out", "data", Patient::class) { patient ->
+            .addAfter("out", "data", Patient::class.java) { patient ->
                 Basic().apply { id = patient.id }
             }
             .execute()
@@ -308,10 +308,10 @@ class AsyncOperationResultTest {
     fun `addAfter with type - works in multi-level chain`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { Patient().apply { id = "P" } }
-            .addAfter("coverage", "patient", Patient::class) { patient ->
+            .addAfter("coverage", "patient", Patient::class.java) { patient ->
                 Coverage().apply { id = "cov-${patient.id}" }
             }
-            .addAfter("claim", "coverage", Coverage::class) { coverage ->
+            .addAfter("claim", "coverage", Coverage::class.java) { coverage ->
                 Claim().apply { id = "claim-${coverage.id}" }
             }
             .execute()
@@ -324,7 +324,7 @@ class AsyncOperationResultTest {
     fun `addListAfter with type - returns list from typed single dependency`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { Patient().apply { id = "p1" } }
-            .addListAfter("observations", "patient", Patient::class) { patient ->
+            .addListAfter("observations", "patient", Patient::class.java) { patient ->
                 listOf(
                     Observation().apply { id = "obs1-${patient.id}" },
                     Observation().apply { id = "obs2-${patient.id}" }
@@ -348,7 +348,7 @@ class AsyncOperationResultTest {
                     Observation().apply { id = "obs3" }
                 )
             }
-            .addAfterAll("summary", "observations", Observation::class) { observations ->
+            .addAfterAll("summary", "observations", Observation::class.java) { observations ->
                 Basic().apply { id = "count-${observations.size}" }
             }
             .execute()
@@ -367,7 +367,7 @@ class AsyncOperationResultTest {
                     Patient().apply { id = "p2" }
                 )
             }
-            .addAfterAll("patientCount", "mixed", Patient::class) { patients ->
+            .addAfterAll("patientCount", "mixed", Patient::class.java) { patients ->
                 Basic().apply { id = "patients-${patients.size}" }
             }
             .execute()
@@ -380,7 +380,7 @@ class AsyncOperationResultTest {
     fun `addAfterAll - receives empty list when no values match type`() = runBlocking {
         val result = AsyncOperationResult()
             .add("data") { StringType("hello") }
-            .addAfterAll("out", "data", Patient::class) { patients ->
+            .addAfterAll("out", "data", Patient::class.java) { patients ->
                 Basic().apply { id = "found-${patients.size}" }
             }
             .execute()
@@ -398,7 +398,7 @@ class AsyncOperationResultTest {
                     Observation().apply { id = "obs2" }
                 )
             }
-            .addListAfterAll("derived", "observations", Observation::class) { observations ->
+            .addListAfterAll("derived", "observations", Observation::class.java) { observations ->
                 observations.map { obs ->
                     Observation().apply { id = "derived-${obs.id}" }
                 }

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultTypedDepOverloadsTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultTypedDepOverloadsTest.kt
@@ -25,7 +25,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
         var received: Patient? = null
         val result = AsyncOperationResult()
             .add("patient") { patient("typed") }
-            .addAfterWithTimeout("encounter", "patient", Patient::class, timeoutMs = 500) { p ->
+            .addAfterWithTimeout("encounter", "patient", Patient::class.java, timeoutMs = 500) { p ->
                 received = p
                 encounter()
             }
@@ -40,7 +40,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addAfterWithTimeout typed — times out and key absent`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { patient() }
-            .addAfterWithTimeout("encounter", "patient", Patient::class, timeoutMs = 20) { _ ->
+            .addAfterWithTimeout("encounter", "patient", Patient::class.java, timeoutMs = 20) { _ ->
                 delay(200)
                 encounter()
             }
@@ -56,7 +56,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addListAfterWithTimeout typed — block receives typed dep value and returns list`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { patient("p") }
-            .addListAfterWithTimeout("encounters", "patient", Patient::class, timeoutMs = 500) { p ->
+            .addListAfterWithTimeout("encounters", "patient", Patient::class.java, timeoutMs = 500) { p ->
                 listOf(encounter(), Encounter().apply { subject.reference = "Patient/${p.idElement.idPart}" })
             }
             .execute()
@@ -70,7 +70,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addListAfterWithTimeout typed — times out and key absent`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { patient() }
-            .addListAfterWithTimeout("encounters", "patient", Patient::class, timeoutMs = 20) { _ ->
+            .addListAfterWithTimeout("encounters", "patient", Patient::class.java, timeoutMs = 20) { _ ->
                 delay(200)
                 listOf(encounter())
             }
@@ -87,7 +87,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
         var receivedList: List<Patient>? = null
         val result = AsyncOperationResult()
             .addList("patients") { listOf(patient("a"), patient("b")) }
-            .addAfterAllWithTimeout("encounter", "patients", Patient::class, timeoutMs = 500) { patients ->
+            .addAfterAllWithTimeout("encounter", "patients", Patient::class.java, timeoutMs = 500) { patients ->
                 receivedList = patients
                 encounter()
             }
@@ -105,7 +105,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
         var receivedSize = -1
         val result = AsyncOperationResult()
             .addList("patients") { listOf(patient("a"), patient("b")) }
-            .addAfterAllWithTimeout("encounter", "patients", Coverage::class, timeoutMs = 500) { coverages ->
+            .addAfterAllWithTimeout("encounter", "patients", Coverage::class.java, timeoutMs = 500) { coverages ->
                 receivedSize = coverages.size
                 encounter()
             }
@@ -121,7 +121,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addListAfterAllWithTimeout typed — block receives typed list and returns list`() = runBlocking {
         val result = AsyncOperationResult()
             .addList("patients") { listOf(patient("a"), patient("b"), patient("c")) }
-            .addListAfterAllWithTimeout("encounters", "patients", Patient::class, timeoutMs = 500) { patients ->
+            .addListAfterAllWithTimeout("encounters", "patients", Patient::class.java, timeoutMs = 500) { patients ->
                 patients.map { Encounter().apply { subject.reference = "Patient/${it.idElement.idPart}" } }
             }
             .execute()
@@ -138,7 +138,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
         var received: Patient? = null
         val result = AsyncOperationResult()
             .add("patient") { patient("typed") }
-            .addAfterWithRetry("encounter", "patient", Patient::class, maxAttempts = 3, initialDelayMs = 0) { p ->
+            .addAfterWithRetry("encounter", "patient", Patient::class.java, maxAttempts = 3, initialDelayMs = 0) { p ->
                 received = p
                 encounter()
             }
@@ -154,7 +154,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
         var attempts = 0
         val result = AsyncOperationResult()
             .add("patient") { patient() }
-            .addAfterWithRetry("encounter", "patient", Patient::class, maxAttempts = 3, initialDelayMs = 0) { _ ->
+            .addAfterWithRetry("encounter", "patient", Patient::class.java, maxAttempts = 3, initialDelayMs = 0) { _ ->
                 attempts++
                 if (attempts < 2) throw RuntimeException("transient")
                 encounter()
@@ -170,7 +170,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addAfterWithRetry typed — all attempts exhausted records error`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { patient() }
-            .addAfterWithRetry("encounter", "patient", Patient::class, maxAttempts = 2, initialDelayMs = 0) { _ ->
+            .addAfterWithRetry("encounter", "patient", Patient::class.java, maxAttempts = 2, initialDelayMs = 0) { _ ->
                 throw RuntimeException("always fails")
             }
             .execute()
@@ -186,7 +186,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addListAfterWithRetry typed — block receives typed dep and returns list`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { patient("p") }
-            .addListAfterWithRetry("encounters", "patient", Patient::class, maxAttempts = 3, initialDelayMs = 0) { p ->
+            .addListAfterWithRetry("encounters", "patient", Patient::class.java, maxAttempts = 3, initialDelayMs = 0) { p ->
                 listOf(encounter(), Encounter().apply { subject.reference = "Patient/${p.idElement.idPart}" })
             }
             .execute()
@@ -201,7 +201,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
         var attempts = 0
         val result = AsyncOperationResult()
             .add("patient") { patient() }
-            .addListAfterWithRetry("encounters", "patient", Patient::class, maxAttempts = 3, initialDelayMs = 0) { _ ->
+            .addListAfterWithRetry("encounters", "patient", Patient::class.java, maxAttempts = 3, initialDelayMs = 0) { _ ->
                 attempts++
                 if (attempts < 3) throw RuntimeException("transient")
                 listOf(encounter())
@@ -220,7 +220,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
         var receivedList: List<Patient>? = null
         val result = AsyncOperationResult()
             .addList("patients") { listOf(patient("x"), patient("y")) }
-            .addAfterAllWithRetry("encounter", "patients", Patient::class, maxAttempts = 3, initialDelayMs = 0) { patients ->
+            .addAfterAllWithRetry("encounter", "patients", Patient::class.java, maxAttempts = 3, initialDelayMs = 0) { patients ->
                 receivedList = patients
                 encounter()
             }
@@ -236,7 +236,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
         var attempts = 0
         val result = AsyncOperationResult()
             .addList("patients") { listOf(patient("a"), patient("b")) }
-            .addAfterAllWithRetry("encounter", "patients", Patient::class, maxAttempts = 3, initialDelayMs = 0) { patients ->
+            .addAfterAllWithRetry("encounter", "patients", Patient::class.java, maxAttempts = 3, initialDelayMs = 0) { patients ->
                 attempts++
                 if (attempts < 2) throw RuntimeException("transient")
                 assertEquals(2, patients.size)
@@ -254,7 +254,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addListAfterAllWithRetry typed — maps typed list to result list`() = runBlocking {
         val result = AsyncOperationResult()
             .addList("patients") { listOf(patient("a"), patient("b")) }
-            .addListAfterAllWithRetry("encounters", "patients", Patient::class, maxAttempts = 3, initialDelayMs = 0) { patients ->
+            .addListAfterAllWithRetry("encounters", "patients", Patient::class.java, maxAttempts = 3, initialDelayMs = 0) { patients ->
                 patients.map { Encounter().apply { subject.reference = "Patient/${it.idElement.idPart}" } }
             }
             .execute()
@@ -272,7 +272,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addAfterWithTimeout typed result has correct FHIR type`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { patient() }
-            .addAfterWithTimeout("encounter", "patient", Patient::class, timeoutMs = 500) { _ -> encounter() }
+            .addAfterWithTimeout("encounter", "patient", Patient::class.java, timeoutMs = 500) { _ -> encounter() }
             .execute()
 
         assertThat(result.getAll("encounter").first(), instanceOf(Encounter::class.java))
@@ -282,7 +282,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addAfterWithRetry typed result has correct FHIR type`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { patient() }
-            .addAfterWithRetry("encounter", "patient", Patient::class, maxAttempts = 1, initialDelayMs = 0) { _ -> encounter() }
+            .addAfterWithRetry("encounter", "patient", Patient::class.java, maxAttempts = 1, initialDelayMs = 0) { _ -> encounter() }
             .execute()
 
         assertThat(result.getAll("encounter").first(), instanceOf(Encounter::class.java))

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultTypedListOutputTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultTypedListOutputTest.kt
@@ -46,7 +46,7 @@ class AsyncOperationResultTypedListOutputTest {
     fun `addListAfterAll - both T and R inferred as concrete types`() = runBlocking {
         val result = AsyncOperationResult()
             .addList("patients") { listOf(Patient().apply { id = "p1" }, Patient().apply { id = "p2" }) }
-            .addListAfterAll("observations", "patients", Patient::class) { patients ->
+            .addListAfterAll("observations", "patients", Patient::class.java) { patients ->
                 patients.map { p -> Observation().apply { id = "obs-${p.id}" } }
             }
             .execute()
@@ -82,7 +82,7 @@ class AsyncOperationResultTypedListOutputTest {
     fun `addListAfterAllWithTimeout - both T and R inferred as concrete types`() = runBlocking {
         val result = AsyncOperationResult()
             .addList("patients") { listOf(Patient().apply { id = "p1" }) }
-            .addListAfterAllWithTimeout("observations", "patients", Patient::class, 5000L) { patients ->
+            .addListAfterAllWithTimeout("observations", "patients", Patient::class.java, 5000L) { patients ->
                 patients.map { p -> Observation().apply { id = "obs-${p.id}" } }
             }
             .execute()
@@ -107,7 +107,7 @@ class AsyncOperationResultTypedListOutputTest {
     fun `addListAfterAllWithRetry - both T and R inferred as concrete types`() = runBlocking {
         val result = AsyncOperationResult()
             .addList("patients") { listOf(Patient().apply { id = "p1" }, Patient().apply { id = "p2" }) }
-            .addListAfterAllWithRetry("observations", "patients", Patient::class, maxAttempts = 1) { patients ->
+            .addListAfterAllWithRetry("observations", "patients", Patient::class.java, maxAttempts = 1) { patients ->
                 patients.map { p -> Observation().apply { id = "obs-${p.id}" } }
             }
             .execute()

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/FhirFilterTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/FhirFilterTest.kt
@@ -49,7 +49,7 @@ class FhirFilterTest {
     @Test
     fun `hasExtensionWithValueType KClass returns true when value type matches`() {
         val patient = patient().apply { addExtension("http://example.org/flag", StringType("yes")) }
-        assertTrue(FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class)(patient))
+        assertTrue(FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class.java)(patient))
     }
 
     @Test

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultComplexTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultComplexTest.kt
@@ -39,7 +39,7 @@ class OperationResultComplexTest {
 
         val result = OperationResult.of(listOf(p1, p2, p3), "patients")
             .addAllFromFiltered(
-                type = Patient::class,
+                type = Patient::class.java,
                 predicate = FhirFilter.hasExtensionValueMatching<BooleanType>("http://example.org/enrolled") { it.booleanValue() }
             ) { enrolled ->
                 enrolled.map { p ->
@@ -376,7 +376,7 @@ class OperationResultComplexTest {
         // First filter: enrolled patients only → produces List<Patient> as head
         val afterExtFilter = OperationResult.of(listOf(activeEnrolled, inactiveEnrolled, activeNotEnrolled), "patients")
             .addAllFromFiltered(
-                type = Patient::class,
+                type = Patient::class.java,
                 predicate = FhirFilter.hasExtensionValueMatching<BooleanType>("http://example.org/enrolled") { it.booleanValue() }
             ) { enrolled ->
                 // Store enrolled patients back so FHIRPath filter can find them
@@ -391,7 +391,7 @@ class OperationResultComplexTest {
         // only sees the 2 enrolled patients, not all 3 originals.
         val finalResult = afterExtFilter
             .filterByName("patient")
-            .addAllFromMatching<Patient, Patient>("active-enrolled", Patient::class, "active = true") { it }
+            .addAllFromMatching<Patient, Patient>("active-enrolled", Patient::class.java, "active = true") { it }
 
         assertEquals(1, finalResult.count("active-enrolled"))
         assertFalse(finalResult.hasErrors())

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFhirErrorHandlingTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFhirErrorHandlingTest.kt
@@ -307,7 +307,7 @@ class OperationResultFhirErrorHandlingTest {
     fun `addFrom with PROPAGATE strategy - exception propagates raw`() {
         val pipeline = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.PROPAGATE)
         assertThrows<RuntimeException> {
-            pipeline.addFrom<Patient, Patient>("test", Patient::class) { throw RuntimeException("addFrom boom") }
+            pipeline.addFrom<Patient, Patient>("test", Patient::class.java) { throw RuntimeException("addFrom boom") }
         }
     }
 
@@ -368,13 +368,13 @@ class OperationResultFhirErrorHandlingTest {
 
     @Test
     fun `fromParametersTyped - missing key returns hasErrors true and null head`() {
-        val result = OperationResult.fromParametersTyped(Parameters(), "patient", Patient::class)
+        val result = OperationResult.fromParametersTyped(Parameters(), "patient", Patient::class.java)
         assertTrue(result.hasErrors())
     }
 
     @Test
     fun `fromParametersTyped - missing key outcome has NOTFOUND code`() {
-        val result = OperationResult.fromParametersTyped(Parameters(), "patient", Patient::class)
+        val result = OperationResult.fromParametersTyped(Parameters(), "patient", Patient::class.java)
         assertThat(result.getOutcomes(), hasSize(1))
         assertThat(result.getOutcomes()[0].issueFirstRep.severity, equalTo(OperationOutcome.IssueSeverity.ERROR))
         assertThat(result.getOutcomes()[0].issueFirstRep.code, equalTo(OperationOutcome.IssueType.NOTFOUND))
@@ -384,7 +384,7 @@ class OperationResultFhirErrorHandlingTest {
     fun `fromParametersTyped - found key returns isSuccessful true with correct typed head`() {
         val p = Patient().apply { setId("p1") }
         val params = Parameters().apply { addParameter().apply { name = "patient"; resource = p } }
-        val result = OperationResult.fromParametersTyped(params, "patient", Patient::class)
+        val result = OperationResult.fromParametersTyped(params, "patient", Patient::class.java)
         assertTrue(result.isSuccessful())
         assertThat(result.getResult().idElement.idPart, equalTo("p1"))
     }
@@ -393,7 +393,7 @@ class OperationResultFhirErrorHandlingTest {
 
     @Test
     fun `fromBundleTyped - missing key returns hasErrors true and null head`() {
-        val result = OperationResult.fromBundleTyped(Bundle(), "patient", Patient::class)
+        val result = OperationResult.fromBundleTyped(Bundle(), "patient", Patient::class.java)
         assertTrue(result.hasErrors())
     }
 
@@ -401,7 +401,7 @@ class OperationResultFhirErrorHandlingTest {
     fun `fromBundleTyped - found resource returns isSuccessful true`() {
         val p = Patient().apply { setId("p1") }
         val bundle = Bundle().apply { addEntry().resource = p }
-        val result = OperationResult.fromBundleTyped(bundle, "patient", Patient::class)
+        val result = OperationResult.fromBundleTyped(bundle, "patient", Patient::class.java)
         assertTrue(result.isSuccessful())
         assertThat(result.getResult().idElement.idPart, equalTo("p1"))
     }
@@ -411,7 +411,7 @@ class OperationResultFhirErrorHandlingTest {
     @Test
     fun `extractParam - missing key adds ERROR outcome and skips (Pattern A)`() {
         val result = OperationResult.of(patient())
-            .extractParam("missing", Coverage::class)
+            .extractParam("missing", Coverage::class.java)
         assertTrue(result.hasErrors())
         assertThat(result.getOutcomes(), hasSize(1))
         assertThat(result.getOutcomes()[0].issueFirstRep.severity, equalTo(OperationOutcome.IssueSeverity.ERROR))
@@ -421,7 +421,7 @@ class OperationResultFhirErrorHandlingTest {
     fun `extractParam - found key changes head and leaves no error`() {
         val p = patient()
         val result = OperationResult.of(p)
-            .extractParam("patient", Patient::class)
+            .extractParam("patient", Patient::class.java)
         assertTrue(result.isSuccessful())
         assertSame(p, result.getResult())
     }
@@ -430,7 +430,7 @@ class OperationResultFhirErrorHandlingTest {
     fun `extractParam - missing key with FAIL_FAST skips subsequent steps`() {
         var step2Ran = false
         val result = OperationResult.of(patient())
-            .extractParam("missing", Coverage::class)
+            .extractParam("missing", Coverage::class.java)
             .add("enc") { step2Ran = true; Encounter() }
         assertTrue(result.hasErrors())
         assertFalse(step2Ran)

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFhirPathTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFhirPathTest.kt
@@ -29,7 +29,7 @@ class OperationResultFhirPathTest {
 
         val result = OperationResult.of(activePatient)
             .add { inactivePatient }
-            .addFromMatching<Patient, StringType>("result", Patient::class, "active = true") { matches ->
+            .addFromMatching<Patient, StringType>("result", Patient::class.java, "active = true") { matches ->
                 assertThat(matches, hasSize(1))
                 assertThat(matches[0].idPart, `is`("p1"))
                 StringType("found")
@@ -44,7 +44,7 @@ class OperationResultFhirPathTest {
         val patient = Patient().apply { active = false }
 
         val result = OperationResult.of(patient)
-            .addFromMatching<Patient, StringType>("result", Patient::class, "active = true") { matches ->
+            .addFromMatching<Patient, StringType>("result", Patient::class.java, "active = true") { matches ->
                 assertThat(matches, empty())
                 StringType("none")
             }
@@ -70,7 +70,7 @@ class OperationResultFhirPathTest {
         val patient = Patient().apply { active = true }
 
         val result = OperationResult.of(patient)
-            .addFromMatching("active-patients", Patient::class, "active = true") { StringType("ok") }
+            .addFromMatching("active-patients", Patient::class.java, "active = true") { StringType("ok") }
 
         assertThat(result.getAll("active-patients"), hasSize(1))
     }
@@ -87,7 +87,7 @@ class OperationResultFhirPathTest {
             .add { patientWithoutId }
             .addFromMatching<Patient, StringType>(
                 "has-id",
-                Patient::class,
+                Patient::class.java,
                 "identifier.where(system = 'http://example.org/mpi').exists()"
             ) { matches ->
                 assertThat(matches, hasSize(1))
@@ -103,7 +103,7 @@ class OperationResultFhirPathTest {
         val patient = Patient().apply { active = true }
 
         val result = OperationResult.of(patient)
-            .addFromMatching<Patient, StringType>("out", Patient::class, "(((invalid") { StringType("x") }
+            .addFromMatching<Patient, StringType>("out", Patient::class.java, "(((invalid") { StringType("x") }
 
         assertTrue(result.hasErrors())
         assertThat(result.getOutcomes(), hasSize(1))
@@ -120,7 +120,7 @@ class OperationResultFhirPathTest {
 
         val result = OperationResult.of(patient)
             .add { observation }
-            .addFromMatching<Patient, StringType>("result", Patient::class, "active = true") { matches ->
+            .addFromMatching<Patient, StringType>("result", Patient::class.java, "active = true") { matches ->
                 assertThat(matches, hasSize(1))
                 StringType("patients-only")
             }
@@ -139,7 +139,7 @@ class OperationResultFhirPathTest {
         val result = OperationResult.of(p1)
             .add { p2 }
             .add { p3 }
-            .addAllFromMatching<Patient, Patient>("active", Patient::class, "active = true") { it }
+            .addAllFromMatching<Patient, Patient>("active", Patient::class.java, "active = true") { it }
 
         assertTrue(result.isSuccessful())
         val patients = result.getResult()
@@ -151,7 +151,7 @@ class OperationResultFhirPathTest {
         val patient = Patient().apply { active = true }
 
         val result = OperationResult.of(patient)
-            .addAllFromMatching("active", Patient::class, "active = true") { it }
+            .addAllFromMatching("active", Patient::class.java, "active = true") { it }
 
         assertThat(result.getAll("active"), hasSize(1))
     }
@@ -311,7 +311,7 @@ class OperationResultFhirPathTest {
         }
 
         val result = OperationResult.of(patient)
-            .selectByPath(HumanName::class, "name.first()", "official-name")
+            .selectByPath(HumanName::class.java, "name.first()", "official-name")
 
         assertThat(result.getAll("official-name"), hasSize(1))
     }
@@ -365,7 +365,7 @@ class OperationResultFhirPathTest {
 
         val result = OperationResult.of(activePatient)
             .add { inactivePatient }
-            .addFromMatching<Patient, StringType>("result", Patient::class, expression) { matches ->
+            .addFromMatching<Patient, StringType>("result", Patient::class.java, expression) { matches ->
                 assertThat(matches, hasSize(1))
                 assertThat(matches[0].idPart, `is`("p1"))
                 StringType("found")
@@ -394,7 +394,7 @@ class OperationResultFhirPathTest {
 
         val result = OperationResult.of(p1)
             .add { p2 }
-            .addAllFromMatching("active", Patient::class, expression) { it }
+            .addAllFromMatching("active", Patient::class.java, expression) { it }
 
         assertTrue(result.isSuccessful())
         assertThat(result.getAll("active"), hasSize(2))
@@ -469,7 +469,7 @@ class OperationResultFhirPathTest {
         val expression = FhirPath.relative().navigate("name").first()
 
         val result = OperationResult.of(patient)
-            .selectByPath(HumanName::class, expression)
+            .selectByPath(HumanName::class.java, expression)
 
         assertTrue(result.isSuccessful())
         assertEquals("Smith", result.getResult().family)

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFromTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultFromTest.kt
@@ -295,7 +295,7 @@ class OperationResultFromTest {
         }
 
         val result: OperationResult<Patient> =
-            OperationResult.fromParametersTyped(fhirParams, "patient", Patient::class)
+            OperationResult.fromParametersTyped(fhirParams, "patient", Patient::class.java)
 
         // Typed assignment proves compiler sees OperationResult<Patient>
         val retrieved: Patient = result.getResult()
@@ -530,7 +530,7 @@ class OperationResultFromTest {
             addEntry().resource = p
         }
 
-        val result = OperationResult.fromBundleTyped(bundle, "patient", Patient::class)
+        val result = OperationResult.fromBundleTyped(bundle, "patient", Patient::class.java)
 
         assertInstanceOf(Patient::class.java, result.getResult())
         assertEquals("p1", result.getResult().idPart)
@@ -609,7 +609,7 @@ class OperationResultFromTest {
             addParameter().apply { name = "patient"; resource = patient() }
         }
         val result = OperationResult.fromParameters(params)
-            .extractParam("patient", Patient::class)
+            .extractParam("patient", Patient::class.java)
 
         assertNotNull(result.getResult())
         assertInstanceOf(Patient::class.java, result.getResult())

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultIdentifierTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultIdentifierTest.kt
@@ -20,7 +20,7 @@ class OperationResultIdentifierTest {
         val withSystem = patient("http://example.org/mrn", "12345")
         val otherSystem = patient("http://other.org/id", "12345")
         val result = OperationResult.of(listOf(withSystem, otherSystem), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -34,7 +34,7 @@ class OperationResultIdentifierTest {
         val b = patient("http://example.org/mrn", "002")
         val c = patient("http://example.org/mrn", "003")
         val result = OperationResult.of(listOf(a, b, c), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -44,7 +44,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifierWithSystem with no matches passes empty list to builder`() {
         val result = OperationResult.of(patient("http://other.org/id", "001"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -57,7 +57,7 @@ class OperationResultIdentifierTest {
         val withMrn = patient("http://example.org/mrn", "001")
         val noId = patientNoIdentifier()
         val result = OperationResult.of(listOf(withMrn, noId), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -67,7 +67,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifierWithSystem stores result under fhirType when name is null`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
                 OperationOutcome().apply { addIssue().diagnostics = "found" }
             }
 
@@ -78,7 +78,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifierWithSystem named overload stores result under explicit key`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
-            .addFromFiltered("mrn-summary", Patient::class, FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
+            .addFromFiltered("mrn-summary", Patient::class.java, FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -100,7 +100,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifierWithSystem records ERROR outcome when builder throws`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
                 throw RuntimeException("builder failed")
             }
 
@@ -113,10 +113,10 @@ class OperationResultIdentifierTest {
     fun `addFromHavingIdentifierWithSystem respects FAIL_FAST and skips when already errored`() {
         var builderCalled = false
         val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
                 throw RuntimeException("first failure")
             }
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
                 builderCalled = true
                 OperationOutcome()
             }
@@ -131,7 +131,7 @@ class OperationResultIdentifierTest {
         val b = patient("http://example.org/mrn", "002")
         val result = OperationResult.of(a, "group-a")
             .add("group-b") { b }
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -146,7 +146,7 @@ class OperationResultIdentifierTest {
         val b = patient("http://example.org/mrn", "002")
         val other = patient("http://other.org/id", "003")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -154,7 +154,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addAllFromHavingIdentifierWithSystem named overload stores under explicit key`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
-            .addAllFromFiltered("mrn-patients", Patient::class, FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { it }
+            .addAllFromFiltered("mrn-patients", Patient::class.java, FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { it }
 
         assertTrue(result.containsKey("mrn-patients"))
     }
@@ -175,7 +175,7 @@ class OperationResultIdentifierTest {
         val target = patient("http://example.org/mrn", "12345")
         val other = patient("http://example.org/mrn", "99999")
         val result = OperationResult.of(listOf(target, other), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithValue("12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithValue("12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -185,7 +185,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifierWithValue with no matches passes empty list to builder`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "99999"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithValue("12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithValue("12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -197,7 +197,7 @@ class OperationResultIdentifierTest {
     fun `addFromHavingIdentifierWithValue excludes resources without identifier property`() {
         val withValue = patient("http://example.org/mrn", "12345")
         val result = OperationResult.of(listOf(withValue, patientNoIdentifier()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithValue("12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithValue("12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -207,7 +207,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifierWithValue stores result under fhirType when name is null`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithValue("12345")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithValue("12345")) { _ ->
                 OperationOutcome().apply { addIssue().diagnostics = "found" }
             }
 
@@ -218,7 +218,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifierWithValue named overload stores under explicit key`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
-            .addFromFiltered("value-result", Patient::class, FhirFilter.hasIdentifierWithValue("12345")) { filtered ->
+            .addFromFiltered("value-result", Patient::class.java, FhirFilter.hasIdentifierWithValue("12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -242,7 +242,7 @@ class OperationResultIdentifierTest {
         val b = patient("http://other.org/id", "12345")
         val other = patient("http://example.org/mrn", "99999")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithValue("12345")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithValue("12345")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -255,7 +255,7 @@ class OperationResultIdentifierTest {
         val wrongValue = patient("http://example.org/mrn", "99999")
         val wrongSystem = patient("http://other.org/id", "12345")
         val result = OperationResult.of(listOf(exact, wrongValue, wrongSystem), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -265,7 +265,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifier does not match when system matches but value does not`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "99999"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -275,7 +275,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifier does not match when value matches but system does not`() {
         val result = OperationResult.of(patient("http://other.org/id", "12345"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -289,7 +289,7 @@ class OperationResultIdentifierTest {
             addIdentifier().apply { system = "http://example.org/mrn"; value = "12345" }
         }
         val result = OperationResult.of(multiId, "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -299,7 +299,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifier with no matches passes empty list to builder`() {
         val result = OperationResult.of(patientNoIdentifier(), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -311,7 +311,7 @@ class OperationResultIdentifierTest {
     fun `addFromHavingIdentifier excludes resources without identifier property`() {
         val exact = patient("http://example.org/mrn", "12345")
         val result = OperationResult.of(listOf(exact, patientNoIdentifier()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -321,7 +321,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifier stores result under fhirType when name is null`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { _ ->
                 OperationOutcome().apply { addIssue().diagnostics = "found" }
             }
 
@@ -332,7 +332,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifier named overload stores under explicit key`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
-            .addFromFiltered("matched-patient", Patient::class, FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
+            .addFromFiltered("matched-patient", Patient::class.java, FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -354,7 +354,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifier records ERROR outcome when builder throws`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { _ ->
                 throw RuntimeException("builder failed")
             }
 
@@ -371,7 +371,7 @@ class OperationResultIdentifierTest {
         val b = patient("http://example.org/mrn", "12345")
         val other = patient("http://example.org/mrn", "99999")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -379,7 +379,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addAllFromHavingIdentifier named overload stores under explicit key`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
-            .addAllFromFiltered("exact-matches", Patient::class, FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { it }
+            .addAllFromFiltered("exact-matches", Patient::class.java, FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { it }
 
         assertTrue(result.containsKey("exact-matches"))
     }
@@ -399,7 +399,7 @@ class OperationResultIdentifierTest {
     fun `identifier filter methods compose with subsequent pipeline steps`() {
         val withMrn = patient("http://example.org/mrn", "12345")
         val result = OperationResult.of(listOf(withMrn, patientNoIdentifier()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
             .add("flag") { org.hl7.fhir.dstu3.model.StringType("done") }

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultJavaInteropTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultJavaInteropTest.kt
@@ -25,7 +25,7 @@ class OperationResultJavaInteropTest {
             .add("appt") { appointment() }
 
         val byClass = result.getByType(Patient::class.java)
-        val byKClass = result.getByType(Patient::class)
+        val byKClass = result.getByType(Patient::class.java)
 
         assertThat(byClass, hasSize(1))
         assertSame(byClass[0], byKClass[0])

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultMetaTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultMetaTest.kt
@@ -20,7 +20,7 @@ class OperationResultMetaTest {
         val withTag = patientWithTag("http://example.org/tags", "reviewed")
         val otherSystem = patientWithTag("http://other.org/tags", "reviewed")
         val result = OperationResult.of(listOf(withTag, otherSystem), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -31,7 +31,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTagWithSystem with no matches passes empty list to builder`() {
         val result = OperationResult.of(patientNoMeta(), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -42,7 +42,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTagWithSystem stores result under fhirType when name is null`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ -> OperationOutcome() }
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ -> OperationOutcome() }
 
         assertTrue(result.containsKey("operationoutcome"))
         assertFalse(result.containsKey("patient"))
@@ -51,7 +51,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTagWithSystem named overload stores result under explicit key`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
-            .addFromFiltered("tagged", Patient::class, FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ -> OperationOutcome() }
+            .addFromFiltered("tagged", Patient::class.java, FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ -> OperationOutcome() }
 
         assertTrue(result.containsKey("tagged"))
         assertFalse(result.containsKey("operationoutcome"))
@@ -71,7 +71,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTagWithSystem records ERROR outcome when builder throws`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
                 throw RuntimeException("builder failed")
             }
 
@@ -83,10 +83,10 @@ class OperationResultMetaTest {
     fun `addFromHavingMetaTagWithSystem respects FAIL_FAST`() {
         var builderCalled = false
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
                 throw RuntimeException("first failure")
             }
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
                 builderCalled = true
                 OperationOutcome()
             }
@@ -101,7 +101,7 @@ class OperationResultMetaTest {
         val b = patientWithTag("http://example.org/tags", "y")
         val result = OperationResult.of(a, "group-a")
             .add("group-b") { b }
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -116,7 +116,7 @@ class OperationResultMetaTest {
         val b = patientWithTag("http://example.org/tags", "y")
         val other = patientWithTag("http://other.org/tags", "x")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -124,7 +124,7 @@ class OperationResultMetaTest {
     @Test
     fun `addAllFromHavingMetaTagWithSystem named overload stores under explicit key`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
-            .addAllFromFiltered("tagged-patients", Patient::class, FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { it }
+            .addAllFromFiltered("tagged-patients", Patient::class.java, FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { it }
 
         assertTrue(result.containsKey("tagged-patients"))
     }
@@ -136,7 +136,7 @@ class OperationResultMetaTest {
         val target = patientWithTag("http://example.org/tags", "reviewed")
         val other = patientWithTag("http://example.org/tags", "draft")
         val result = OperationResult.of(listOf(target, other), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithCode("reviewed")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithCode("reviewed")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -146,7 +146,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTagWithCode named overload stores under explicit key`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "reviewed"), "patients")
-            .addFromFiltered("reviewed-result", Patient::class, FhirFilter.hasMetaTagWithCode("reviewed")) { _ -> OperationOutcome() }
+            .addFromFiltered("reviewed-result", Patient::class.java, FhirFilter.hasMetaTagWithCode("reviewed")) { _ -> OperationOutcome() }
 
         assertTrue(result.containsKey("reviewed-result"))
     }
@@ -157,7 +157,7 @@ class OperationResultMetaTest {
         val b = patientWithTag("http://sys2.org", "reviewed")
         val other = patientWithTag("http://sys1.org", "draft")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithCode("reviewed")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithCode("reviewed")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -170,7 +170,7 @@ class OperationResultMetaTest {
         val wrongCode = patientWithTag("http://example.org/tags", "draft")
         val wrongSystem = patientWithTag("http://other.org/tags", "reviewed")
         val result = OperationResult.of(listOf(exact, wrongCode, wrongSystem), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -184,7 +184,7 @@ class OperationResultMetaTest {
             meta.addTag().apply { system = "http://example.org/tags"; code = "reviewed" }
         }
         val result = OperationResult.of(multiTag, "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -194,7 +194,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTag named overload stores under explicit key`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "reviewed"), "patients")
-            .addFromFiltered("matched", Patient::class, FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { _ -> OperationOutcome() }
+            .addFromFiltered("matched", Patient::class.java, FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { _ -> OperationOutcome() }
 
         assertTrue(result.containsKey("matched"))
         assertFalse(result.containsKey("operationoutcome"))
@@ -214,7 +214,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTag records ERROR outcome when builder throws`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "reviewed"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { _ ->
                 throw RuntimeException("builder failed")
             }
 
@@ -228,7 +228,7 @@ class OperationResultMetaTest {
         val b = patientWithTag("http://example.org/tags", "reviewed")
         val other = patientWithTag("http://example.org/tags", "draft")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -240,7 +240,7 @@ class OperationResultMetaTest {
         val restricted = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
         val other = patientWithSecurity("http://other.org/security", "R")
         val result = OperationResult.of(listOf(restricted, other), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurityWithSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurityWithSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -250,7 +250,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaSecurityWithSystem named overload stores under explicit key`() {
         val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
-            .addFromFiltered("restricted", Patient::class, FhirFilter.hasMetaSecurityWithSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode")) { _ -> OperationOutcome() }
+            .addFromFiltered("restricted", Patient::class.java, FhirFilter.hasMetaSecurityWithSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode")) { _ -> OperationOutcome() }
 
         assertTrue(result.containsKey("restricted"))
     }
@@ -272,7 +272,7 @@ class OperationResultMetaTest {
         val b = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N")
         val other = patientWithSecurity("http://other.org/security", "R")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurityWithSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurityWithSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -284,7 +284,7 @@ class OperationResultMetaTest {
         val restricted = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
         val normal = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N")
         val result = OperationResult.of(listOf(restricted, normal), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurityWithCode("R")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurityWithCode("R")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -294,7 +294,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaSecurityWithCode named overload stores under explicit key`() {
         val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
-            .addFromFiltered("restricted-result", Patient::class, FhirFilter.hasMetaSecurityWithCode("R")) { _ -> OperationOutcome() }
+            .addFromFiltered("restricted-result", Patient::class.java, FhirFilter.hasMetaSecurityWithCode("R")) { _ -> OperationOutcome() }
 
         assertTrue(result.containsKey("restricted-result"))
     }
@@ -305,7 +305,7 @@ class OperationResultMetaTest {
         val b = patientWithSecurity("http://sys2.org", "R")
         val other = patientWithSecurity("http://sys1.org", "N")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurityWithCode("R")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurityWithCode("R")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -318,7 +318,7 @@ class OperationResultMetaTest {
         val wrongCode = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N")
         val wrongSystem = patientWithSecurity("http://other.org/security", "R")
         val result = OperationResult.of(listOf(exact, wrongCode, wrongSystem), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -332,7 +332,7 @@ class OperationResultMetaTest {
             meta.addSecurity().apply { system = "http://terminology.hl7.org/CodeSystem/v3-ActCode"; code = "R" }
         }
         val result = OperationResult.of(multiSec, "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -342,7 +342,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaSecurity named overload stores under explicit key`() {
         val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
-            .addFromFiltered("restricted", Patient::class, FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { _ -> OperationOutcome() }
+            .addFromFiltered("restricted", Patient::class.java, FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { _ -> OperationOutcome() }
 
         assertTrue(result.containsKey("restricted"))
         assertFalse(result.containsKey("operationoutcome"))
@@ -362,7 +362,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaSecurity records ERROR outcome when builder throws`() {
         val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { _ ->
                 throw RuntimeException("builder failed")
             }
 
@@ -376,7 +376,7 @@ class OperationResultMetaTest {
         val b = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
         val other = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -388,7 +388,7 @@ class OperationResultMetaTest {
         val conforming = patientWithProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")
         val other = patientWithProfile("http://example.org/fhir/StructureDefinition/custom-patient")
         val result = OperationResult.of(listOf(conforming, other), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -398,7 +398,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaProfile with no matches passes empty list to builder`() {
         val result = OperationResult.of(patientNoMeta(), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -409,7 +409,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaProfile stores result under fhirType when name is null`() {
         val result = OperationResult.of(patientWithProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")) { _ -> OperationOutcome() }
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")) { _ -> OperationOutcome() }
 
         assertTrue(result.containsKey("operationoutcome"))
         assertFalse(result.containsKey("patient"))
@@ -418,7 +418,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaProfile named overload stores result under explicit key`() {
         val result = OperationResult.of(patientWithProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient"), "patients")
-            .addFromFiltered("us-core-result", Patient::class, FhirFilter.hasMetaProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")) { _ -> OperationOutcome() }
+            .addFromFiltered("us-core-result", Patient::class.java, FhirFilter.hasMetaProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")) { _ -> OperationOutcome() }
 
         assertTrue(result.containsKey("us-core-result"))
         assertFalse(result.containsKey("operationoutcome"))
@@ -442,7 +442,7 @@ class OperationResultMetaTest {
             meta.addProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")
         }
         val result = OperationResult.of(multiProfile, "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -452,7 +452,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaProfile records ERROR outcome when builder throws`() {
         val result = OperationResult.of(patientWithProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/StructureDefinition/us-core-patient")) { _ ->
                 throw RuntimeException("builder failed")
             }
 
@@ -465,8 +465,8 @@ class OperationResultMetaTest {
         var builderCalled = false
         val url = "http://hl7.org/fhir/StructureDefinition/us-core-patient"
         val result = OperationResult.of(patientWithProfile(url), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile(url)) { _ -> throw RuntimeException("first failure") }
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile(url)) { _ -> builderCalled = true; OperationOutcome() }
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile(url)) { _ -> throw RuntimeException("first failure") }
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile(url)) { _ -> builderCalled = true; OperationOutcome() }
 
         assertFalse(builderCalled)
         assertTrue(result.hasErrors())
@@ -477,7 +477,7 @@ class OperationResultMetaTest {
         val url = "http://hl7.org/fhir/StructureDefinition/us-core-patient"
         val result = OperationResult.of(patientWithProfile(url), "group-a")
             .add("group-b") { patientWithProfile(url) }
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile(url)) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile(url)) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -493,7 +493,7 @@ class OperationResultMetaTest {
         val b = patientWithProfile(url)
         val other = patientWithProfile("http://example.org/fhir/StructureDefinition/other")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile(url)) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile(url)) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -502,7 +502,7 @@ class OperationResultMetaTest {
     fun `addAllFromHavingMetaProfile named overload stores under explicit key`() {
         val url = "http://hl7.org/fhir/StructureDefinition/us-core-patient"
         val result = OperationResult.of(patientWithProfile(url), "patients")
-            .addAllFromFiltered("us-core-patients", Patient::class, FhirFilter.hasMetaProfile(url)) { it }
+            .addAllFromFiltered("us-core-patients", Patient::class.java, FhirFilter.hasMetaProfile(url)) { it }
 
         assertTrue(result.containsKey("us-core-patients"))
     }

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/OperationResultTest.kt
@@ -218,7 +218,7 @@ class OperationResultTest {
         val p1 = patient()
         val p2 = patient()
         val result = OperationResult.of(listOf(p1, p2), "people")
-            .addFrom("people", Patient::class) { patients ->
+            .addFrom("people", Patient::class.java) { patients ->
                 OperationOutcome().apply {
                     issue = patients.map { OperationOutcome.OperationOutcomeIssueComponent() }
                 }
@@ -232,7 +232,7 @@ class OperationResultTest {
     @Test
     fun `addFrom returns empty list when key does not exist`() {
         val result = OperationResult.of(patient())
-            .addFrom("missing", Patient::class) { patients ->
+            .addFrom("missing", Patient::class.java) { patients ->
                 Appointment().apply { addParticipant().actor = Reference().apply { display = "count=${patients.size}" } }
             }
 
@@ -273,7 +273,7 @@ class OperationResultTest {
     @Test
     fun `addAllFrom builder returning a Set stores all elements`() {
         val result = OperationResult.of(listOf(patient(), patient()), "patients")
-            .addAllFrom("patients", Patient::class) { patients ->
+            .addAllFrom("patients", Patient::class.java) { patients ->
                 patients.map { OperationOutcome() }.toSet()
             }
 
@@ -286,7 +286,7 @@ class OperationResultTest {
     @Test
     fun `addAllFrom filters by type and maps to list added under same name`() {
         val result = OperationResult.of(listOf(patient(), appointment()), "items")
-            .addAllFrom("items", Patient::class) { patients ->
+            .addAllFrom("items", Patient::class.java) { patients ->
                 patients.map { OperationOutcome() }
             }
 
@@ -302,7 +302,7 @@ class OperationResultTest {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val notEnrolled = patient()
         val result = OperationResult.of(listOf(enrolled, notEnrolled), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -319,7 +319,7 @@ class OperationResultTest {
         }
         val onlyFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val result = OperationResult.of(listOf(both, onlyFirst), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/url1", "http://example.org/url2")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/url1", "http://example.org/url2")) { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -338,7 +338,7 @@ class OperationResultTest {
         }
         val hasNeither = patient()
         val result = OperationResult.of(listOf(hasFirst, hasSecond, hasBoth, hasNeither), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAnyExtension("http://example.org/url1", "http://example.org/url2")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAnyExtension("http://example.org/url1", "http://example.org/url2")) { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -352,7 +352,7 @@ class OperationResultTest {
         val hasIt = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val hasNot = patient()
         val result = OperationResult.of(listOf(hasIt, hasNot), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAnyExtension("http://example.org/url1")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAnyExtension("http://example.org/url1")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -362,7 +362,7 @@ class OperationResultTest {
     @Test
     fun `addFromFiltered - hasAllExtensions with no URLs returns all resources of the given type`() {
         val result = OperationResult.of(listOf(patient(), patient(), appointment()), "items")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions()) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions()) { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -374,7 +374,7 @@ class OperationResultTest {
     @Test
     fun `addFromFiltered - hasAllExtensions predicate produces empty list when no resources match`() {
         val result = OperationResult.of(listOf(patient(), patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/nonexistent")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/nonexistent")) { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -386,7 +386,7 @@ class OperationResultTest {
     @Test
     fun `addFromFiltered - hasAnyExtension predicate produces empty list when no resources match`() {
         val result = OperationResult.of(listOf(patient(), patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAnyExtension("http://example.org/nonexistent")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAnyExtension("http://example.org/nonexistent")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -399,7 +399,7 @@ class OperationResultTest {
         val enrolled2 = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(enrolled1, "group-a")
             .add("group-b") { enrolled2 }
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -412,7 +412,7 @@ class OperationResultTest {
     fun `addAllFromFiltered - hasAllExtensions returns list result`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
                 filtered.map { OperationOutcome() }
             }
 
@@ -425,7 +425,7 @@ class OperationResultTest {
         val hasFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val hasSecond = patient().apply { addExtension("http://example.org/url2", StringType("b")) }
         val result = OperationResult.of(listOf(hasFirst, hasSecond, patient()), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasAnyExtension("http://example.org/url1", "http://example.org/url2")) { filtered ->
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAnyExtension("http://example.org/url1", "http://example.org/url2")) { filtered ->
                 filtered.map { OperationOutcome() }
             }
 
@@ -460,7 +460,7 @@ class OperationResultTest {
     @Test
     fun `addFromFiltered - records error outcome when builder throws`() {
         val result = OperationResult.of(patient(), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions()) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions()) { _ ->
                 throw RuntimeException("builder failed")
             }
 
@@ -472,7 +472,7 @@ class OperationResultTest {
     fun `addFromFiltered - hasAllExtensions unnamed overload stores result under output fhirType not input type`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { _ ->
                 OperationOutcome().apply { addIssue().diagnostics = "found" }
             }
 
@@ -485,7 +485,7 @@ class OperationResultTest {
     fun `addFromFiltered - hasAnyExtension unnamed overload stores result under output fhirType not input type`() {
         val hasExt = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val result = OperationResult.of(listOf(hasExt, patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAnyExtension("http://example.org/url1")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAnyExtension("http://example.org/url1")) { _ ->
                 OperationOutcome().apply { addIssue().diagnostics = "found" }
             }
 
@@ -497,14 +497,14 @@ class OperationResultTest {
     fun `addFromFiltered - named overload stores result under explicit name`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
-            .addFromFiltered("enrolled-summary", Patient::class, FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
+            .addFromFiltered("enrolled-summary", Patient::class.java, FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
             }
 
         assertTrue(result.containsKey("enrolled-summary"))
-        val summary = result.takeFirstTyped("enrolled-summary", OperationOutcome::class)
+        val summary = result.takeFirstTyped("enrolled-summary", OperationOutcome::class.java)
         assertEquals("count=1", summary!!.issueFirstRep.diagnostics)
     }
 
@@ -523,7 +523,7 @@ class OperationResultTest {
     fun `addAllFromFiltered - hasAllExtensions unnamed overload stores results under output fhirType not input type`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
                 filtered.map { OperationOutcome() }
             }
 
@@ -536,7 +536,7 @@ class OperationResultTest {
         val hasFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val hasSecond = patient().apply { addExtension("http://example.org/url2", StringType("b")) }
         val result = OperationResult.of(listOf(hasFirst, hasSecond, patient()), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasAnyExtension("http://example.org/url1", "http://example.org/url2")) { filtered ->
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAnyExtension("http://example.org/url1", "http://example.org/url2")) { filtered ->
                 filtered.map { OperationOutcome() }
             }
 
@@ -552,7 +552,7 @@ class OperationResultTest {
         val withBoolean = patient().apply { addExtension("http://example.org/flag", BooleanType(true)) }
         val noExtension = patient()
         val result = OperationResult.of(listOf(withString, withBoolean, noExtension), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class)) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class.java)) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -563,7 +563,7 @@ class OperationResultTest {
     fun `addFromFiltered - hasExtensionWithValueType produces empty list when no resources match`() {
         val withBoolean = patient().apply { addExtension("http://example.org/flag", BooleanType(false)) }
         val result = OperationResult.of(listOf(withBoolean, patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class)) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class.java)) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -574,12 +574,12 @@ class OperationResultTest {
     fun `addFromFiltered - hasExtensionWithValueType named variant stores result under explicit name`() {
         val withString = patient().apply { addExtension("http://example.org/flag", StringType("active")) }
         val result = OperationResult.of(listOf(withString, patient()), "patients")
-            .addFromFiltered("flag-summary", Patient::class, FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class)) { filtered ->
+            .addFromFiltered("flag-summary", Patient::class.java, FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class.java)) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
         assertTrue(result.containsKey("flag-summary"))
-        val summary = result.takeFirstTyped("flag-summary", OperationOutcome::class)
+        val summary = result.takeFirstTyped("flag-summary", OperationOutcome::class.java)
         assertEquals("count=1", summary!!.issueFirstRep.diagnostics)
     }
 
@@ -589,7 +589,7 @@ class OperationResultTest {
         val withString2 = patient().apply { addExtension("http://example.org/flag", StringType("b")) }
         val withBoolean = patient().apply { addExtension("http://example.org/flag", BooleanType(true)) }
         val result = OperationResult.of(listOf(withString1, withString2, withBoolean), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class)) { filtered ->
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class.java)) { filtered ->
                 filtered.map { OperationOutcome() }
             }
 
@@ -613,7 +613,7 @@ class OperationResultTest {
         val notEnrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("false")) }
         val noExt = patient()
         val result = OperationResult.of(listOf(enrolled, notEnrolled, noExt), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -624,7 +624,7 @@ class OperationResultTest {
     fun `addFromFiltered - hasExtensionValueMatching produces empty list when predicate never satisfied`() {
         val patient1 = patient().apply { addExtension("http://example.org/enrolled", StringType("false")) }
         val result = OperationResult.of(listOf(patient1, patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -635,12 +635,12 @@ class OperationResultTest {
     fun `addFromFiltered - hasExtensionValueMatching named variant stores result under explicit name`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
-            .addFromFiltered("enrolled-patients", Patient::class, FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { filtered ->
+            .addFromFiltered("enrolled-patients", Patient::class.java, FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
         assertTrue(result.containsKey("enrolled-patients"))
-        val summary = result.takeFirstTyped("enrolled-patients", OperationOutcome::class)
+        val summary = result.takeFirstTyped("enrolled-patients", OperationOutcome::class.java)
         assertEquals("count=1", summary!!.issueFirstRep.diagnostics)
     }
 
@@ -650,7 +650,7 @@ class OperationResultTest {
         val low = patient().apply { addExtension("http://example.org/priority", IntegerType(1)) }
         val none = patient()
         val result = OperationResult.of(listOf(high, low, none), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<IntegerType>("http://example.org/priority") { it.value > 5 }) { filtered ->
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionValueMatching<IntegerType>("http://example.org/priority") { it.value > 5 }) { filtered ->
                 filtered.map { OperationOutcome() }
             }
 
@@ -677,7 +677,7 @@ class OperationResultTest {
         }
         val userOnly = patient().apply { addExtension("http://example.org/role", StringType("user")) }
         val result = OperationResult.of(listOf(multiExt, userOnly, patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/role") { it.value == "admin" }) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/role") { it.value == "admin" }) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -688,7 +688,7 @@ class OperationResultTest {
     fun `addFromFiltered - hasExtensionValueMatching unnamed overload stores result under output fhirType not input type`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { _ ->
                 OperationOutcome().apply { addIssue().diagnostics = "found" }
             }
 
@@ -700,7 +700,7 @@ class OperationResultTest {
     fun `addAllFromFiltered - hasExtensionValueMatching unnamed overload stores results under output fhirType not input type`() {
         val high = patient().apply { addExtension("http://example.org/priority", IntegerType(10)) }
         val result = OperationResult.of(listOf(high, patient()), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<IntegerType>("http://example.org/priority") { it.value > 5 }) { filtered ->
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionValueMatching<IntegerType>("http://example.org/priority") { it.value > 5 }) { filtered ->
                 filtered.map { OperationOutcome() }
             }
 
@@ -1436,7 +1436,7 @@ class OperationResultTest {
         val original = patient()
         val replacement = patient().apply { addName().family = "Smith" }
         val result = OperationResult.of(original, "patient")
-            .mapStored("patient", Patient::class) { replacement }
+            .mapStored("patient", Patient::class.java) { replacement }
 
         assertThat(result.getAll("patient").first(), sameInstance(replacement))
     }
@@ -1446,7 +1446,7 @@ class OperationResultTest {
         val appt = appointment()
         val result = OperationResult.of(patient(), "mixed")
             .add("mixed") { appt }
-            .mapStored("mixed", Patient::class) { patient().apply { addName().family = "Transformed" } }
+            .mapStored("mixed", Patient::class.java) { patient().apply { addName().family = "Transformed" } }
 
         assertTrue(result.getAll("mixed").any { it is Appointment && it === appt })
     }
@@ -1455,7 +1455,7 @@ class OperationResultTest {
     fun `mapStored named key absent is a no-op`() {
         val p = patient()
         val result = OperationResult.of(p, "patient")
-            .mapStored("other", Patient::class) { patient() }
+            .mapStored("other", Patient::class.java) { patient() }
 
         assertThat(result.getAll("patient").first(), sameInstance(p))
         assertFalse(result.containsKey("other"))
@@ -1465,7 +1465,7 @@ class OperationResultTest {
     fun `mapStored named head is unchanged`() {
         val original = patient()
         val result = OperationResult.of(original, "patient")
-            .mapStored("patient", Patient::class) { patient() }
+            .mapStored("patient", Patient::class.java) { patient() }
 
         assertThat(result.getResult(), sameInstance(original))
     }
@@ -1475,7 +1475,7 @@ class OperationResultTest {
         val appt = appointment()
         val result = OperationResult.of(patient(), "patient")
             .add("appt") { appt }
-            .mapStored("patient", Patient::class) { patient() }
+            .mapStored("patient", Patient::class.java) { patient() }
 
         assertThat(result.getAll("appt").first(), sameInstance(appt))
     }
@@ -1484,7 +1484,7 @@ class OperationResultTest {
     fun `mapStored named transform throws records WARNING outcome and preserves original`() {
         val original = patient()
         val result = OperationResult.of(original, "patient")
-            .mapStored("patient", Patient::class) { throw RuntimeException("boom") }
+            .mapStored("patient", Patient::class.java) { throw RuntimeException("boom") }
 
         assertFalse(result.hasErrors())
         assertTrue(result.hasWarnings())
@@ -1501,7 +1501,7 @@ class OperationResultTest {
         var called = false
         val result = OperationResult.of(original, "patient")
             .add { throw RuntimeException("first") }
-            .mapStored("patient", Patient::class) { called = true; patient() }
+            .mapStored("patient", Patient::class.java) { called = true; patient() }
 
         assertFalse(called)
         assertThat(result.getAll("patient").first(), sameInstance(original))
@@ -1520,7 +1520,7 @@ class OperationResultTest {
     fun `mapStored named Class overload produces same result as KClass overload`() {
         val replacement = patient().apply { addName().family = "Java" }
         val viaKClass = OperationResult.of(patient(), "patient")
-            .mapStored("patient", Patient::class) { replacement }
+            .mapStored("patient", Patient::class.java) { replacement }
         val viaClass = OperationResult.of(patient(), "patient")
             .mapStored("patient", Patient::class.java) { replacement }
 
@@ -1539,7 +1539,7 @@ class OperationResultTest {
         val replacement = patient().apply { addName().family = "Transformed" }
         val result = OperationResult.of(p1, "key1")
             .add("key2") { p2 }
-            .mapStored(Patient::class) { replacement }
+            .mapStored(Patient::class.java) { replacement }
 
         assertTrue(result.getAll("key1").all { it === replacement })
         assertTrue(result.getAll("key2").all { it === replacement })
@@ -1550,7 +1550,7 @@ class OperationResultTest {
         val appt = appointment()
         val result = OperationResult.of(patient(), "patient")
             .add("appt") { appt }
-            .mapStored(Patient::class) { patient().apply { addName().family = "X" } }
+            .mapStored(Patient::class.java) { patient().apply { addName().family = "X" } }
 
         assertThat(result.getAll("appt").first(), sameInstance(appt))
     }
@@ -1559,7 +1559,7 @@ class OperationResultTest {
     fun `mapStored unkeyed no matching values is a no-op`() {
         val appt = appointment()
         val result = OperationResult.of(appt, "appt")
-            .mapStored(Patient::class) { patient() }
+            .mapStored(Patient::class.java) { patient() }
 
         assertThat(result.getAll("appt").first(), sameInstance(appt))
     }
@@ -1568,7 +1568,7 @@ class OperationResultTest {
     fun `mapStored unkeyed head is unchanged`() {
         val original = patient()
         val result = OperationResult.of(original, "patient")
-            .mapStored(Patient::class) { patient() }
+            .mapStored(Patient::class.java) { patient() }
 
         assertThat(result.getResult(), sameInstance(original))
     }
@@ -1577,7 +1577,7 @@ class OperationResultTest {
     fun `mapStored unkeyed transform throws records WARNING outcome and preserves original`() {
         val original = patient()
         val result = OperationResult.of(original, "patient")
-            .mapStored(Patient::class) { throw RuntimeException("boom") }
+            .mapStored(Patient::class.java) { throw RuntimeException("boom") }
 
         assertFalse(result.hasErrors())
         assertTrue(result.hasWarnings())
@@ -1594,7 +1594,7 @@ class OperationResultTest {
         var called = false
         val result = OperationResult.of(original, "patient")
             .add { throw RuntimeException("first") }
-            .mapStored(Patient::class) { called = true; patient() }
+            .mapStored(Patient::class.java) { called = true; patient() }
 
         assertFalse(called)
         assertThat(result.getAll("patient").first(), sameInstance(original))
@@ -1685,7 +1685,7 @@ class OperationResultTest {
         val result = OperationResult.of(patient(), "entry")
             .add("entry") { appt }
 
-        val found: Appointment? = result.takeFirstTyped("entry", Appointment::class)
+        val found: Appointment? = result.takeFirstTyped("entry", Appointment::class.java)
         assertThat(found, sameInstance(appt))
     }
 
@@ -1693,7 +1693,7 @@ class OperationResultTest {
     fun `takeFirstTyped returns null when no value matches the given type`() {
         val result = OperationResult.of(patient(), "patient")
 
-        assertEquals(null, result.takeFirstTyped("patient", Appointment::class))
+        assertEquals(null, result.takeFirstTyped("patient", Appointment::class.java))
     }
 
     @Test
@@ -2610,7 +2610,7 @@ class OperationResultTest {
     fun `addFromFiltered stores result under output fhirType when name is null`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -2621,7 +2621,7 @@ class OperationResultTest {
     @Test
     fun `addFromFiltered with explicit name stores under that name`() {
         val result = OperationResult.of(listOf(patient()), "patients")
-            .addFromFiltered("my-key", Patient::class, { true }) { patients ->
+            .addFromFiltered("my-key", Patient::class.java, { true }) { patients ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${patients.size}" }
             }
 
@@ -2642,7 +2642,7 @@ class OperationResultTest {
     @Test
     fun `addFromFiltered with no matching resources passes empty list to builder`() {
         val result = OperationResult.of(listOf(patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = { false }) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = { false }) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -2653,7 +2653,7 @@ class OperationResultTest {
     @Test
     fun `addFromFiltered builder exception records ERROR outcome (Pattern A)`() {
         val result = OperationResult.of(listOf(patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = { true }) { _ -> throw RuntimeException("boom") }
+            .addFromFiltered(type = Patient::class.java, predicate = { true }) { _ -> throw RuntimeException("boom") }
 
         assertTrue(result.hasErrors())
         assertEquals(
@@ -2665,7 +2665,7 @@ class OperationResultTest {
     @Test
     fun `addFromFiltered stores result under output type not input type`() {
         val result = OperationResult.of(listOf(patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = { true }) { _ -> OperationOutcome() }
+            .addFromFiltered(type = Patient::class.java, predicate = { true }) { _ -> OperationOutcome() }
 
         assertTrue(result.containsKey("operationoutcome"))
         assertFalse(result.containsKey("patient"))
@@ -2676,7 +2676,7 @@ class OperationResultTest {
         val p1 = patient()
         val p2 = patient()
         val result = OperationResult.of(listOf(p1, p2, appointment()), "items")
-            .addAllFromFiltered(type = Patient::class, predicate = { true }) { filtered -> filtered }
+            .addAllFromFiltered(type = Patient::class.java, predicate = { true }) { filtered -> filtered }
 
         assertThat(result.getResultList(), hasSize(2))
         assertTrue(result.containsKey("patient"))
@@ -2685,7 +2685,7 @@ class OperationResultTest {
     @Test
     fun `addAllFromFiltered with explicit name groups all items under that name`() {
         val result = OperationResult.of(listOf(patient(), appointment()), "items")
-            .addAllFromFiltered("mixed", org.hl7.fhir.dstu3.model.Base::class, { true }) { items -> items }
+            .addAllFromFiltered("mixed", org.hl7.fhir.dstu3.model.Base::class.java, { true }) { items -> items }
 
         assertEquals(2, result.count("mixed"))
     }
@@ -2695,7 +2695,7 @@ class OperationResultTest {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(enrolled, "p1")
             .add { patient() }
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 

--- a/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/AsyncOperationResult.kt
+++ b/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/AsyncOperationResult.kt
@@ -21,7 +21,6 @@ import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.OperationOutcome
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.reflect.KClass
 import kotlin.time.measureTime
 import kotlin.time.measureTimedValue
 
@@ -251,14 +250,6 @@ class AsyncOperationResult {
     ): AsyncOperationResult =
         addAfter(key, dep, type) { block.apply(it) }
 
-    /** [KClass] overload of [addAfter] (typed) — Kotlin callers may pass [KClass] directly. */
-    fun <T : Base> addAfter(
-        key: String,
-        dep: String,
-        type: KClass<T>,
-        block: suspend (T) -> Base
-    ): AsyncOperationResult = addAfter(key, dep, type.java, block)
-
     /**
      * Type-safe overload of [addListAfter] for a single dependency.
      *
@@ -290,14 +281,6 @@ class AsyncOperationResult {
     ): AsyncOperationResult =
         addListAfter(key, dep, type) { block.apply(it) }
 
-    /** [KClass] overload of [addListAfter] (typed) — Kotlin callers may pass [KClass] directly. */
-    fun <T : Base, R : Base> addListAfter(
-        key: String,
-        dep: String,
-        type: KClass<T>,
-        block: suspend (T) -> Collection<R>
-    ): AsyncOperationResult = addListAfter(key, dep, type.java, block)
-
     // Type-safe list-injection convenience methods
 
     /**
@@ -328,14 +311,6 @@ class AsyncOperationResult {
     ): AsyncOperationResult =
         addAfterAll(key, dep, type) { block.apply(it) }
 
-    /** [KClass] overload of [addAfterAll] — Kotlin callers may pass [KClass] directly. */
-    fun <T : Base> addAfterAll(
-        key: String,
-        dep: String,
-        type: KClass<T>,
-        block: suspend (List<T>) -> Base
-    ): AsyncOperationResult = addAfterAll(key, dep, type.java, block)
-
     /**
      * Like [addAfterAll] but [block] returns a `Collection<R>`.
      *
@@ -363,14 +338,6 @@ class AsyncOperationResult {
         block: Function<List<T>, out Collection<out R>>
     ): AsyncOperationResult =
         addListAfterAll(key, dep, type) { block.apply(it) }
-
-    /** [KClass] overload of [addListAfterAll] — Kotlin callers may pass [KClass] directly. */
-    fun <T : Base, R : Base> addListAfterAll(
-        key: String,
-        dep: String,
-        type: KClass<T>,
-        block: suspend (List<T>) -> Collection<R>
-    ): AsyncOperationResult = addListAfterAll(key, dep, type.java, block)
 
     // ── Retry helper ─────────────────────────────────────────────────────────
 
@@ -601,15 +568,6 @@ class AsyncOperationResult {
     ): AsyncOperationResult =
         addAfterWithTimeout(key, dep, type, timeoutMs) { block.apply(it) }
 
-    /** [KClass] overload of [addAfterWithTimeout] (typed) — Kotlin callers may pass [KClass] directly. */
-    fun <T : Base> addAfterWithTimeout(
-        key: String,
-        dep: String,
-        type: KClass<T>,
-        timeoutMs: Long,
-        block: suspend (T) -> Base
-    ): AsyncOperationResult = addAfterWithTimeout(key, dep, type.java, timeoutMs, block)
-
     /**
      * Registers a dependent list-producing DAG task with a per-task timeout where the single
      * dependency value is extracted and typed automatically.
@@ -640,14 +598,6 @@ class AsyncOperationResult {
     ): AsyncOperationResult =
         addListAfterWithTimeout(key, dep, type, timeoutMs) { block.apply(it) }
 
-    /** [KClass] overload of [addListAfterWithTimeout] (typed) — Kotlin callers may pass [KClass] directly. */
-    fun <T : Base, R : Base> addListAfterWithTimeout(
-        key: String,
-        dep: String,
-        type: KClass<T>,
-        timeoutMs: Long,
-        block: suspend (T) -> Collection<R>
-    ): AsyncOperationResult = addListAfterWithTimeout(key, dep, type.java, timeoutMs, block)
 
     /**
      * Registers a dependent DAG task with a per-task timeout where all values stored under
@@ -678,14 +628,6 @@ class AsyncOperationResult {
     ): AsyncOperationResult =
         addAfterAllWithTimeout(key, dep, type, timeoutMs) { block.apply(it) }
 
-    /** [KClass] overload of [addAfterAllWithTimeout] — Kotlin callers may pass [KClass] directly. */
-    fun <T : Base> addAfterAllWithTimeout(
-        key: String,
-        dep: String,
-        type: KClass<T>,
-        timeoutMs: Long,
-        block: suspend (List<T>) -> Base
-    ): AsyncOperationResult = addAfterAllWithTimeout(key, dep, type.java, timeoutMs, block)
 
     /**
      * Registers a dependent list-producing DAG task with a per-task timeout where all values
@@ -716,14 +658,6 @@ class AsyncOperationResult {
     ): AsyncOperationResult =
         addListAfterAllWithTimeout(key, dep, type, timeoutMs) { block.apply(it) }
 
-    /** [KClass] overload of [addListAfterAllWithTimeout] — Kotlin callers may pass [KClass] directly. */
-    fun <T : Base, R : Base> addListAfterAllWithTimeout(
-        key: String,
-        dep: String,
-        type: KClass<T>,
-        timeoutMs: Long,
-        block: suspend (List<T>) -> Collection<R>
-    ): AsyncOperationResult = addListAfterAllWithTimeout(key, dep, type.java, timeoutMs, block)
 
     // ── Dependent task with retry ─────────────────────────────────────────────
 
@@ -839,17 +773,6 @@ class AsyncOperationResult {
         block(value)
     }
 
-    /** [KClass] overload of [addAfterWithRetry] (typed) — Kotlin callers may pass [KClass] directly. */
-    @JvmOverloads
-    fun <T : Base> addAfterWithRetry(
-        key: String,
-        dep: String,
-        type: KClass<T>,
-        maxAttempts: Int = 3,
-        initialDelayMs: Long = 500,
-        retryOn: (Exception) -> Boolean = { true },
-        block: suspend (T) -> Base
-    ): AsyncOperationResult = addAfterWithRetry(key, dep, type.java, maxAttempts, initialDelayMs, retryOn, block)
 
     /**
      * Registers a dependent list-producing DAG task with retry where the single dependency
@@ -884,17 +807,6 @@ class AsyncOperationResult {
         block(value)
     }
 
-    /** [KClass] overload of [addListAfterWithRetry] (typed) — Kotlin callers may pass [KClass] directly. */
-    @JvmOverloads
-    fun <T : Base, R : Base> addListAfterWithRetry(
-        key: String,
-        dep: String,
-        type: KClass<T>,
-        maxAttempts: Int = 3,
-        initialDelayMs: Long = 500,
-        retryOn: (Exception) -> Boolean = { true },
-        block: suspend (T) -> Collection<R>
-    ): AsyncOperationResult = addListAfterWithRetry(key, dep, type.java, maxAttempts, initialDelayMs, retryOn, block)
 
     /**
      * Registers a dependent DAG task with retry where all values stored under [dep] are
@@ -928,17 +840,6 @@ class AsyncOperationResult {
         block(values)
     }
 
-    /** [KClass] overload of [addAfterAllWithRetry] — Kotlin callers may pass [KClass] directly. */
-    @JvmOverloads
-    fun <T : Base> addAfterAllWithRetry(
-        key: String,
-        dep: String,
-        type: KClass<T>,
-        maxAttempts: Int = 3,
-        initialDelayMs: Long = 500,
-        retryOn: (Exception) -> Boolean = { true },
-        block: suspend (List<T>) -> Base
-    ): AsyncOperationResult = addAfterAllWithRetry(key, dep, type.java, maxAttempts, initialDelayMs, retryOn, block)
 
     /**
      * Registers a dependent list-producing DAG task with retry where all values stored under
@@ -972,17 +873,6 @@ class AsyncOperationResult {
         block(values)
     }
 
-    /** [KClass] overload of [addListAfterAllWithRetry] — Kotlin callers may pass [KClass] directly. */
-    @JvmOverloads
-    fun <T : Base, R : Base> addListAfterAllWithRetry(
-        key: String,
-        dep: String,
-        type: KClass<T>,
-        maxAttempts: Int = 3,
-        initialDelayMs: Long = 500,
-        retryOn: (Exception) -> Boolean = { true },
-        block: suspend (List<T>) -> Collection<R>
-    ): AsyncOperationResult = addListAfterAllWithRetry(key, dep, type.java, maxAttempts, initialDelayMs, retryOn, block)
 
     // ── Independent task with fallback value ─────────────────────────────────
 

--- a/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/AsyncOperationResult.kt
+++ b/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/AsyncOperationResult.kt
@@ -230,30 +230,34 @@ class AsyncOperationResult {
      *
      * @param key storage key for the result
      * @param dep the single dependency key
-     * @param type the expected type of the dependency value
+     * @param type the expected Java [Class] of the dependency value
      * @param block the suspending lambda; receives the typed dependency value
      */
     fun <T : Base> addAfter(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         block: suspend (T) -> Base
     ): AsyncOperationResult = addAfter(key, dep) { deps ->
-        val value = deps[dep]!!.filterIsInstance(type.java).firstOrNull()
+        val value = deps[dep]!!.filterIsInstance(type).firstOrNull()
             ?: error("No value of type ${type.simpleName} found under dependency '$dep'")
         block(value)
     }
-
-    /** Java-friendly overload of [addAfter] (typed) — accepts [Class] instead of [KClass]. */
-    fun <T : Base> addAfter(key: String, dep: String, type: Class<T>, block: suspend (T) -> Base): AsyncOperationResult =
-        addAfter(key, dep, type.kotlin, block)
 
     /** Java-friendly [Function] overload of [addAfter] (typed). */
     fun <T : Base> addAfter(
         key: String, dep: String, type: Class<T>,
         block: Function<T, out Base>
     ): AsyncOperationResult =
-        addAfter(key, dep, type.kotlin) { block.apply(it) }
+        addAfter(key, dep, type) { block.apply(it) }
+
+    /** [KClass] overload of [addAfter] (typed) — Kotlin callers may pass [KClass] directly. */
+    fun <T : Base> addAfter(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        block: suspend (T) -> Base
+    ): AsyncOperationResult = addAfter(key, dep, type.java, block)
 
     /**
      * Type-safe overload of [addListAfter] for a single dependency.
@@ -265,30 +269,34 @@ class AsyncOperationResult {
      *
      * @param key storage key for the result list
      * @param dep the single dependency key
-     * @param type the expected type of the dependency value
+     * @param type the expected Java [Class] of the dependency value
      * @param block the suspending lambda; receives the typed dependency value
      */
     fun <T : Base, R : Base> addListAfter(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         block: suspend (T) -> Collection<R>
     ): AsyncOperationResult = addListAfter(key, dep) { deps ->
-        val value = deps[dep]!!.filterIsInstance(type.java).firstOrNull()
+        val value = deps[dep]!!.filterIsInstance(type).firstOrNull()
             ?: error("No value of type ${type.simpleName} found under dependency '$dep'")
         block(value)
     }
-
-    /** Java-friendly overload of [addListAfter] (typed) — accepts [Class] instead of [KClass]. */
-    fun <T : Base, R : Base> addListAfter(key: String, dep: String, type: Class<T>, block: suspend (T) -> Collection<R>): AsyncOperationResult =
-        addListAfter(key, dep, type.kotlin, block)
 
     /** Java-friendly [Function] overload of [addListAfter] (typed). */
     fun <T : Base, R : Base> addListAfter(
         key: String, dep: String, type: Class<T>,
         block: Function<T, out Collection<out R>>
     ): AsyncOperationResult =
-        addListAfter(key, dep, type.kotlin) { block.apply(it) }
+        addListAfter(key, dep, type) { block.apply(it) }
+
+    /** [KClass] overload of [addListAfter] (typed) — Kotlin callers may pass [KClass] directly. */
+    fun <T : Base, R : Base> addListAfter(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        block: suspend (T) -> Collection<R>
+    ): AsyncOperationResult = addListAfter(key, dep, type.java, block)
 
     // Type-safe list-injection convenience methods
 
@@ -300,29 +308,33 @@ class AsyncOperationResult {
      *
      * @param key storage key for the result
      * @param dep the single dependency key
-     * @param type the expected type of the dependency values
+     * @param type the expected Java [Class] of the dependency values
      * @param block the suspending lambda; receives the typed dependency list
      */
     fun <T : Base> addAfterAll(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         block: suspend (List<T>) -> Base
     ): AsyncOperationResult = addAfter(key, dep) { deps ->
-        val values = deps[dep]!!.filterIsInstance(type.java)
+        val values = deps[dep]!!.filterIsInstance(type)
         block(values)
     }
-
-    /** Java-friendly overload of [addAfterAll] — accepts [Class] instead of [KClass]. */
-    fun <T : Base> addAfterAll(key: String, dep: String, type: Class<T>, block: suspend (List<T>) -> Base): AsyncOperationResult =
-        addAfterAll(key, dep, type.kotlin, block)
 
     /** Java-friendly [Function] overload of [addAfterAll]. */
     fun <T : Base> addAfterAll(
         key: String, dep: String, type: Class<T>,
         block: Function<List<T>, out Base>
     ): AsyncOperationResult =
-        addAfterAll(key, dep, type.kotlin) { block.apply(it) }
+        addAfterAll(key, dep, type) { block.apply(it) }
+
+    /** [KClass] overload of [addAfterAll] — Kotlin callers may pass [KClass] directly. */
+    fun <T : Base> addAfterAll(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        block: suspend (List<T>) -> Base
+    ): AsyncOperationResult = addAfterAll(key, dep, type.java, block)
 
     /**
      * Like [addAfterAll] but [block] returns a `Collection<R>`.
@@ -332,29 +344,33 @@ class AsyncOperationResult {
      *
      * @param key storage key for the result list
      * @param dep the single dependency key
-     * @param type the expected type of the dependency values
+     * @param type the expected Java [Class] of the dependency values
      * @param block the suspending lambda; receives the typed dependency list
      */
     fun <T : Base, R : Base> addListAfterAll(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         block: suspend (List<T>) -> Collection<R>
     ): AsyncOperationResult = addListAfter(key, dep) { deps ->
-        val values = deps[dep]!!.filterIsInstance(type.java)
+        val values = deps[dep]!!.filterIsInstance(type)
         block(values)
     }
-
-    /** Java-friendly overload of [addListAfterAll] — accepts [Class] instead of [KClass]. */
-    fun <T : Base, R : Base> addListAfterAll(key: String, dep: String, type: Class<T>, block: suspend (List<T>) -> Collection<R>): AsyncOperationResult =
-        addListAfterAll(key, dep, type.kotlin, block)
 
     /** Java-friendly [Function] overload of [addListAfterAll]. */
     fun <T : Base, R : Base> addListAfterAll(
         key: String, dep: String, type: Class<T>,
         block: Function<List<T>, out Collection<out R>>
     ): AsyncOperationResult =
-        addListAfterAll(key, dep, type.kotlin) { block.apply(it) }
+        addListAfterAll(key, dep, type) { block.apply(it) }
+
+    /** [KClass] overload of [addListAfterAll] — Kotlin callers may pass [KClass] directly. */
+    fun <T : Base, R : Base> addListAfterAll(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        block: suspend (List<T>) -> Collection<R>
+    ): AsyncOperationResult = addListAfterAll(key, dep, type.java, block)
 
     // ── Retry helper ─────────────────────────────────────────────────────────
 
@@ -569,25 +585,30 @@ class AsyncOperationResult {
     fun <T : Base> addAfterWithTimeout(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         timeoutMs: Long,
         block: suspend (T) -> Base
     ): AsyncOperationResult = addAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
-        val value = deps[dep]!!.filterIsInstance(type.java).firstOrNull()
+        val value = deps[dep]!!.filterIsInstance(type).firstOrNull()
             ?: error("No value of type ${type.simpleName} found under dependency '$dep'")
         block(value)
     }
-
-    /** Java-friendly overload of [addAfterWithTimeout] (typed) — accepts [Class] instead of [KClass]. */
-    fun <T : Base> addAfterWithTimeout(key: String, dep: String, type: Class<T>, timeoutMs: Long, block: suspend (T) -> Base): AsyncOperationResult =
-        addAfterWithTimeout(key, dep, type.kotlin, timeoutMs, block)
 
     /** Java-friendly [Function] overload of [addAfterWithTimeout] (typed). */
     fun <T : Base> addAfterWithTimeout(
         key: String, dep: String, type: Class<T>, timeoutMs: Long,
         block: Function<T, out Base>
     ): AsyncOperationResult =
-        addAfterWithTimeout(key, dep, type.kotlin, timeoutMs) { block.apply(it) }
+        addAfterWithTimeout(key, dep, type, timeoutMs) { block.apply(it) }
+
+    /** [KClass] overload of [addAfterWithTimeout] (typed) — Kotlin callers may pass [KClass] directly. */
+    fun <T : Base> addAfterWithTimeout(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        timeoutMs: Long,
+        block: suspend (T) -> Base
+    ): AsyncOperationResult = addAfterWithTimeout(key, dep, type.java, timeoutMs, block)
 
     /**
      * Registers a dependent list-producing DAG task with a per-task timeout where the single
@@ -603,25 +624,30 @@ class AsyncOperationResult {
     fun <T : Base, R : Base> addListAfterWithTimeout(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         timeoutMs: Long,
         block: suspend (T) -> Collection<R>
     ): AsyncOperationResult = addListAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
-        val value = deps[dep]!!.filterIsInstance(type.java).firstOrNull()
+        val value = deps[dep]!!.filterIsInstance(type).firstOrNull()
             ?: error("No value of type ${type.simpleName} found under dependency '$dep'")
         block(value)
     }
-
-    /** Java-friendly overload of [addListAfterWithTimeout] (typed) — accepts [Class] instead of [KClass]. */
-    fun <T : Base, R : Base> addListAfterWithTimeout(key: String, dep: String, type: Class<T>, timeoutMs: Long, block: suspend (T) -> Collection<R>): AsyncOperationResult =
-        addListAfterWithTimeout(key, dep, type.kotlin, timeoutMs, block)
 
     /** Java-friendly [Function] overload of [addListAfterWithTimeout] (typed). */
     fun <T : Base, R : Base> addListAfterWithTimeout(
         key: String, dep: String, type: Class<T>, timeoutMs: Long,
         block: Function<T, out Collection<out R>>
     ): AsyncOperationResult =
-        addListAfterWithTimeout(key, dep, type.kotlin, timeoutMs) { block.apply(it) }
+        addListAfterWithTimeout(key, dep, type, timeoutMs) { block.apply(it) }
+
+    /** [KClass] overload of [addListAfterWithTimeout] (typed) — Kotlin callers may pass [KClass] directly. */
+    fun <T : Base, R : Base> addListAfterWithTimeout(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        timeoutMs: Long,
+        block: suspend (T) -> Collection<R>
+    ): AsyncOperationResult = addListAfterWithTimeout(key, dep, type.java, timeoutMs, block)
 
     /**
      * Registers a dependent DAG task with a per-task timeout where all values stored under
@@ -637,24 +663,29 @@ class AsyncOperationResult {
     fun <T : Base> addAfterAllWithTimeout(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         timeoutMs: Long,
         block: suspend (List<T>) -> Base
     ): AsyncOperationResult = addAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
-        val values = deps[dep]!!.filterIsInstance(type.java)
+        val values = deps[dep]!!.filterIsInstance(type)
         block(values)
     }
-
-    /** Java-friendly overload of [addAfterAllWithTimeout] — accepts [Class] instead of [KClass]. */
-    fun <T : Base> addAfterAllWithTimeout(key: String, dep: String, type: Class<T>, timeoutMs: Long, block: suspend (List<T>) -> Base): AsyncOperationResult =
-        addAfterAllWithTimeout(key, dep, type.kotlin, timeoutMs, block)
 
     /** Java-friendly [Function] overload of [addAfterAllWithTimeout]. */
     fun <T : Base> addAfterAllWithTimeout(
         key: String, dep: String, type: Class<T>, timeoutMs: Long,
         block: Function<List<T>, out Base>
     ): AsyncOperationResult =
-        addAfterAllWithTimeout(key, dep, type.kotlin, timeoutMs) { block.apply(it) }
+        addAfterAllWithTimeout(key, dep, type, timeoutMs) { block.apply(it) }
+
+    /** [KClass] overload of [addAfterAllWithTimeout] — Kotlin callers may pass [KClass] directly. */
+    fun <T : Base> addAfterAllWithTimeout(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        timeoutMs: Long,
+        block: suspend (List<T>) -> Base
+    ): AsyncOperationResult = addAfterAllWithTimeout(key, dep, type.java, timeoutMs, block)
 
     /**
      * Registers a dependent list-producing DAG task with a per-task timeout where all values
@@ -670,24 +701,29 @@ class AsyncOperationResult {
     fun <T : Base, R : Base> addListAfterAllWithTimeout(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         timeoutMs: Long,
         block: suspend (List<T>) -> Collection<R>
     ): AsyncOperationResult = addListAfterWithTimeout(key, dep, timeoutMs = timeoutMs) { deps ->
-        val values = deps[dep]!!.filterIsInstance(type.java)
+        val values = deps[dep]!!.filterIsInstance(type)
         block(values)
     }
-
-    /** Java-friendly overload of [addListAfterAllWithTimeout] — accepts [Class] instead of [KClass]. */
-    fun <T : Base, R : Base> addListAfterAllWithTimeout(key: String, dep: String, type: Class<T>, timeoutMs: Long, block: suspend (List<T>) -> Collection<R>): AsyncOperationResult =
-        addListAfterAllWithTimeout(key, dep, type.kotlin, timeoutMs, block)
 
     /** Java-friendly [Function] overload of [addListAfterAllWithTimeout]. */
     fun <T : Base, R : Base> addListAfterAllWithTimeout(
         key: String, dep: String, type: Class<T>, timeoutMs: Long,
         block: Function<List<T>, out Collection<out R>>
     ): AsyncOperationResult =
-        addListAfterAllWithTimeout(key, dep, type.kotlin, timeoutMs) { block.apply(it) }
+        addListAfterAllWithTimeout(key, dep, type, timeoutMs) { block.apply(it) }
+
+    /** [KClass] overload of [addListAfterAllWithTimeout] — Kotlin callers may pass [KClass] directly. */
+    fun <T : Base, R : Base> addListAfterAllWithTimeout(
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        timeoutMs: Long,
+        block: suspend (List<T>) -> Collection<R>
+    ): AsyncOperationResult = addListAfterAllWithTimeout(key, dep, type.java, timeoutMs, block)
 
     // ── Dependent task with retry ─────────────────────────────────────────────
 
@@ -787,7 +823,7 @@ class AsyncOperationResult {
     fun <T : Base> addAfterWithRetry(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
@@ -798,19 +834,22 @@ class AsyncOperationResult {
         initialDelayMs = initialDelayMs,
         retryOn = retryOn
     ) { deps ->
-        val value = deps[dep]!!.filterIsInstance(type.java).firstOrNull()
+        val value = deps[dep]!!.filterIsInstance(type).firstOrNull()
             ?: error("No value of type ${type.simpleName} found under dependency '$dep'")
         block(value)
     }
 
-    /** Java-friendly overload of [addAfterWithRetry] (typed) — accepts [Class] instead of [KClass]. */
+    /** [KClass] overload of [addAfterWithRetry] (typed) — Kotlin callers may pass [KClass] directly. */
     @JvmOverloads
     fun <T : Base> addAfterWithRetry(
-        key: String, dep: String, type: Class<T>,
-        maxAttempts: Int = 3, initialDelayMs: Long = 500,
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        maxAttempts: Int = 3,
+        initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
         block: suspend (T) -> Base
-    ): AsyncOperationResult = addAfterWithRetry(key, dep, type.kotlin, maxAttempts, initialDelayMs, retryOn, block)
+    ): AsyncOperationResult = addAfterWithRetry(key, dep, type.java, maxAttempts, initialDelayMs, retryOn, block)
 
     /**
      * Registers a dependent list-producing DAG task with retry where the single dependency
@@ -829,7 +868,7 @@ class AsyncOperationResult {
     fun <T : Base, R : Base> addListAfterWithRetry(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
@@ -840,19 +879,22 @@ class AsyncOperationResult {
         initialDelayMs = initialDelayMs,
         retryOn = retryOn
     ) { deps ->
-        val value = deps[dep]!!.filterIsInstance(type.java).firstOrNull()
+        val value = deps[dep]!!.filterIsInstance(type).firstOrNull()
             ?: error("No value of type ${type.simpleName} found under dependency '$dep'")
         block(value)
     }
 
-    /** Java-friendly overload of [addListAfterWithRetry] (typed) — accepts [Class] instead of [KClass]. */
+    /** [KClass] overload of [addListAfterWithRetry] (typed) — Kotlin callers may pass [KClass] directly. */
     @JvmOverloads
     fun <T : Base, R : Base> addListAfterWithRetry(
-        key: String, dep: String, type: Class<T>,
-        maxAttempts: Int = 3, initialDelayMs: Long = 500,
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        maxAttempts: Int = 3,
+        initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
         block: suspend (T) -> Collection<R>
-    ): AsyncOperationResult = addListAfterWithRetry(key, dep, type.kotlin, maxAttempts, initialDelayMs, retryOn, block)
+    ): AsyncOperationResult = addListAfterWithRetry(key, dep, type.java, maxAttempts, initialDelayMs, retryOn, block)
 
     /**
      * Registers a dependent DAG task with retry where all values stored under [dep] are
@@ -871,7 +913,7 @@ class AsyncOperationResult {
     fun <T : Base> addAfterAllWithRetry(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
@@ -882,18 +924,21 @@ class AsyncOperationResult {
         initialDelayMs = initialDelayMs,
         retryOn = retryOn
     ) { deps ->
-        val values = deps[dep]!!.filterIsInstance(type.java)
+        val values = deps[dep]!!.filterIsInstance(type)
         block(values)
     }
 
-    /** Java-friendly overload of [addAfterAllWithRetry] — accepts [Class] instead of [KClass]. */
+    /** [KClass] overload of [addAfterAllWithRetry] — Kotlin callers may pass [KClass] directly. */
     @JvmOverloads
     fun <T : Base> addAfterAllWithRetry(
-        key: String, dep: String, type: Class<T>,
-        maxAttempts: Int = 3, initialDelayMs: Long = 500,
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        maxAttempts: Int = 3,
+        initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
         block: suspend (List<T>) -> Base
-    ): AsyncOperationResult = addAfterAllWithRetry(key, dep, type.kotlin, maxAttempts, initialDelayMs, retryOn, block)
+    ): AsyncOperationResult = addAfterAllWithRetry(key, dep, type.java, maxAttempts, initialDelayMs, retryOn, block)
 
     /**
      * Registers a dependent list-producing DAG task with retry where all values stored under
@@ -912,7 +957,7 @@ class AsyncOperationResult {
     fun <T : Base, R : Base> addListAfterAllWithRetry(
         key: String,
         dep: String,
-        type: KClass<T>,
+        type: Class<T>,
         maxAttempts: Int = 3,
         initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
@@ -923,18 +968,21 @@ class AsyncOperationResult {
         initialDelayMs = initialDelayMs,
         retryOn = retryOn
     ) { deps ->
-        val values = deps[dep]!!.filterIsInstance(type.java)
+        val values = deps[dep]!!.filterIsInstance(type)
         block(values)
     }
 
-    /** Java-friendly overload of [addListAfterAllWithRetry] — accepts [Class] instead of [KClass]. */
+    /** [KClass] overload of [addListAfterAllWithRetry] — Kotlin callers may pass [KClass] directly. */
     @JvmOverloads
     fun <T : Base, R : Base> addListAfterAllWithRetry(
-        key: String, dep: String, type: Class<T>,
-        maxAttempts: Int = 3, initialDelayMs: Long = 500,
+        key: String,
+        dep: String,
+        type: KClass<T>,
+        maxAttempts: Int = 3,
+        initialDelayMs: Long = 500,
         retryOn: (Exception) -> Boolean = { true },
         block: suspend (List<T>) -> Collection<R>
-    ): AsyncOperationResult = addListAfterAllWithRetry(key, dep, type.kotlin, maxAttempts, initialDelayMs, retryOn, block)
+    ): AsyncOperationResult = addListAfterAllWithRetry(key, dep, type.java, maxAttempts, initialDelayMs, retryOn, block)
 
     // ── Independent task with fallback value ─────────────────────────────────
 

--- a/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/FhirExtensionHelper.kt
+++ b/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/FhirExtensionHelper.kt
@@ -7,7 +7,6 @@ import org.hl7.fhir.r4.model.Type
 import java.util.Collections
 import java.util.IdentityHashMap
 import java.util.Optional
-import kotlin.reflect.KClass
 
 /**
  * Utility object for retrieving FHIR extensions from any object that can carry them.
@@ -219,11 +218,11 @@ object FhirExtensionHelper {
  */
 internal fun <I : Base> filterByExtension(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     extUrls: Array<out String>,
     matchAll: Boolean
 ): List<I> {
-    val allOfType = allValues.filterIsInstance(type.java)
+    val allOfType = allValues.filterIsInstance(type)
     return if (extUrls.isEmpty()) allOfType
     else allOfType.filter { resource ->
         resource is IBaseHasExtensions && if (matchAll) {
@@ -243,14 +242,14 @@ internal fun <I : Base> filterByExtension(
  */
 internal fun <I : Base, V : Type> filterByExtensionAndValueType(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     url: String,
-    valueType: KClass<V>,
+    valueType: Class<V>,
     predicate: (V) -> Boolean
 ): List<I> =
     allValues
-        .filterIsInstance(type.java)
+        .filterIsInstance(type)
         .filter { resource ->
             resource is IBaseHasExtensions &&
-                FhirExtensionHelper.getAllValuesAs(resource, url, valueType.java).any(predicate)
+                FhirExtensionHelper.getAllValuesAs(resource, url, valueType).any(predicate)
         }

--- a/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/FhirFilter.kt
+++ b/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/FhirFilter.kt
@@ -2,7 +2,6 @@ package dev.ratkay.operation.r4
 
 import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.Type
-import kotlin.reflect.KClass
 
 /**
  * Predicate factories for use with [OperationResult.addFromFiltered] and
@@ -47,10 +46,6 @@ object FhirFilter {
     inline fun <reified V : Type> hasExtensionWithValueType(url: String): (Base) -> Boolean =
         hasExtensionWithValueType(url, V::class.java)
 
-    /** [KClass] overload — Kotlin callers may pass [KClass] directly. */
-    fun <V : Type> hasExtensionWithValueType(url: String, valueType: KClass<V>): (Base) -> Boolean =
-        hasExtensionWithValueType(url, valueType.java)
-
     /**
      * Returns `true` when the resource has an extension at [url] whose value is an instance
      * of [valueType] and satisfies [predicate].
@@ -77,14 +72,6 @@ object FhirFilter {
         noinline predicate: (V) -> Boolean
     ): (Base) -> Boolean =
         hasExtensionValueMatchingInternal(url, V::class.java, predicate)
-
-    /** [KClass] overload — Kotlin callers may pass [KClass] directly. */
-    fun <V : Type> hasExtensionValueMatching(
-        url: String,
-        valueType: KClass<V>,
-        predicate: (V) -> Boolean
-    ): (Base) -> Boolean =
-        hasExtensionValueMatchingInternal(url, valueType.java, predicate)
 
     @PublishedApi
     @JvmSynthetic

--- a/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/FhirFilter.kt
+++ b/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/FhirFilter.kt
@@ -25,50 +25,47 @@ object FhirFilter {
     /** Returns `true` when the resource has **all** of the given extension URLs. */
     @JvmStatic
     fun hasAllExtensions(vararg urls: String): (Base) -> Boolean =
-        { filterByExtension(listOf(it), Base::class, urls, matchAll = true).isNotEmpty() }
+        { filterByExtension(listOf(it), Base::class.java, urls, matchAll = true).isNotEmpty() }
 
     /** Returns `true` when the resource has **at least one** of the given extension URLs. */
     @JvmStatic
     fun hasAnyExtension(vararg urls: String): (Base) -> Boolean =
-        { filterByExtension(listOf(it), Base::class, urls, matchAll = false).isNotEmpty() }
+        { filterByExtension(listOf(it), Base::class.java, urls, matchAll = false).isNotEmpty() }
 
     /**
      * Returns `true` when the resource has an extension at [url] whose value is an
      * instance of [valueType].
+     *
+     * @param url the extension URL to match
+     * @param valueType the expected Java class of the extension value
      */
     @JvmStatic
-    @Suppress("UNCHECKED_CAST")
-    fun hasExtensionWithValueType(url: String, valueType: KClass<out Type>): (Base) -> Boolean {
-        val typed = valueType as KClass<Type>
-        return { filterByExtensionAndValueType(listOf(it), Base::class, url, typed) { true }.isNotEmpty() }
-    }
-
-    /** Reified overload of [hasExtensionWithValueType]. */
-    inline fun <reified V : Type> hasExtensionWithValueType(url: String): (Base) -> Boolean =
-        hasExtensionWithValueType(url, V::class)
-
-    /** Java-friendly overload of [hasExtensionWithValueType] — accepts [Class] instead of [KClass]. */
-    @JvmStatic
     fun <V : Type> hasExtensionWithValueType(url: String, valueType: Class<V>): (Base) -> Boolean =
-        hasExtensionWithValueType(url, valueType.kotlin)
+        { filterByExtensionAndValueType(listOf(it), Base::class.java, url, valueType) { true }.isNotEmpty() }
+
+    /** Reified overload — no [Class] argument needed at call sites. */
+    inline fun <reified V : Type> hasExtensionWithValueType(url: String): (Base) -> Boolean =
+        hasExtensionWithValueType(url, V::class.java)
+
+    /** [KClass] overload — Kotlin callers may pass [KClass] directly. */
+    fun <V : Type> hasExtensionWithValueType(url: String, valueType: KClass<V>): (Base) -> Boolean =
+        hasExtensionWithValueType(url, valueType.java)
 
     /**
      * Returns `true` when the resource has an extension at [url] whose value is an instance
      * of [valueType] and satisfies [predicate].
      *
-     * Java callers: the [predicate] receives the value cast to [valueType]; use the
-     * reified overload from Kotlin for full type safety.
+     * @param url the extension URL to match
+     * @param valueType the expected Java class of the extension value
+     * @param predicate additional condition the value must satisfy
      */
     @JvmStatic
-    @Suppress("UNCHECKED_CAST")
-    fun hasExtensionValueMatching(
+    fun <V : Type> hasExtensionValueMatching(
         url: String,
-        valueType: KClass<out Type>,
-        predicate: (Type) -> Boolean
-    ): (Base) -> Boolean {
-        val typed = valueType as KClass<Type>
-        return { filterByExtensionAndValueType(listOf(it), Base::class, url, typed, predicate).isNotEmpty() }
-    }
+        valueType: Class<V>,
+        predicate: (V) -> Boolean
+    ): (Base) -> Boolean =
+        hasExtensionValueMatchingInternal(url, valueType, predicate)
 
     /**
      * Reified, fully type-safe overload of [hasExtensionValueMatching].
@@ -79,76 +76,67 @@ object FhirFilter {
         url: String,
         noinline predicate: (V) -> Boolean
     ): (Base) -> Boolean =
-        hasExtensionValueMatchingInternal(url, V::class, predicate)
-
-    /** Java-friendly overload of [hasExtensionValueMatching] — accepts [Class] instead of [KClass]. */
-    @JvmStatic
-    fun <V : Type> hasExtensionValueMatching(
-        url: String,
-        valueType: Class<V>,
-        predicate: (V) -> Boolean
-    ): (Base) -> Boolean =
-        hasExtensionValueMatchingInternal(url, valueType.kotlin, predicate)
+        hasExtensionValueMatchingInternal(url, V::class.java, predicate)
 
     @PublishedApi
     @JvmSynthetic
     internal fun <V : Type> hasExtensionValueMatchingInternal(
         url: String,
-        valueType: KClass<V>,
+        valueType: Class<V>,
         predicate: (V) -> Boolean
     ): (Base) -> Boolean =
-        { filterByExtensionAndValueType(listOf(it), Base::class, url, valueType, predicate).isNotEmpty() }
+        { filterByExtensionAndValueType(listOf(it), Base::class.java, url, valueType, predicate).isNotEmpty() }
 
     // ── Identifier predicates ─────────────────────────────────────────────────
 
     /** Returns `true` when the resource has an identifier with [system]. */
     @JvmStatic
     fun hasIdentifierWithSystem(system: String): (Base) -> Boolean =
-        { filterByIdentifierSystem(listOf(it), Base::class, system).isNotEmpty() }
+        { filterByIdentifierSystem(listOf(it), Base::class.java, system).isNotEmpty() }
 
     /** Returns `true` when the resource has an identifier with [identifierValue]. */
     @JvmStatic
     fun hasIdentifierWithValue(identifierValue: String): (Base) -> Boolean =
-        { filterByIdentifierValue(listOf(it), Base::class, identifierValue).isNotEmpty() }
+        { filterByIdentifierValue(listOf(it), Base::class.java, identifierValue).isNotEmpty() }
 
     /** Returns `true` when the resource has an identifier matching both [system] and [identifierValue]. */
     @JvmStatic
     fun hasIdentifier(system: String, identifierValue: String): (Base) -> Boolean =
-        { filterByIdentifier(listOf(it), Base::class, system, identifierValue).isNotEmpty() }
+        { filterByIdentifier(listOf(it), Base::class.java, system, identifierValue).isNotEmpty() }
 
     // ── Meta tag predicates ───────────────────────────────────────────────────
 
     /** Returns `true` when the resource has a meta.tag with [system]. */
     @JvmStatic
     fun hasMetaTagWithSystem(system: String): (Base) -> Boolean =
-        { filterByMetaTagSystem(listOf(it), Base::class, system).isNotEmpty() }
+        { filterByMetaTagSystem(listOf(it), Base::class.java, system).isNotEmpty() }
 
     /** Returns `true` when the resource has a meta.tag with [code]. */
     @JvmStatic
     fun hasMetaTagWithCode(code: String): (Base) -> Boolean =
-        { filterByMetaTagCode(listOf(it), Base::class, code).isNotEmpty() }
+        { filterByMetaTagCode(listOf(it), Base::class.java, code).isNotEmpty() }
 
     /** Returns `true` when the resource has a meta.tag matching both [system] and [code]. */
     @JvmStatic
     fun hasMetaTag(system: String, code: String): (Base) -> Boolean =
-        { filterByMetaTag(listOf(it), Base::class, system, code).isNotEmpty() }
+        { filterByMetaTag(listOf(it), Base::class.java, system, code).isNotEmpty() }
 
     // ── Meta security predicates ──────────────────────────────────────────────
 
     /** Returns `true` when the resource has a meta.security with [system]. */
     @JvmStatic
     fun hasMetaSecurityWithSystem(system: String): (Base) -> Boolean =
-        { filterByMetaSecuritySystem(listOf(it), Base::class, system).isNotEmpty() }
+        { filterByMetaSecuritySystem(listOf(it), Base::class.java, system).isNotEmpty() }
 
     /** Returns `true` when the resource has a meta.security with [code]. */
     @JvmStatic
     fun hasMetaSecurityWithCode(code: String): (Base) -> Boolean =
-        { filterByMetaSecurityCode(listOf(it), Base::class, code).isNotEmpty() }
+        { filterByMetaSecurityCode(listOf(it), Base::class.java, code).isNotEmpty() }
 
     /** Returns `true` when the resource has a meta.security matching both [system] and [code]. */
     @JvmStatic
     fun hasMetaSecurity(system: String, code: String): (Base) -> Boolean =
-        { filterByMetaSecurity(listOf(it), Base::class, system, code).isNotEmpty() }
+        { filterByMetaSecurity(listOf(it), Base::class.java, system, code).isNotEmpty() }
 
     // ── Combinators ───────────────────────────────────────────────────────────
 
@@ -172,5 +160,5 @@ object FhirFilter {
     /** Returns `true` when the resource has the given [url] in meta.profile. */
     @JvmStatic
     fun hasMetaProfile(url: String): (Base) -> Boolean =
-        { filterByMetaProfile(listOf(it), Base::class, url).isNotEmpty() }
+        { filterByMetaProfile(listOf(it), Base::class.java, url).isNotEmpty() }
 }

--- a/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/FhirFilter.kt
+++ b/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/FhirFilter.kt
@@ -78,6 +78,14 @@ object FhirFilter {
     ): (Base) -> Boolean =
         hasExtensionValueMatchingInternal(url, V::class.java, predicate)
 
+    /** [KClass] overload — Kotlin callers may pass [KClass] directly. */
+    fun <V : Type> hasExtensionValueMatching(
+        url: String,
+        valueType: KClass<V>,
+        predicate: (V) -> Boolean
+    ): (Base) -> Boolean =
+        hasExtensionValueMatchingInternal(url, valueType.java, predicate)
+
     @PublishedApi
     @JvmSynthetic
     internal fun <V : Type> hasExtensionValueMatchingInternal(

--- a/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/FhirIdentifierHelper.kt
+++ b/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/FhirIdentifierHelper.kt
@@ -2,7 +2,6 @@ package dev.ratkay.operation.r4
 
 import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.Identifier
-import kotlin.reflect.KClass
 
 internal fun identifiersOf(resource: Base): List<Identifier> =
     resource.children()
@@ -13,24 +12,24 @@ internal fun identifiersOf(resource: Base): List<Identifier> =
 
 internal fun <I : Base> filterByIdentifierSystem(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     system: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> identifiersOf(resource).any { it.system == system } }
 
 internal fun <I : Base> filterByIdentifierValue(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     identifierValue: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> identifiersOf(resource).any { it.value == identifierValue } }
 
 internal fun <I : Base> filterByIdentifier(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     system: String,
     identifierValue: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource ->
         identifiersOf(resource).any { it.system == system && it.value == identifierValue }
     }

--- a/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/FhirMetaHelper.kt
+++ b/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/FhirMetaHelper.kt
@@ -3,7 +3,6 @@ package dev.ratkay.operation.r4
 import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.Resource
-import kotlin.reflect.KClass
 
 internal fun metaTagsOf(resource: Base): List<Coding> =
     if (resource is Resource) resource.meta.tag else emptyList()
@@ -16,51 +15,51 @@ internal fun metaProfilesOf(resource: Base): List<String> =
 
 internal fun <I : Base> filterByMetaTagSystem(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     system: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> metaTagsOf(resource).any { it.system == system } }
 
 internal fun <I : Base> filterByMetaTagCode(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     code: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> metaTagsOf(resource).any { it.code == code } }
 
 internal fun <I : Base> filterByMetaTag(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     system: String,
     code: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> metaTagsOf(resource).any { it.system == system && it.code == code } }
 
 internal fun <I : Base> filterByMetaSecuritySystem(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     system: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> metaSecurityOf(resource).any { it.system == system } }
 
 internal fun <I : Base> filterByMetaSecurityCode(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     code: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> metaSecurityOf(resource).any { it.code == code } }
 
 internal fun <I : Base> filterByMetaSecurity(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     system: String,
     code: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> metaSecurityOf(resource).any { it.system == system && it.code == code } }
 
 internal fun <I : Base> filterByMetaProfile(
     allValues: List<Base>,
-    type: KClass<I>,
+    type: Class<I>,
     url: String
-): List<I> = allValues.filterIsInstance(type.java)
+): List<I> = allValues.filterIsInstance(type)
     .filter { resource -> metaProfilesOf(resource).any { it == url } }

--- a/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -33,6 +33,7 @@ import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZonedDateTime
 import java.util.IdentityHashMap
+import java.util.function.Consumer
 import kotlin.reflect.KClass
 import kotlin.time.measureTime
 import kotlin.time.measureTimedValue
@@ -51,8 +52,6 @@ import kotlin.time.measureTimedValue
  * |---------|---------|
  * | Error state | `hasErrors`, `isSuccessful`, `getOutcomes`, `getFailedTasks`, `toOperationOutcome`, `throwIfErrors` |
  * | Metrics & timing | `timed`, `getMetrics` |
- * | Extension URL filters | `addFromHavingAllExtensions`, `addFromHavingAnyExtension`, `addAllFrom…`, `addFromHavingExtensionWithValueType`, `addFromHavingExtensionValueMatching`, … |
- * | Identifier filters | `addFromHavingIdentifierWithSystem`, `addFromHavingIdentifierWithValue`, `addFromHavingIdentifier`, `addAllFrom…` |
  * | Filtered builders | `addFromFiltered`, `addAllFromFiltered` — pass a [FhirFilter] predicate or any `(I) -> Boolean` |
  * | FHIRPath filters | `addFromMatching`, `addAllFromMatching` |
  * | Core builders | `add`, `addUsing`, `addAll`, `addAllUsing`, `addFrom`, `addAllFrom`, `addOrSkip`, `addOrDefault`, `addWithRetry`, `addWithRetryUsing` |
@@ -315,35 +314,39 @@ class OperationResult<T> private constructor(
      * Use [addAllFromFiltered] when [builder] returns a `List<R>`.
      *
      * Error handling follows Pattern A.
+     *
+     * @param type the Java [Class] of resources to collect.
+     * @param predicate filter applied to each collected resource.
+     * @param builder function that produces the new pipeline head from the filtered list.
      */
-    @JvmOverloads
-    fun <I : Base, R : Base> addFromFiltered(
-        name: String? = null,
-        type: KClass<I>,
-        predicate: (I) -> Boolean,
-        builder: (List<I>) -> R
-    ): OperationResult<R> = runBuilderStep(name) {
-        val (value, duration) = measureTimedValue {
-            builder(parameters.values.flatten().filterIsInstance(type.java).filter(predicate))
-        }
-        storeAndCopy(name, value, duration.inWholeMilliseconds)
-    }
-
-    /** Reified overload of [addFromFiltered] — no explicit [KClass] needed. */
-    inline fun <reified I : Base, R : Base> addFromFiltered(
-        name: String? = null,
-        noinline predicate: (I) -> Boolean,
-        noinline builder: (List<I>) -> R
-    ): OperationResult<R> = addFromFiltered(name, I::class, predicate, builder)
-
-    /** Java-friendly overload of [addFromFiltered] — accepts [Class] instead of [KClass]. */
     @JvmOverloads
     fun <I : Base, R : Base> addFromFiltered(
         name: String? = null,
         type: Class<I>,
         predicate: (I) -> Boolean,
         builder: (List<I>) -> R
-    ): OperationResult<R> = addFromFiltered(name, type.kotlin, predicate, builder)
+    ): OperationResult<R> = runBuilderStep(name) {
+        val (value, duration) = measureTimedValue {
+            builder(parameters.values.flatten().filterIsInstance(type).filter(predicate))
+        }
+        storeAndCopy(name, value, duration.inWholeMilliseconds)
+    }
+
+    /** Reified overload of [addFromFiltered] — no explicit [Class] needed. */
+    inline fun <reified I : Base, R : Base> addFromFiltered(
+        name: String? = null,
+        noinline predicate: (I) -> Boolean,
+        noinline builder: (List<I>) -> R
+    ): OperationResult<R> = addFromFiltered(name, I::class.java, predicate, builder)
+
+    /** [KClass] overload of [addFromFiltered] — Kotlin callers may pass [KClass] directly. */
+    @JvmOverloads
+    fun <I : Base, R : Base> addFromFiltered(
+        name: String? = null,
+        type: KClass<I>,
+        predicate: (I) -> Boolean,
+        builder: (List<I>) -> R
+    ): OperationResult<R> = addFromFiltered(name, type.java, predicate, builder)
 
     /**
      * Like [addFromFiltered] but [builder] returns a `Collection<R>`, making the new
@@ -351,40 +354,44 @@ class OperationResult<T> private constructor(
      *
      * Accepts any [Collection] return (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
      * always stored as a [List].
+     *
+     * @param type the Java [Class] of resources to collect.
+     * @param predicate filter applied to each collected resource.
+     * @param builder function that produces the collection of new resources from the filtered list.
      */
-    @JvmOverloads
-    fun <I : Base, R : Base> addAllFromFiltered(
-        name: String? = null,
-        type: KClass<I>,
-        predicate: (I) -> Boolean,
-        builder: (List<I>) -> Collection<R>
-    ): OperationResult<List<R>> = runBuilderStep(name) {
-        val (values, duration) = measureTimedValue {
-            builder(parameters.values.flatten().filterIsInstance(type.java).filter(predicate))
-        }
-        storeListAndCopy(name, values, duration.inWholeMilliseconds)
-    }
-
-    /** Reified overload of [addAllFromFiltered] — no explicit [KClass] needed. */
-    inline fun <reified I : Base, R : Base> addAllFromFiltered(
-        name: String? = null,
-        noinline predicate: (I) -> Boolean,
-        noinline builder: (List<I>) -> Collection<R>
-    ): OperationResult<List<R>> = addAllFromFiltered(name, I::class, predicate, builder)
-
-    /** Java-friendly overload of [addAllFromFiltered] — accepts [Class] instead of [KClass]. */
     @JvmOverloads
     fun <I : Base, R : Base> addAllFromFiltered(
         name: String? = null,
         type: Class<I>,
         predicate: (I) -> Boolean,
         builder: (List<I>) -> Collection<R>
-    ): OperationResult<List<R>> = addAllFromFiltered(name, type.kotlin, predicate, builder)
+    ): OperationResult<List<R>> = runBuilderStep(name) {
+        val (values, duration) = measureTimedValue {
+            builder(parameters.values.flatten().filterIsInstance(type).filter(predicate))
+        }
+        storeListAndCopy(name, values, duration.inWholeMilliseconds)
+    }
+
+    /** Reified overload of [addAllFromFiltered] — no explicit [Class] needed. */
+    inline fun <reified I : Base, R : Base> addAllFromFiltered(
+        name: String? = null,
+        noinline predicate: (I) -> Boolean,
+        noinline builder: (List<I>) -> Collection<R>
+    ): OperationResult<List<R>> = addAllFromFiltered(name, I::class.java, predicate, builder)
+
+    /** [KClass] overload of [addAllFromFiltered] — Kotlin callers may pass [KClass] directly. */
+    @JvmOverloads
+    fun <I : Base, R : Base> addAllFromFiltered(
+        name: String? = null,
+        type: KClass<I>,
+        predicate: (I) -> Boolean,
+        builder: (List<I>) -> Collection<R>
+    ): OperationResult<List<R>> = addAllFromFiltered(name, type.java, predicate, builder)
 
     // Builder methods — filter all accumulated parameters by type and FHIRPath expression
 
-    private fun <I : Base> collectByPath(type: KClass<I>, expression: String): List<I> =
-        filterByPath(parameters.values.flatten(), type.java, expression)
+    private fun <I : Base> collectByPath(type: Class<I>, expression: String): List<I> =
+        filterByPath(parameters.values.flatten(), type, expression)
 
     /**
      * Searches **all** accumulated parameters for instances of [type] where [expression]
@@ -399,11 +406,15 @@ class OperationResult<T> private constructor(
      * a relative path (e.g. `"active = true"`, not `"Patient.active = true"`).
      *
      * Use [addAllFromMatching] when [builder] returns a `List<R>`.
+     *
+     * @param type the Java [Class] of resources to match.
+     * @param expression FHIRPath expression evaluated against each resource.
+     * @param builder function that produces the new pipeline head from the matched list.
      */
     @JvmOverloads
     fun <I : Base, R : Base> addFromMatching(
         name: String? = null,
-        type: KClass<I>,
+        type: Class<I>,
         expression: String,
         builder: (List<I>) -> R
     ): OperationResult<R> {
@@ -417,7 +428,7 @@ class OperationResult<T> private constructor(
     @JvmOverloads
     fun <I : Base, R : Base> addFromMatching(
         name: String? = null,
-        type: KClass<I>,
+        type: Class<I>,
         expression: FhirPath,
         builder: (List<I>) -> R
     ): OperationResult<R> = addFromMatching(name, type, expression.build(), builder)
@@ -429,11 +440,15 @@ class OperationResult<T> private constructor(
      *
      * Accepts any [Collection] return (e.g. [List], [Set], [LinkedHashSet]); the pipeline head is
      * always stored as a [List].
+     *
+     * @param type the Java [Class] of resources to match.
+     * @param expression FHIRPath expression evaluated against each resource.
+     * @param builder function that produces the collection of new resources from the matched list.
      */
     @JvmOverloads
     fun <I : Base, R : Base> addAllFromMatching(
         name: String? = null,
-        type: KClass<I>,
+        type: Class<I>,
         expression: String,
         builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> {
@@ -447,38 +462,74 @@ class OperationResult<T> private constructor(
     @JvmOverloads
     fun <I : Base, R : Base> addAllFromMatching(
         name: String? = null,
-        type: KClass<I>,
+        type: Class<I>,
         expression: FhirPath,
         builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = addAllFromMatching(name, type, expression.build(), builder)
 
-    /** Reified overload of [addFromMatching] — no [KClass] argument needed at call sites. */
+    /** [KClass] overload of [addFromMatching] — Kotlin callers may pass [KClass] directly. */
+    @JvmOverloads
+    fun <I : Base, R : Base> addFromMatching(
+        name: String? = null,
+        type: KClass<I>,
+        expression: String,
+        builder: (List<I>) -> R
+    ): OperationResult<R> = addFromMatching(name, type.java, expression, builder)
+
+    /** [KClass] + [FhirPath] overload of [addFromMatching] — Kotlin callers may pass [KClass] directly. */
+    @JvmOverloads
+    fun <I : Base, R : Base> addFromMatching(
+        name: String? = null,
+        type: KClass<I>,
+        expression: FhirPath,
+        builder: (List<I>) -> R
+    ): OperationResult<R> = addFromMatching(name, type.java, expression.build(), builder)
+
+    /** [KClass] overload of [addAllFromMatching] — Kotlin callers may pass [KClass] directly. */
+    @JvmOverloads
+    fun <I : Base, R : Base> addAllFromMatching(
+        name: String? = null,
+        type: KClass<I>,
+        expression: String,
+        builder: (List<I>) -> Collection<R>
+    ): OperationResult<List<R>> = addAllFromMatching(name, type.java, expression, builder)
+
+    /** [KClass] + [FhirPath] overload of [addAllFromMatching] — Kotlin callers may pass [KClass] directly. */
+    @JvmOverloads
+    fun <I : Base, R : Base> addAllFromMatching(
+        name: String? = null,
+        type: KClass<I>,
+        expression: FhirPath,
+        builder: (List<I>) -> Collection<R>
+    ): OperationResult<List<R>> = addAllFromMatching(name, type.java, expression.build(), builder)
+
+    /** Reified overload of [addFromMatching] — no [Class] argument needed at call sites. */
     inline fun <reified I : Base, R : Base> addFromMatching(
         name: String? = null,
         expression: String,
         noinline builder: (List<I>) -> R
-    ): OperationResult<R> = addFromMatching(name, I::class, expression, builder)
+    ): OperationResult<R> = addFromMatching(name, I::class.java, expression, builder)
 
     /** [FhirPath] reified overload of [addFromMatching]. */
     inline fun <reified I : Base, R : Base> addFromMatching(
         name: String? = null,
         expression: FhirPath,
         noinline builder: (List<I>) -> R
-    ): OperationResult<R> = addFromMatching(name, I::class, expression.build(), builder)
+    ): OperationResult<R> = addFromMatching(name, I::class.java, expression.build(), builder)
 
-    /** Reified overload of [addAllFromMatching] — no [KClass] argument needed at call sites. */
+    /** Reified overload of [addAllFromMatching] — no [Class] argument needed at call sites. */
     inline fun <reified I : Base, R : Base> addAllFromMatching(
         name: String? = null,
         expression: String,
         noinline builder: (List<I>) -> Collection<R>
-    ): OperationResult<List<R>> = addAllFromMatching(name, I::class, expression, builder)
+    ): OperationResult<List<R>> = addAllFromMatching(name, I::class.java, expression, builder)
 
     /** [FhirPath] reified overload of [addAllFromMatching]. */
     inline fun <reified I : Base, R : Base> addAllFromMatching(
         name: String? = null,
         expression: FhirPath,
         noinline builder: (List<I>) -> Collection<R>
-    ): OperationResult<List<R>> = addAllFromMatching(name, I::class, expression.build(), builder)
+    ): OperationResult<List<R>> = addAllFromMatching(name, I::class.java, expression.build(), builder)
 
     // Builder methods - single item
 
@@ -553,21 +604,22 @@ class OperationResult<T> private constructor(
      * result. The pipeline head becomes [R].
      *
      * Error handling follows Pattern A.
+     *
+     * @param type the Java [Class] of values to filter under [name].
+     * @param builder function that produces the new pipeline head from the filtered list.
      */
-    fun <I : Base, R : Base> addFrom(name: String, type: KClass<I>, builder: (List<I>) -> R): OperationResult<R> =
+    fun <I : Base, R : Base> addFrom(name: String, type: Class<I>, builder: (List<I>) -> R): OperationResult<R> =
         runBuilderStep(name) {
             val (value, duration) = measureTimedValue {
-                val filtered = parameters[name]?.filterIsInstance(type.java) ?: emptyList()
+                val filtered = parameters[name]?.filterIsInstance(type) ?: emptyList()
                 builder(filtered)
             }
             storeAndCopy(name, value, duration.inWholeMilliseconds)
         }
 
-    /**
-     * Java-friendly overload of [addFrom] — accepts a [Class] instead of a [KClass].
-     */
-    fun <I : Base, R : Base> addFrom(name: String, type: Class<I>, builder: (List<I>) -> R): OperationResult<R> =
-        addFrom(name, type.kotlin, builder)
+    /** [KClass] overload of [addFrom] — Kotlin callers may pass [KClass] directly. */
+    fun <I : Base, R : Base> addFrom(name: String, type: KClass<I>, builder: (List<I>) -> R): OperationResult<R> =
+        addFrom(name, type.java, builder)
 
     /**
      * Like [addFrom] but [builder] returns a `Collection<R>`. The pipeline head becomes `List<R>`.
@@ -576,21 +628,22 @@ class OperationResult<T> private constructor(
      * always stored as a [List].
      *
      * Error handling follows Pattern A.
+     *
+     * @param type the Java [Class] of values to filter under [name].
+     * @param builder function that produces the collection of new resources from the filtered list.
      */
-    fun <I : Base, R : Base> addAllFrom(name: String, type: KClass<I>, builder: (List<I>) -> Collection<R>): OperationResult<List<R>> =
+    fun <I : Base, R : Base> addAllFrom(name: String, type: Class<I>, builder: (List<I>) -> Collection<R>): OperationResult<List<R>> =
         runBuilderStep(name) {
             val (values, duration) = measureTimedValue {
-                val filtered = parameters[name]?.filterIsInstance(type.java) ?: emptyList()
+                val filtered = parameters[name]?.filterIsInstance(type) ?: emptyList()
                 builder(filtered)
             }
             storeListAndCopy(name, values, duration.inWholeMilliseconds)
         }
 
-    /**
-     * Java-friendly overload of [addAllFrom] — accepts a [Class] instead of a [KClass].
-     */
-    fun <I : Base, R : Base> addAllFrom(name: String, type: Class<I>, builder: (List<I>) -> Collection<R>): OperationResult<List<R>> =
-        addAllFrom(name, type.kotlin, builder)
+    /** [KClass] overload of [addAllFrom] — Kotlin callers may pass [KClass] directly. */
+    fun <I : Base, R : Base> addAllFrom(name: String, type: KClass<I>, builder: (List<I>) -> Collection<R>): OperationResult<List<R>> =
+        addAllFrom(name, type.java, builder)
 
     // Builder variants with explicit error handling
 
@@ -1022,17 +1075,17 @@ class OperationResult<T> private constructor(
     /**
      * Returns all accumulated values that are instances of [type], across all keys.
      * Prefer the inline reified overload [getByType] where the type can be inferred.
+     *
+     * @param type the Java [Class] of values to retrieve.
      */
-    fun <R : Base> getByType(type: KClass<R>): List<R> =
-        parameters.values.flatten().filterIsInstance(type.java)
+    fun <R : Base> getByType(type: Class<R>): List<R> =
+        parameters.values.flatten().filterIsInstance(type)
 
-    /** Reified overload — no [KClass] argument needed at call sites. */
-    inline fun <reified R : Base> getByType(): List<R> = getByType(R::class)
+    /** Reified overload — no [Class] argument needed at call sites. */
+    inline fun <reified R : Base> getByType(): List<R> = getByType(R::class.java)
 
-    /**
-     * Java-friendly overload of [getByType] — accepts a [Class] instead of a [KClass].
-     */
-    fun <R : Base> getByType(type: Class<R>): List<R> = getByType(type.kotlin)
+    /** [KClass] overload — Kotlin callers may pass [KClass] directly. */
+    fun <R : Base> getByType(type: KClass<R>): List<R> = getByType(type.java)
 
     override fun containsKey(name: String): Boolean =
         parameters.containsKey(name)
@@ -1057,11 +1110,13 @@ class OperationResult<T> private constructor(
     /**
      * Returns a new result containing only entries whose values match [type].
      * Prefer the inline reified overload [filterByType] where the type can be inferred.
+     *
+     * @param type the Java [Class] of values to keep; entries with no matching values are dropped.
      */
-    fun <R : Base> filterByType(type: KClass<R>): OperationResult<T> {
+    fun <R : Base> filterByType(type: Class<R>): OperationResult<T> {
         val filtered = mutableMapOf<String, MutableList<Base>>()
         parameters.forEach { (name, values) ->
-            val matchingValues = values.filterIsInstance(type.java)
+            val matchingValues = values.filterIsInstance(type)
             if (matchingValues.isNotEmpty()) {
                 filtered[name] = matchingValues.toMutableList()
             }
@@ -1069,13 +1124,8 @@ class OperationResult<T> private constructor(
         return copyWith(result, params = filtered)
     }
 
-    /** Reified overload — no [KClass] argument needed at call sites. */
-    inline fun <reified R : Base> filterByType(): OperationResult<T> = filterByType(R::class)
-
-    /**
-     * Java-friendly overload of [filterByType] — accepts a [Class] instead of a [KClass].
-     */
-    fun <R : Base> filterByType(type: Class<R>): OperationResult<T> = filterByType(type.kotlin)
+    /** Reified overload — no [Class] argument needed at call sites. */
+    inline fun <reified R : Base> filterByType(): OperationResult<T> = filterByType(R::class.java)
 
     /** Returns a new result containing only the entry for [name]. All other keys are dropped. No-op if [name] is absent. */
     fun filterByName(name: String): OperationResult<T> {
@@ -1173,10 +1223,10 @@ class OperationResult<T> private constructor(
      * Respects [ErrorStrategy.FAIL_FAST]: returns immediately when the pipeline has errors.
      *
      * @param name the key whose values to transform.
-     * @param type the [KClass] of values to match; non-matching values pass through.
+     * @param type the Java [Class] of values to match; non-matching values pass through.
      * @param transform element-wise mapping function applied to each matching value.
      */
-    fun <I : Base, R : Base> mapStored(name: String, type: KClass<I>, transform: (I) -> R): OperationResult<T> {
+    fun <I : Base, R : Base> mapStored(name: String, type: Class<I>, transform: (I) -> R): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val (outcome, duration) = measureTimedValue {
             runCatching {
@@ -1184,7 +1234,7 @@ class OperationResult<T> private constructor(
                 val existing = newParams[name]
                 if (existing != null) {
                     newParams[name] = existing.map {
-                        if (type.java.isInstance(it)) transform(type.java.cast(it)) else it
+                        if (type.isInstance(it)) transform(type.cast(it)) else it
                     }.toMutableList()
                 }
                 newParams
@@ -1207,13 +1257,13 @@ class OperationResult<T> private constructor(
         )
     }
 
-    /** Java-friendly [Class] overload of [mapStored] — targets values under [name]. */
-    fun <I : Base, R : Base> mapStored(name: String, type: Class<I>, transform: (I) -> R): OperationResult<T> =
-        mapStored(name, type.kotlin, transform)
-
-    /** Reified overload — no [KClass] argument needed at call sites. Targets values under [name]. */
+    /** Reified overload — no [Class] argument needed at call sites. Targets values under [name]. */
     inline fun <reified I : Base, R : Base> mapStored(name: String, noinline transform: (I) -> R): OperationResult<T> =
-        mapStored(name, I::class, transform)
+        mapStored(name, I::class.java, transform)
+
+    /** [KClass] overload of [mapStored] — Kotlin callers may pass [KClass] directly. Targets values under [name]. */
+    fun <I : Base, R : Base> mapStored(name: String, type: KClass<I>, transform: (I) -> R): OperationResult<T> =
+        mapStored(name, type.java, transform)
 
     /**
      * Applies [transform] to every value across all stored keys that is an instance of [type],
@@ -1227,16 +1277,16 @@ class OperationResult<T> private constructor(
      * the original parameter map is preserved unchanged (Pattern B — head-preserving).
      * Respects [ErrorStrategy.FAIL_FAST]: returns immediately when the pipeline has errors.
      *
-     * @param type the [KClass] of values to match; non-matching values pass through.
+     * @param type the Java [Class] of values to match; non-matching values pass through.
      * @param transform element-wise mapping function applied to each matching value.
      */
-    fun <I : Base, R : Base> mapStored(type: KClass<I>, transform: (I) -> R): OperationResult<T> {
+    fun <I : Base, R : Base> mapStored(type: Class<I>, transform: (I) -> R): OperationResult<T> {
         if (shouldSkip()) return copyWith(result)
         val (outcome, duration) = measureTimedValue {
             runCatching {
                 val newParams = shallowCopyParams()
                 newParams.replaceAll { _, values ->
-                    values.map { if (type.java.isInstance(it)) transform(type.java.cast(it)) else it }.toMutableList()
+                    values.map { if (type.isInstance(it)) transform(type.cast(it)) else it }.toMutableList()
                 }
                 newParams
             }
@@ -1258,13 +1308,13 @@ class OperationResult<T> private constructor(
         )
     }
 
-    /** Java-friendly [Class] overload of [mapStored] — targets all stored values of [type] across all keys. */
-    fun <I : Base, R : Base> mapStored(type: Class<I>, transform: (I) -> R): OperationResult<T> =
-        mapStored(type.kotlin, transform)
-
-    /** Reified overload — no [KClass] argument needed at call sites. Targets all stored values of the type across all keys. */
+    /** Reified overload — no [Class] argument needed at call sites. Targets all stored values of the type across all keys. */
     inline fun <reified I : Base, R : Base> mapStored(noinline transform: (I) -> R): OperationResult<T> =
-        mapStored(I::class, transform)
+        mapStored(I::class.java, transform)
+
+    /** [KClass] overload of [mapStored] — Kotlin callers may pass [KClass] directly. Targets all stored values of the type across all keys. */
+    fun <I : Base, R : Base> mapStored(type: KClass<I>, transform: (I) -> R): OperationResult<T> =
+        mapStored(type.java, transform)
 
     /**
      * Invokes [block] with a snapshot of the current parameter map for side-effects (logging,
@@ -1272,6 +1322,17 @@ class OperationResult<T> private constructor(
      */
     fun peek(block: (Map<String, List<Base>>) -> Unit): OperationResult<T> {
         block(getAllParameters())
+        return this
+    }
+
+    /**
+     * Java-friendly overload of [peek] — accepts a [Consumer] instead of a Kotlin function type,
+     * enabling use of method references and lambda expressions from Java without explicit casting.
+     *
+     * @param block consumer that receives a snapshot of the current parameter map.
+     */
+    fun peek(block: Consumer<Map<String, List<Base>>>): OperationResult<T> {
+        block.accept(getAllParameters())
         return this
     }
 
@@ -1492,15 +1553,18 @@ class OperationResult<T> private constructor(
      *
      * Use the reified overload to avoid passing [type] explicitly:
      * `result.selectByPath<HumanName>("name.first()")`
+     *
+     * @param type the Java [Class] of values to extract via the FHIRPath expression.
+     * @param expression FHIRPath expression evaluated against the current head resource.
      */
     @JvmOverloads
-    fun <R : Base> selectByPath(type: KClass<R>, expression: String, name: String? = null): OperationResult<R> {
+    fun <R : Base> selectByPath(type: Class<R>, expression: String, name: String? = null): OperationResult<R> {
         val stepName = name ?: expression
         return runBuilderStep(stepName) {
             val head = result
             require(head is Base) { "selectByPath: head value is not a FHIR resource" }
             val (match, duration) = measureTimedValue {
-                FhirPathHelper.evaluateFirst(head as Base, expression, type.java)
+                FhirPathHelper.evaluateFirst(head as Base, expression, type)
                     ?: error("selectByPath: expression '$expression' matched no ${type.simpleName} values")
             }
             storeAndCopy(name, match, duration.inWholeMilliseconds)
@@ -1509,16 +1573,26 @@ class OperationResult<T> private constructor(
 
     /** [FhirPath] overload of [selectByPath] — builds the expression and delegates. */
     @JvmOverloads
-    fun <R : Base> selectByPath(type: KClass<R>, expression: FhirPath, name: String? = null): OperationResult<R> =
+    fun <R : Base> selectByPath(type: Class<R>, expression: FhirPath, name: String? = null): OperationResult<R> =
         selectByPath(type, expression.build(), name)
 
-    /** Reified overload of [selectByPath] — no [KClass] argument needed at call sites. */
+    /** Reified overload of [selectByPath] — no [Class] argument needed at call sites. */
     inline fun <reified R : Base> selectByPath(expression: String, name: String? = null): OperationResult<R> =
-        selectByPath(R::class, expression, name)
+        selectByPath(R::class.java, expression, name)
 
     /** [FhirPath] reified overload of [selectByPath]. */
     inline fun <reified R : Base> selectByPath(expression: FhirPath, name: String? = null): OperationResult<R> =
-        selectByPath(R::class, expression.build(), name)
+        selectByPath(R::class.java, expression.build(), name)
+
+    /** [KClass] overload of [selectByPath] — Kotlin callers may pass [KClass] directly. */
+    @JvmOverloads
+    fun <R : Base> selectByPath(type: KClass<R>, expression: String, name: String? = null): OperationResult<R> =
+        selectByPath(type.java, expression, name)
+
+    /** [KClass] + [FhirPath] overload of [selectByPath] — Kotlin callers may pass [KClass] directly. */
+    @JvmOverloads
+    fun <R : Base> selectByPath(type: KClass<R>, expression: FhirPath, name: String? = null): OperationResult<R> =
+        selectByPath(type.java, expression.build(), name)
 
     /** Returns the first value stored under [name], or `null` if the key is absent or empty. */
     fun takeFirst(name: String): Base? = parameters[name]?.firstOrNull()
@@ -1526,12 +1600,17 @@ class OperationResult<T> private constructor(
     /**
      * Returns the first value stored under [name] that is an instance of [type], or `null`.
      * Prefer the inline reified overload [takeFirstTyped] where the type can be inferred.
+     *
+     * @param type the Java [Class] of the value to retrieve.
      */
-    fun <R : Base> takeFirstTyped(name: String, type: KClass<R>): R? =
-        parameters[name]?.filterIsInstance(type.java)?.firstOrNull()
+    fun <R : Base> takeFirstTyped(name: String, type: Class<R>): R? =
+        parameters[name]?.filterIsInstance(type)?.firstOrNull()
 
-    /** Reified overload — no [KClass] argument needed at call sites. */
-    inline fun <reified R : Base> takeFirstTyped(name: String): R? = takeFirstTyped(name, R::class)
+    /** Reified overload — no [Class] argument needed at call sites. */
+    inline fun <reified R : Base> takeFirstTyped(name: String): R? = takeFirstTyped(name, R::class.java)
+
+    /** [KClass] overload — Kotlin callers may pass [KClass] directly. */
+    fun <R : Base> takeFirstTyped(name: String, type: KClass<R>): R? = takeFirstTyped(name, type.java)
 
     /**
      * Extracts the first value of type [R] stored under [name] and sets it as the pipeline head.
@@ -1542,45 +1621,44 @@ class OperationResult<T> private constructor(
      * all subsequent steps, ACCUMULATE will continue).
      *
      * @param name the parameter-map key to look up.
-     * @param type the expected [KClass] of the stored resource.
+     * @param type the expected Java [Class] of the stored resource.
      */
-    fun <R : Base> extractParam(name: String, type: KClass<R>): OperationResult<R> =
+    fun <R : Base> extractParam(name: String, type: Class<R>): OperationResult<R> =
         runBuilderStep(name) {
-            val value = parameters[name]?.filterIsInstance(type.java)?.firstOrNull()
+            val value = parameters[name]?.filterIsInstance(type)?.firstOrNull()
                 ?: error("No value of type '${type.simpleName}' found under key '$name'")
             copyWith(value)
         }
 
-    /** Reified overload — no [KClass] argument needed at call sites. */
+    /** Reified overload — no [Class] argument needed at call sites. */
     inline fun <reified R : Base> extractParam(name: String): OperationResult<R> =
-        extractParam(name, R::class)
+        extractParam(name, R::class.java)
 
-    /**
-     * Java-friendly overload of [extractParam] — accepts a [Class] instead of a [KClass].
-     */
-    fun <R : Base> extractParam(name: String, type: Class<R>): OperationResult<R> =
-        extractParam(name, type.kotlin)
+    /** [KClass] overload — Kotlin callers may pass [KClass] directly. */
+    fun <R : Base> extractParam(name: String, type: KClass<R>): OperationResult<R> =
+        extractParam(name, type.java)
 
     /**
      * Extracts all values of type [R] stored under [name] and sets the list as the pipeline head.
      * Returns an empty list (not an error) if no values match.
+     *
+     * @param name the parameter-map key to look up.
+     * @param type the expected Java [Class] of the stored resources.
      */
-    fun <R : Base> extractParamList(name: String, type: KClass<R>): OperationResult<List<R>> {
+    fun <R : Base> extractParamList(name: String, type: Class<R>): OperationResult<List<R>> {
         val values = parameters[name]
-            ?.filterIsInstance(type.java)
+            ?.filterIsInstance(type)
             ?: emptyList()
         return copyWith(values)
     }
 
-    /** Reified overload — no [KClass] argument needed at call sites. */
+    /** Reified overload — no [Class] argument needed at call sites. */
     inline fun <reified R : Base> extractParamList(name: String): OperationResult<List<R>> =
-        extractParamList(name, R::class)
+        extractParamList(name, R::class.java)
 
-    /**
-     * Java-friendly overload of [extractParamList] — accepts a [Class] instead of a [KClass].
-     */
-    fun <R : Base> extractParamList(name: String, type: Class<R>): OperationResult<List<R>> =
-        extractParamList(name, type.kotlin)
+    /** [KClass] overload — Kotlin callers may pass [KClass] directly. */
+    fun <R : Base> extractParamList(name: String, type: KClass<R>): OperationResult<List<R>> =
+        extractParamList(name, type.java)
 
     // Reference linking
 
@@ -1841,16 +1919,16 @@ class OperationResult<T> private constructor(
          * Call [useErrorStrategy] on the returned result to change the strategy if needed.
          *
          * @param primaryKey the parameter-map key whose value should become the pipeline head.
-         * @param type the expected [KClass] of the primary resource.
+         * @param type the expected Java [Class] of the primary resource.
          */
         @JvmStatic
         fun <T : Base> fromParametersTyped(
             parameters: Parameters,
             primaryKey: String,
-            type: KClass<T>
+            type: Class<T>
         ): OperationResult<T> {
             val (params, exts) = ParameterMapSerializer.flatten(parameters)
-            val primary = params[primaryKey]?.filterIsInstance(type.java)?.firstOrNull()
+            val primary = params[primaryKey]?.filterIsInstance(type)?.firstOrNull()
             return if (primary != null) {
                 OperationResult(params, primary, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf(), extensions = exts)
             } else {
@@ -1859,25 +1937,19 @@ class OperationResult<T> private constructor(
             }
         }
 
-        /** Reified overload of [fromParametersTyped] — no [KClass] argument needed at call sites. */
+        /** Reified overload of [fromParametersTyped] — no [Class] argument needed at call sites. */
         inline fun <reified T : Base> fromParametersTyped(
             parameters: Parameters,
             primaryKey: String
-        ): OperationResult<T> = fromParametersTyped(parameters, primaryKey, T::class)
+        ): OperationResult<T> = fromParametersTyped(parameters, primaryKey, T::class.java)
 
-        /**
-         * Java-friendly overload of [fromParametersTyped] — accepts a [Class] instead of a [KClass]
-         * so Java callers can write `fromParametersTyped(params, "patient", Patient.class)`.
-         *
-         * When no value of [type] is found under [primaryKey], returns a pipeline with
-         * [hasErrors] `== true` and a null head.
-         */
+        /** [KClass] overload of [fromParametersTyped] — Kotlin callers may pass [KClass] directly. */
         @JvmStatic
         fun <T : Base> fromParametersTyped(
             parameters: Parameters,
             primaryKey: String,
-            type: Class<T>
-        ): OperationResult<T> = fromParametersTyped(parameters, primaryKey, type.kotlin)
+            type: KClass<T>
+        ): OperationResult<T> = fromParametersTyped(parameters, primaryKey, type.java)
 
         /**
          * Builds an [OperationResult] from a FHIR [Bundle].
@@ -1936,13 +2008,13 @@ class OperationResult<T> private constructor(
          * [hasErrors] `== true` and a null head (consistent with Pattern A mid-pipeline steps).
          *
          * @param primaryKey the parameter-map key whose value should become the pipeline head.
-         * @param type the expected [KClass] of the primary resource.
+         * @param type the expected Java [Class] of the primary resource.
          */
         @JvmStatic
         fun <T : Resource> fromBundleTyped(
             bundle: Bundle,
             primaryKey: String,
-            type: KClass<T>
+            type: Class<T>
         ): OperationResult<T> {
             val params = mutableMapOf<String, MutableList<Base>>()
             bundle.entry
@@ -1951,7 +2023,7 @@ class OperationResult<T> private constructor(
                     val key = entry.resource.fhirType().lowercase()
                     params.getOrPut(key) { mutableListOf() }.add(entry.resource)
                 }
-            val primary = params[primaryKey]?.filterIsInstance(type.java)?.firstOrNull()
+            val primary = params[primaryKey]?.filterIsInstance(type)?.firstOrNull()
             return if (primary != null) {
                 OperationResult(params, primary, mutableListOf(), ErrorStrategy.FAIL_FAST, mutableMapOf())
             } else {
@@ -1960,24 +2032,19 @@ class OperationResult<T> private constructor(
             }
         }
 
-        /**
-         * Java-friendly overload of [fromBundleTyped] — accepts [Class] instead of [KClass].
-         *
-         * When no resource of [type] is found under [primaryKey], returns a pipeline with
-         * [hasErrors] `== true` and a null head.
-         */
+        /** Reified overload of [fromBundleTyped] — no [Class] argument needed at call sites. */
+        inline fun <reified T : Resource> fromBundleTyped(
+            bundle: Bundle,
+            primaryKey: String
+        ): OperationResult<T> = fromBundleTyped(bundle, primaryKey, T::class.java)
+
+        /** [KClass] overload of [fromBundleTyped] — Kotlin callers may pass [KClass] directly. */
         @JvmStatic
         fun <T : Resource> fromBundleTyped(
             bundle: Bundle,
             primaryKey: String,
-            type: Class<T>
-        ): OperationResult<T> = fromBundleTyped(bundle, primaryKey, type.kotlin)
-
-        /** Reified overload of [fromBundleTyped] — no [KClass] argument needed at call sites. */
-        inline fun <reified T : Resource> fromBundleTyped(
-            bundle: Bundle,
-            primaryKey: String
-        ): OperationResult<T> = fromBundleTyped(bundle, primaryKey, T::class)
+            type: KClass<T>
+        ): OperationResult<T> = fromBundleTyped(bundle, primaryKey, type.java)
 
         /**
          * Creates an empty [OperationResult] with no parameters and no pipeline head.

--- a/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
+++ b/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/OperationResult.kt
@@ -34,7 +34,6 @@ import java.time.OffsetDateTime
 import java.time.ZonedDateTime
 import java.util.IdentityHashMap
 import java.util.function.Consumer
-import kotlin.reflect.KClass
 import kotlin.time.measureTime
 import kotlin.time.measureTimedValue
 
@@ -339,15 +338,6 @@ class OperationResult<T> private constructor(
         noinline builder: (List<I>) -> R
     ): OperationResult<R> = addFromFiltered(name, I::class.java, predicate, builder)
 
-    /** [KClass] overload of [addFromFiltered] — Kotlin callers may pass [KClass] directly. */
-    @JvmOverloads
-    fun <I : Base, R : Base> addFromFiltered(
-        name: String? = null,
-        type: KClass<I>,
-        predicate: (I) -> Boolean,
-        builder: (List<I>) -> R
-    ): OperationResult<R> = addFromFiltered(name, type.java, predicate, builder)
-
     /**
      * Like [addFromFiltered] but [builder] returns a `Collection<R>`, making the new
      * pipeline head `List<R>`.
@@ -378,15 +368,6 @@ class OperationResult<T> private constructor(
         noinline predicate: (I) -> Boolean,
         noinline builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = addAllFromFiltered(name, I::class.java, predicate, builder)
-
-    /** [KClass] overload of [addAllFromFiltered] — Kotlin callers may pass [KClass] directly. */
-    @JvmOverloads
-    fun <I : Base, R : Base> addAllFromFiltered(
-        name: String? = null,
-        type: KClass<I>,
-        predicate: (I) -> Boolean,
-        builder: (List<I>) -> Collection<R>
-    ): OperationResult<List<R>> = addAllFromFiltered(name, type.java, predicate, builder)
 
     // Builder methods — filter all accumulated parameters by type and FHIRPath expression
 
@@ -466,42 +447,6 @@ class OperationResult<T> private constructor(
         expression: FhirPath,
         builder: (List<I>) -> Collection<R>
     ): OperationResult<List<R>> = addAllFromMatching(name, type, expression.build(), builder)
-
-    /** [KClass] overload of [addFromMatching] — Kotlin callers may pass [KClass] directly. */
-    @JvmOverloads
-    fun <I : Base, R : Base> addFromMatching(
-        name: String? = null,
-        type: KClass<I>,
-        expression: String,
-        builder: (List<I>) -> R
-    ): OperationResult<R> = addFromMatching(name, type.java, expression, builder)
-
-    /** [KClass] + [FhirPath] overload of [addFromMatching] — Kotlin callers may pass [KClass] directly. */
-    @JvmOverloads
-    fun <I : Base, R : Base> addFromMatching(
-        name: String? = null,
-        type: KClass<I>,
-        expression: FhirPath,
-        builder: (List<I>) -> R
-    ): OperationResult<R> = addFromMatching(name, type.java, expression.build(), builder)
-
-    /** [KClass] overload of [addAllFromMatching] — Kotlin callers may pass [KClass] directly. */
-    @JvmOverloads
-    fun <I : Base, R : Base> addAllFromMatching(
-        name: String? = null,
-        type: KClass<I>,
-        expression: String,
-        builder: (List<I>) -> Collection<R>
-    ): OperationResult<List<R>> = addAllFromMatching(name, type.java, expression, builder)
-
-    /** [KClass] + [FhirPath] overload of [addAllFromMatching] — Kotlin callers may pass [KClass] directly. */
-    @JvmOverloads
-    fun <I : Base, R : Base> addAllFromMatching(
-        name: String? = null,
-        type: KClass<I>,
-        expression: FhirPath,
-        builder: (List<I>) -> Collection<R>
-    ): OperationResult<List<R>> = addAllFromMatching(name, type.java, expression.build(), builder)
 
     /** Reified overload of [addFromMatching] — no [Class] argument needed at call sites. */
     inline fun <reified I : Base, R : Base> addFromMatching(
@@ -617,10 +562,6 @@ class OperationResult<T> private constructor(
             storeAndCopy(name, value, duration.inWholeMilliseconds)
         }
 
-    /** [KClass] overload of [addFrom] — Kotlin callers may pass [KClass] directly. */
-    fun <I : Base, R : Base> addFrom(name: String, type: KClass<I>, builder: (List<I>) -> R): OperationResult<R> =
-        addFrom(name, type.java, builder)
-
     /**
      * Like [addFrom] but [builder] returns a `Collection<R>`. The pipeline head becomes `List<R>`.
      *
@@ -640,10 +581,6 @@ class OperationResult<T> private constructor(
             }
             storeListAndCopy(name, values, duration.inWholeMilliseconds)
         }
-
-    /** [KClass] overload of [addAllFrom] — Kotlin callers may pass [KClass] directly. */
-    fun <I : Base, R : Base> addAllFrom(name: String, type: KClass<I>, builder: (List<I>) -> Collection<R>): OperationResult<List<R>> =
-        addAllFrom(name, type.java, builder)
 
     // Builder variants with explicit error handling
 
@@ -1084,9 +1021,6 @@ class OperationResult<T> private constructor(
     /** Reified overload — no [Class] argument needed at call sites. */
     inline fun <reified R : Base> getByType(): List<R> = getByType(R::class.java)
 
-    /** [KClass] overload — Kotlin callers may pass [KClass] directly. */
-    fun <R : Base> getByType(type: KClass<R>): List<R> = getByType(type.java)
-
     override fun containsKey(name: String): Boolean =
         parameters.containsKey(name)
 
@@ -1261,10 +1195,6 @@ class OperationResult<T> private constructor(
     inline fun <reified I : Base, R : Base> mapStored(name: String, noinline transform: (I) -> R): OperationResult<T> =
         mapStored(name, I::class.java, transform)
 
-    /** [KClass] overload of [mapStored] — Kotlin callers may pass [KClass] directly. Targets values under [name]. */
-    fun <I : Base, R : Base> mapStored(name: String, type: KClass<I>, transform: (I) -> R): OperationResult<T> =
-        mapStored(name, type.java, transform)
-
     /**
      * Applies [transform] to every value across all stored keys that is an instance of [type],
      * replacing each matching value with the result of [transform]. Values that are not instances
@@ -1311,10 +1241,6 @@ class OperationResult<T> private constructor(
     /** Reified overload — no [Class] argument needed at call sites. Targets all stored values of the type across all keys. */
     inline fun <reified I : Base, R : Base> mapStored(noinline transform: (I) -> R): OperationResult<T> =
         mapStored(I::class.java, transform)
-
-    /** [KClass] overload of [mapStored] — Kotlin callers may pass [KClass] directly. Targets all stored values of the type across all keys. */
-    fun <I : Base, R : Base> mapStored(type: KClass<I>, transform: (I) -> R): OperationResult<T> =
-        mapStored(type.java, transform)
 
     /**
      * Invokes [block] with a snapshot of the current parameter map for side-effects (logging,
@@ -1584,16 +1510,6 @@ class OperationResult<T> private constructor(
     inline fun <reified R : Base> selectByPath(expression: FhirPath, name: String? = null): OperationResult<R> =
         selectByPath(R::class.java, expression.build(), name)
 
-    /** [KClass] overload of [selectByPath] — Kotlin callers may pass [KClass] directly. */
-    @JvmOverloads
-    fun <R : Base> selectByPath(type: KClass<R>, expression: String, name: String? = null): OperationResult<R> =
-        selectByPath(type.java, expression, name)
-
-    /** [KClass] + [FhirPath] overload of [selectByPath] — Kotlin callers may pass [KClass] directly. */
-    @JvmOverloads
-    fun <R : Base> selectByPath(type: KClass<R>, expression: FhirPath, name: String? = null): OperationResult<R> =
-        selectByPath(type.java, expression.build(), name)
-
     /** Returns the first value stored under [name], or `null` if the key is absent or empty. */
     fun takeFirst(name: String): Base? = parameters[name]?.firstOrNull()
 
@@ -1608,9 +1524,6 @@ class OperationResult<T> private constructor(
 
     /** Reified overload — no [Class] argument needed at call sites. */
     inline fun <reified R : Base> takeFirstTyped(name: String): R? = takeFirstTyped(name, R::class.java)
-
-    /** [KClass] overload — Kotlin callers may pass [KClass] directly. */
-    fun <R : Base> takeFirstTyped(name: String, type: KClass<R>): R? = takeFirstTyped(name, type.java)
 
     /**
      * Extracts the first value of type [R] stored under [name] and sets it as the pipeline head.
@@ -1634,10 +1547,6 @@ class OperationResult<T> private constructor(
     inline fun <reified R : Base> extractParam(name: String): OperationResult<R> =
         extractParam(name, R::class.java)
 
-    /** [KClass] overload — Kotlin callers may pass [KClass] directly. */
-    fun <R : Base> extractParam(name: String, type: KClass<R>): OperationResult<R> =
-        extractParam(name, type.java)
-
     /**
      * Extracts all values of type [R] stored under [name] and sets the list as the pipeline head.
      * Returns an empty list (not an error) if no values match.
@@ -1655,10 +1564,6 @@ class OperationResult<T> private constructor(
     /** Reified overload — no [Class] argument needed at call sites. */
     inline fun <reified R : Base> extractParamList(name: String): OperationResult<List<R>> =
         extractParamList(name, R::class.java)
-
-    /** [KClass] overload — Kotlin callers may pass [KClass] directly. */
-    fun <R : Base> extractParamList(name: String, type: KClass<R>): OperationResult<List<R>> =
-        extractParamList(name, type.java)
 
     // Reference linking
 
@@ -1943,14 +1848,6 @@ class OperationResult<T> private constructor(
             primaryKey: String
         ): OperationResult<T> = fromParametersTyped(parameters, primaryKey, T::class.java)
 
-        /** [KClass] overload of [fromParametersTyped] — Kotlin callers may pass [KClass] directly. */
-        @JvmStatic
-        fun <T : Base> fromParametersTyped(
-            parameters: Parameters,
-            primaryKey: String,
-            type: KClass<T>
-        ): OperationResult<T> = fromParametersTyped(parameters, primaryKey, type.java)
-
         /**
          * Builds an [OperationResult] from a FHIR [Bundle].
          *
@@ -2037,14 +1934,6 @@ class OperationResult<T> private constructor(
             bundle: Bundle,
             primaryKey: String
         ): OperationResult<T> = fromBundleTyped(bundle, primaryKey, T::class.java)
-
-        /** [KClass] overload of [fromBundleTyped] — Kotlin callers may pass [KClass] directly. */
-        @JvmStatic
-        fun <T : Resource> fromBundleTyped(
-            bundle: Bundle,
-            primaryKey: String,
-            type: KClass<T>
-        ): OperationResult<T> = fromBundleTyped(bundle, primaryKey, type.java)
 
         /**
          * Creates an empty [OperationResult] with no parameters and no pipeline head.

--- a/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/ReferenceLinkRule.kt
+++ b/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/ReferenceLinkRule.kt
@@ -1,6 +1,7 @@
 package dev.ratkay.operation.r4
 
 import org.hl7.fhir.r4.model.Resource
+import java.util.function.BiConsumer
 import kotlin.reflect.KClass
 
 /**
@@ -11,13 +12,21 @@ import kotlin.reflect.KClass
  * The [setter] lambda receives the strongly-typed source and target so callers don't
  * need to cast.
  *
- * Example:
+ * Kotlin callers use the primary constructor with `KClass` and a lambda:
  * ```kotlin
  * val rule = ReferenceLinkRule(
  *     sourceType = Encounter::class,
  *     targetType = Patient::class,
  *     setter     = { encounter, patient -> encounter.subject = Reference("Patient/${patient.idPart}") }
  * )
+ * ```
+ *
+ * Java callers use the [of] factory with `Class` and a `BiConsumer`:
+ * ```java
+ * ReferenceLinkRule<Encounter, Patient> rule = ReferenceLinkRule.of(
+ *     Encounter.class, Patient.class,
+ *     (encounter, patient) -> encounter.setSubject(new Reference("Patient/" + patient.getIdPart()))
+ * );
  * ```
  *
  * @param S the FHIR resource type that holds the reference (the "source")
@@ -37,4 +46,31 @@ data class ReferenceLinkRule<S : Resource, T : Resource>(
     @Suppress("UNCHECKED_CAST")
     internal fun applyTo(source: Resource, target: Resource) =
         setter(source as S, target as T)
+
+    companion object {
+        /**
+         * Java-friendly factory for [ReferenceLinkRule] — accepts [Class] and [BiConsumer]
+         * instead of [KClass] and a Kotlin lambda.
+         *
+         * Example:
+         * ```java
+         * ReferenceLinkRule<Encounter, Patient> rule = ReferenceLinkRule.of(
+         *     Encounter.class, Patient.class,
+         *     (encounter, patient) ->
+         *         encounter.setSubject(new Reference("Patient/" + patient.getIdPart()))
+         * );
+         * ```
+         *
+         * @param sourceType the Java [Class] of the resource that holds the reference.
+         * @param targetType the Java [Class] of the resource being referenced.
+         * @param setter [BiConsumer] that wires the reference from [source] to [target].
+         */
+        @JvmStatic
+        fun <S : Resource, T : Resource> of(
+            sourceType: Class<S>,
+            targetType: Class<T>,
+            setter: BiConsumer<S, T>
+        ): ReferenceLinkRule<S, T> =
+            ReferenceLinkRule(sourceType.kotlin, targetType.kotlin) { s, t -> setter.accept(s, t) }
+    }
 }

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultComplexTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultComplexTest.kt
@@ -42,7 +42,7 @@ class AsyncOperationResultComplexTest {
                 val bId = (deps["b"]!!.first() as Practitioner).id
                 Basic().apply { id = "$aId+$bId" }
             }
-            .addAfter("d", "c", Basic::class) { c ->
+            .addAfter("d", "c", Basic::class.java) { c ->
                 Encounter().apply { id = "D-from-${c.id}" }
             }
             .execute()
@@ -120,16 +120,16 @@ class AsyncOperationResultComplexTest {
     fun `five-level linear chain passes data through correctly at every level`() = runBlocking {
         val result = AsyncOperationResult()
             .add("a") { Patient().apply { id = "A" } }
-            .addAfter("b", "a", Patient::class) { a ->
+            .addAfter("b", "a", Patient::class.java) { a ->
                 Patient().apply { id = "${a.id}-B" }
             }
-            .addAfter("c", "b", Patient::class) { b ->
+            .addAfter("c", "b", Patient::class.java) { b ->
                 Patient().apply { id = "${b.id}-C" }
             }
-            .addAfter("d", "c", Patient::class) { c ->
+            .addAfter("d", "c", Patient::class.java) { c ->
                 Patient().apply { id = "${c.id}-D" }
             }
-            .addAfter("e", "d", Patient::class) { d ->
+            .addAfter("e", "d", Patient::class.java) { d ->
                 StringType("${d.id}-E")
             }
             .execute()
@@ -172,8 +172,8 @@ class AsyncOperationResultComplexTest {
         val result = AsyncOperationResult()
             .add("a") { error("a fails") }                                       // fails
             .add("b") { Patient().apply { id = "B" } }                           // succeeds
-            .addAfter("c", "a", Patient::class) { Patient().apply { id = "C" } } // skipped (a failed)
-            .addAfter("d", "b", Patient::class) { p ->
+            .addAfter("c", "a", Patient::class.java) { Patient().apply { id = "C" } } // skipped (a failed)
+            .addAfter("d", "b", Patient::class.java) { p ->
                 Encounter().apply { id = "D-${p.id}" }
             }                                                                      // succeeds (b ok)
             .execute()
@@ -226,7 +226,7 @@ class AsyncOperationResultComplexTest {
                 if (attempts < 3) error("transient failure attempt $attempts")
                 Patient().apply { id = "retried-p1" }
             }
-            .addAfter("encounter", "patient", Patient::class) { p ->
+            .addAfter("encounter", "patient", Patient::class.java) { p ->
                 Encounter().apply { id = "enc-${p.id}" }
             }
             .execute()
@@ -250,15 +250,15 @@ class AsyncOperationResultComplexTest {
 
         val result = AsyncOperationResult()
             .add("patient") { Patient().apply { id = "P" } }
-            .addAfter("encounter", "patient", Patient::class) { p ->
+            .addAfter("encounter", "patient", Patient::class.java) { p ->
                 patientReceived = p
                 Encounter().apply { id = "E-from-${p.id}" }
             }
-            .addAfter("observation", "encounter", Encounter::class) { e ->
+            .addAfter("observation", "encounter", Encounter::class.java) { e ->
                 encounterReceived = e
                 Observation().apply { id = "O-from-${e.id}" }
             }
-            .addAfter("outcome", "observation", Observation::class) { obs ->
+            .addAfter("outcome", "observation", Observation::class.java) { obs ->
                 observationReceived = obs
                 OperationOutcome().apply {
                     addIssue().diagnostics = "processed-${obs.id}"

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultDefaultTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultDefaultTest.kt
@@ -129,7 +129,7 @@ class AsyncOperationResultDefaultTest {
 
         val result = AsyncOperationResult()
             .addWithDefault("patient", defaultPatient) { blockPatient }
-            .addAfter("encounter", "patient", Patient::class) { p ->
+            .addAfter("encounter", "patient", Patient::class.java) { p ->
                 Encounter().apply { subject.reference = "Patient/${p.idElement.idPart}" }
             }
             .execute()

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultMergeTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultMergeTest.kt
@@ -54,7 +54,7 @@ class AsyncOperationResultMergeTest {
                 AsyncOperationResult()
                     .add("patient") { Patient().apply { id = "p1" } }
             }
-            .addAfter("encounter", "patient", Patient::class) { patient ->
+            .addAfter("encounter", "patient", Patient::class.java) { patient ->
                 Encounter().apply { id = "enc-${patient.id}" }
             }
             .execute()
@@ -87,7 +87,7 @@ class AsyncOperationResultMergeTest {
             .merge {
                 AsyncOperationResult()
                     .add("base") { Patient().apply { id = "base" } }
-                    .addAfter("derived", "base", Patient::class) { p ->
+                    .addAfter("derived", "base", Patient::class.java) { p ->
                         Coverage().apply { id = "derived-from-${p.id}" }
                     }
             }
@@ -103,10 +103,10 @@ class AsyncOperationResultMergeTest {
             .merge {
                 AsyncOperationResult()
                     .add("a") { Patient().apply { id = "A" } }
-                    .addAfter("b", "a", Patient::class) { a ->
+                    .addAfter("b", "a", Patient::class.java) { a ->
                         Patient().apply { id = "${a.id}-B" }
                     }
-                    .addAfter("c", "b", Patient::class) { b ->
+                    .addAfter("c", "b", Patient::class.java) { b ->
                         Patient().apply { id = "${b.id}-C" }
                     }
             }
@@ -240,10 +240,10 @@ class AsyncOperationResultMergeTest {
                 AsyncOperationResult()
                     .add("patient") { Patient().apply { id = "p1" } }
             }
-            .addAfter("coverage", "patient", Patient::class) { p ->
+            .addAfter("coverage", "patient", Patient::class.java) { p ->
                 Coverage().apply { id = "cov-${p.id}" }
             }
-            .addAfter("claim", "coverage", Coverage::class) { c ->
+            .addAfter("claim", "coverage", Coverage::class.java) { c ->
                 Claim().apply { id = "claim-${c.id}" }
             }
             .execute()

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultMetricsTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultMetricsTest.kt
@@ -138,7 +138,7 @@ class AsyncOperationResultMetricsTest {
         val dag = AsyncOperationResult()
             .timed()
             .add("patient") { patient() }
-            .addAfter("encounter", "patient", Patient::class) { _ -> encounter() }
+            .addAfter("encounter", "patient", Patient::class.java) { _ -> encounter() }
 
         dag.executeBlocking()
 

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultTest.kt
@@ -238,7 +238,7 @@ class AsyncOperationResultTest {
             .add("practitioner") { Practitioner().apply { id = "pr1" } }
             .execute()
 
-        val patients = result.getByType(Patient::class)
+        val patients = result.getByType(Patient::class.java)
         assertThat(patients, hasSize(1))
         assertThat(patients.first().id, `is`("p1"))
     }
@@ -282,7 +282,7 @@ class AsyncOperationResultTest {
     fun `addAfter with type - dependent task receives typed upstream result`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { Patient().apply { id = "p1" } }
-            .addAfter("coverage", "patient", Patient::class) { patient ->
+            .addAfter("coverage", "patient", Patient::class.java) { patient ->
                 Coverage().apply { id = "cov-for-${patient.id}" }
             }
             .execute()
@@ -295,7 +295,7 @@ class AsyncOperationResultTest {
     fun `addAfter with type - captures NoSuchElementException as failed task when upstream has no matching type`() = runBlocking {
         val result = AsyncOperationResult()
             .add("data") { StringType("hello") }
-            .addAfter("out", "data", Patient::class) { patient ->
+            .addAfter("out", "data", Patient::class.java) { patient ->
                 Basic().apply { id = patient.id }
             }
             .execute()
@@ -308,10 +308,10 @@ class AsyncOperationResultTest {
     fun `addAfter with type - works in multi-level chain`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { Patient().apply { id = "P" } }
-            .addAfter("coverage", "patient", Patient::class) { patient ->
+            .addAfter("coverage", "patient", Patient::class.java) { patient ->
                 Coverage().apply { id = "cov-${patient.id}" }
             }
-            .addAfter("claim", "coverage", Coverage::class) { coverage ->
+            .addAfter("claim", "coverage", Coverage::class.java) { coverage ->
                 Claim().apply { id = "claim-${coverage.id}" }
             }
             .execute()
@@ -324,7 +324,7 @@ class AsyncOperationResultTest {
     fun `addListAfter with type - returns list from typed single dependency`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { Patient().apply { id = "p1" } }
-            .addListAfter("observations", "patient", Patient::class) { patient ->
+            .addListAfter("observations", "patient", Patient::class.java) { patient ->
                 listOf(
                     Observation().apply { id = "obs1-${patient.id}" },
                     Observation().apply { id = "obs2-${patient.id}" }
@@ -348,7 +348,7 @@ class AsyncOperationResultTest {
                     Observation().apply { id = "obs3" }
                 )
             }
-            .addAfterAll("summary", "observations", Observation::class) { observations ->
+            .addAfterAll("summary", "observations", Observation::class.java) { observations ->
                 Basic().apply { id = "count-${observations.size}" }
             }
             .execute()
@@ -367,7 +367,7 @@ class AsyncOperationResultTest {
                     Patient().apply { id = "p2" }
                 )
             }
-            .addAfterAll("patientCount", "mixed", Patient::class) { patients ->
+            .addAfterAll("patientCount", "mixed", Patient::class.java) { patients ->
                 Basic().apply { id = "patients-${patients.size}" }
             }
             .execute()
@@ -380,7 +380,7 @@ class AsyncOperationResultTest {
     fun `addAfterAll - receives empty list when no values match type`() = runBlocking {
         val result = AsyncOperationResult()
             .add("data") { StringType("hello") }
-            .addAfterAll("out", "data", Patient::class) { patients ->
+            .addAfterAll("out", "data", Patient::class.java) { patients ->
                 Basic().apply { id = "found-${patients.size}" }
             }
             .execute()
@@ -398,7 +398,7 @@ class AsyncOperationResultTest {
                     Observation().apply { id = "obs2" }
                 )
             }
-            .addListAfterAll("derived", "observations", Observation::class) { observations ->
+            .addListAfterAll("derived", "observations", Observation::class.java) { observations ->
                 observations.map { obs ->
                     Observation().apply { id = "derived-${obs.id}" }
                 }

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultTypedDepOverloadsTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultTypedDepOverloadsTest.kt
@@ -37,7 +37,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
         var received: Patient? = null
         val result = AsyncOperationResult()
             .add("patient") { patient("typed") }
-            .addAfterWithTimeout("encounter", "patient", Patient::class, timeoutMs = 500) { p ->
+            .addAfterWithTimeout("encounter", "patient", Patient::class.java, timeoutMs = 500) { p ->
                 received = p
                 encounter()
             }
@@ -52,7 +52,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addAfterWithTimeout typed — times out and key absent`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { patient() }
-            .addAfterWithTimeout("encounter", "patient", Patient::class, timeoutMs = 20) { _ ->
+            .addAfterWithTimeout("encounter", "patient", Patient::class.java, timeoutMs = 20) { _ ->
                 delay(200)
                 encounter()
             }
@@ -68,7 +68,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addListAfterWithTimeout typed — block receives typed dep value and returns list`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { patient("p") }
-            .addListAfterWithTimeout("encounters", "patient", Patient::class, timeoutMs = 500) { p ->
+            .addListAfterWithTimeout("encounters", "patient", Patient::class.java, timeoutMs = 500) { p ->
                 listOf(encounter(), Encounter().apply { subject.reference = "Patient/${p.idElement.idPart}" })
             }
             .execute()
@@ -82,7 +82,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addListAfterWithTimeout typed — times out and key absent`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { patient() }
-            .addListAfterWithTimeout("encounters", "patient", Patient::class, timeoutMs = 20) { _ ->
+            .addListAfterWithTimeout("encounters", "patient", Patient::class.java, timeoutMs = 20) { _ ->
                 delay(200)
                 listOf(encounter())
             }
@@ -99,7 +99,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
         var receivedList: List<Patient>? = null
         val result = AsyncOperationResult()
             .addList("patients") { listOf(patient("a"), patient("b")) }
-            .addAfterAllWithTimeout("encounter", "patients", Patient::class, timeoutMs = 500) { patients ->
+            .addAfterAllWithTimeout("encounter", "patients", Patient::class.java, timeoutMs = 500) { patients ->
                 receivedList = patients
                 encounter()
             }
@@ -117,7 +117,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
         var receivedSize = -1
         val result = AsyncOperationResult()
             .addList("patients") { listOf(patient("a"), patient("b")) }
-            .addAfterAllWithTimeout("encounter", "patients", Coverage::class, timeoutMs = 500) { coverages ->
+            .addAfterAllWithTimeout("encounter", "patients", Coverage::class.java, timeoutMs = 500) { coverages ->
                 receivedSize = coverages.size
                 encounter()
             }
@@ -133,7 +133,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addListAfterAllWithTimeout typed — block receives typed list and returns list`() = runBlocking {
         val result = AsyncOperationResult()
             .addList("patients") { listOf(patient("a"), patient("b"), patient("c")) }
-            .addListAfterAllWithTimeout("encounters", "patients", Patient::class, timeoutMs = 500) { patients ->
+            .addListAfterAllWithTimeout("encounters", "patients", Patient::class.java, timeoutMs = 500) { patients ->
                 patients.map { Encounter().apply { subject.reference = "Patient/${it.idElement.idPart}" } }
             }
             .execute()
@@ -150,7 +150,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
         var received: Patient? = null
         val result = AsyncOperationResult()
             .add("patient") { patient("typed") }
-            .addAfterWithRetry("encounter", "patient", Patient::class, maxAttempts = 3, initialDelayMs = 0) { p ->
+            .addAfterWithRetry("encounter", "patient", Patient::class.java, maxAttempts = 3, initialDelayMs = 0) { p ->
                 received = p
                 encounter()
             }
@@ -166,7 +166,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
         var attempts = 0
         val result = AsyncOperationResult()
             .add("patient") { patient() }
-            .addAfterWithRetry("encounter", "patient", Patient::class, maxAttempts = 3, initialDelayMs = 0) { _ ->
+            .addAfterWithRetry("encounter", "patient", Patient::class.java, maxAttempts = 3, initialDelayMs = 0) { _ ->
                 attempts++
                 if (attempts < 2) throw RuntimeException("transient")
                 encounter()
@@ -182,7 +182,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addAfterWithRetry typed — all attempts exhausted records error`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { patient() }
-            .addAfterWithRetry("encounter", "patient", Patient::class, maxAttempts = 2, initialDelayMs = 0) { _ ->
+            .addAfterWithRetry("encounter", "patient", Patient::class.java, maxAttempts = 2, initialDelayMs = 0) { _ ->
                 throw RuntimeException("always fails")
             }
             .execute()
@@ -198,7 +198,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addListAfterWithRetry typed — block receives typed dep and returns list`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { patient("p") }
-            .addListAfterWithRetry("encounters", "patient", Patient::class, maxAttempts = 3, initialDelayMs = 0) { p ->
+            .addListAfterWithRetry("encounters", "patient", Patient::class.java, maxAttempts = 3, initialDelayMs = 0) { p ->
                 listOf(encounter(), Encounter().apply { subject.reference = "Patient/${p.idElement.idPart}" })
             }
             .execute()
@@ -213,7 +213,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
         var attempts = 0
         val result = AsyncOperationResult()
             .add("patient") { patient() }
-            .addListAfterWithRetry("encounters", "patient", Patient::class, maxAttempts = 3, initialDelayMs = 0) { _ ->
+            .addListAfterWithRetry("encounters", "patient", Patient::class.java, maxAttempts = 3, initialDelayMs = 0) { _ ->
                 attempts++
                 if (attempts < 3) throw RuntimeException("transient")
                 listOf(encounter())
@@ -232,7 +232,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
         var receivedList: List<Patient>? = null
         val result = AsyncOperationResult()
             .addList("patients") { listOf(patient("x"), patient("y")) }
-            .addAfterAllWithRetry("encounter", "patients", Patient::class, maxAttempts = 3, initialDelayMs = 0) { patients ->
+            .addAfterAllWithRetry("encounter", "patients", Patient::class.java, maxAttempts = 3, initialDelayMs = 0) { patients ->
                 receivedList = patients
                 encounter()
             }
@@ -248,7 +248,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
         var attempts = 0
         val result = AsyncOperationResult()
             .addList("patients") { listOf(patient("a"), patient("b")) }
-            .addAfterAllWithRetry("encounter", "patients", Patient::class, maxAttempts = 3, initialDelayMs = 0) { patients ->
+            .addAfterAllWithRetry("encounter", "patients", Patient::class.java, maxAttempts = 3, initialDelayMs = 0) { patients ->
                 attempts++
                 if (attempts < 2) throw RuntimeException("transient")
                 assertEquals(2, patients.size)
@@ -266,7 +266,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addListAfterAllWithRetry typed — maps typed list to result list`() = runBlocking {
         val result = AsyncOperationResult()
             .addList("patients") { listOf(patient("a"), patient("b")) }
-            .addListAfterAllWithRetry("encounters", "patients", Patient::class, maxAttempts = 3, initialDelayMs = 0) { patients ->
+            .addListAfterAllWithRetry("encounters", "patients", Patient::class.java, maxAttempts = 3, initialDelayMs = 0) { patients ->
                 patients.map { Encounter().apply { subject.reference = "Patient/${it.idElement.idPart}" } }
             }
             .execute()
@@ -284,7 +284,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addAfterWithTimeout typed result has correct FHIR type`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { patient() }
-            .addAfterWithTimeout("encounter", "patient", Patient::class, timeoutMs = 500) { _ -> encounter() }
+            .addAfterWithTimeout("encounter", "patient", Patient::class.java, timeoutMs = 500) { _ -> encounter() }
             .execute()
 
         assertThat(result.getAll("encounter").first(), instanceOf(Encounter::class.java))
@@ -294,7 +294,7 @@ class AsyncOperationResultTypedDepOverloadsTest {
     fun `addAfterWithRetry typed result has correct FHIR type`() = runBlocking {
         val result = AsyncOperationResult()
             .add("patient") { patient() }
-            .addAfterWithRetry("encounter", "patient", Patient::class, maxAttempts = 1, initialDelayMs = 0) { _ -> encounter() }
+            .addAfterWithRetry("encounter", "patient", Patient::class.java, maxAttempts = 1, initialDelayMs = 0) { _ -> encounter() }
             .execute()
 
         assertThat(result.getAll("encounter").first(), instanceOf(Encounter::class.java))

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultTypedListOutputTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultTypedListOutputTest.kt
@@ -46,7 +46,7 @@ class AsyncOperationResultTypedListOutputTest {
     fun `addListAfterAll - both T and R inferred as concrete types`() = runBlocking {
         val result = AsyncOperationResult()
             .addList("patients") { listOf(Patient().apply { id = "p1" }, Patient().apply { id = "p2" }) }
-            .addListAfterAll("observations", "patients", Patient::class) { patients ->
+            .addListAfterAll("observations", "patients", Patient::class.java) { patients ->
                 patients.map { p -> Observation().apply { id = "obs-${p.id}" } }
             }
             .execute()
@@ -82,7 +82,7 @@ class AsyncOperationResultTypedListOutputTest {
     fun `addListAfterAllWithTimeout - both T and R inferred as concrete types`() = runBlocking {
         val result = AsyncOperationResult()
             .addList("patients") { listOf(Patient().apply { id = "p1" }) }
-            .addListAfterAllWithTimeout("observations", "patients", Patient::class, 5000L) { patients ->
+            .addListAfterAllWithTimeout("observations", "patients", Patient::class.java, 5000L) { patients ->
                 patients.map { p -> Observation().apply { id = "obs-${p.id}" } }
             }
             .execute()
@@ -107,7 +107,7 @@ class AsyncOperationResultTypedListOutputTest {
     fun `addListAfterAllWithRetry - both T and R inferred as concrete types`() = runBlocking {
         val result = AsyncOperationResult()
             .addList("patients") { listOf(Patient().apply { id = "p1" }, Patient().apply { id = "p2" }) }
-            .addListAfterAllWithRetry("observations", "patients", Patient::class, maxAttempts = 1) { patients ->
+            .addListAfterAllWithRetry("observations", "patients", Patient::class.java, maxAttempts = 1) { patients ->
                 patients.map { p -> Observation().apply { id = "obs-${p.id}" } }
             }
             .execute()

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/FhirFilterTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/FhirFilterTest.kt
@@ -49,7 +49,7 @@ class FhirFilterTest {
     @Test
     fun `hasExtensionWithValueType KClass returns true when value type matches`() {
         val patient = patient().apply { addExtension("http://example.org/flag", StringType("yes")) }
-        assertTrue(FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class)(patient))
+        assertTrue(FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class.java)(patient))
     }
 
     @Test

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/OperationResultComplexTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/OperationResultComplexTest.kt
@@ -38,7 +38,7 @@ class OperationResultComplexTest {
 
         val result = OperationResult.of(listOf(p1, p2, p3), "patients")
             .addAllFromFiltered(
-                type = Patient::class,
+                type = Patient::class.java,
                 predicate = FhirFilter.hasExtensionValueMatching<BooleanType>("http://example.org/enrolled") { it.booleanValue() }
             ) { enrolled ->
                 enrolled.map { p ->
@@ -375,7 +375,7 @@ class OperationResultComplexTest {
         // First filter: enrolled patients only → produces List<Patient> as head
         val afterExtFilter = OperationResult.of(listOf(activeEnrolled, inactiveEnrolled, activeNotEnrolled), "patients")
             .addAllFromFiltered(
-                type = Patient::class,
+                type = Patient::class.java,
                 predicate = FhirFilter.hasExtensionValueMatching<BooleanType>("http://example.org/enrolled") { it.booleanValue() }
             ) { enrolled ->
                 // Store enrolled patients back so FHIRPath filter can find them
@@ -390,7 +390,7 @@ class OperationResultComplexTest {
         // only sees the 2 enrolled patients, not all 3 originals.
         val finalResult = afterExtFilter
             .filterByName("patient")
-            .addAllFromMatching<Patient, Patient>("active-enrolled", Patient::class, "active = true") { it }
+            .addAllFromMatching<Patient, Patient>("active-enrolled", Patient::class.java, "active = true") { it }
 
         assertEquals(1, finalResult.count("active-enrolled"))
         assertFalse(finalResult.hasErrors())

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFhirErrorHandlingTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFhirErrorHandlingTest.kt
@@ -346,7 +346,7 @@ class OperationResultFhirErrorHandlingTest {
     fun `addFrom with PROPAGATE strategy - exception propagates raw`() {
         val pipeline = OperationResult.of(patient()).useErrorStrategy(ErrorStrategy.PROPAGATE)
         assertThrows<RuntimeException> {
-            pipeline.addFrom<Patient, Patient>("test", Patient::class) { throw RuntimeException("addFrom boom") }
+            pipeline.addFrom<Patient, Patient>("test", Patient::class.java) { throw RuntimeException("addFrom boom") }
         }
     }
 
@@ -407,13 +407,13 @@ class OperationResultFhirErrorHandlingTest {
 
     @Test
     fun `fromParametersTyped - missing key returns hasErrors true and null head`() {
-        val result = OperationResult.fromParametersTyped(Parameters(), "patient", Patient::class)
+        val result = OperationResult.fromParametersTyped(Parameters(), "patient", Patient::class.java)
         assertTrue(result.hasErrors())
     }
 
     @Test
     fun `fromParametersTyped - missing key outcome has NOTFOUND code`() {
-        val result = OperationResult.fromParametersTyped(Parameters(), "patient", Patient::class)
+        val result = OperationResult.fromParametersTyped(Parameters(), "patient", Patient::class.java)
         assertThat(result.getOutcomes(), hasSize(1))
         assertThat(result.getOutcomes()[0].issueFirstRep.severity, equalTo(OperationOutcome.IssueSeverity.ERROR))
         assertThat(result.getOutcomes()[0].issueFirstRep.code, equalTo(OperationOutcome.IssueType.NOTFOUND))
@@ -423,7 +423,7 @@ class OperationResultFhirErrorHandlingTest {
     fun `fromParametersTyped - found key returns isSuccessful true with correct typed head`() {
         val p = Patient().apply { setId("p1") }
         val params = Parameters().apply { addParameter().setName("patient").setResource(p) }
-        val result = OperationResult.fromParametersTyped(params, "patient", Patient::class)
+        val result = OperationResult.fromParametersTyped(params, "patient", Patient::class.java)
         assertTrue(result.isSuccessful())
         assertThat(result.getResult().idElement.idPart, equalTo("p1"))
     }
@@ -432,7 +432,7 @@ class OperationResultFhirErrorHandlingTest {
 
     @Test
     fun `fromBundleTyped - missing key returns hasErrors true and null head`() {
-        val result = OperationResult.fromBundleTyped(Bundle(), "patient", Patient::class)
+        val result = OperationResult.fromBundleTyped(Bundle(), "patient", Patient::class.java)
         assertTrue(result.hasErrors())
     }
 
@@ -440,7 +440,7 @@ class OperationResultFhirErrorHandlingTest {
     fun `fromBundleTyped - found resource returns isSuccessful true`() {
         val p = Patient().apply { setId("p1") }
         val bundle = Bundle().apply { addEntry().resource = p }
-        val result = OperationResult.fromBundleTyped(bundle, "patient", Patient::class)
+        val result = OperationResult.fromBundleTyped(bundle, "patient", Patient::class.java)
         assertTrue(result.isSuccessful())
         assertThat(result.getResult().idElement.idPart, equalTo("p1"))
     }
@@ -450,7 +450,7 @@ class OperationResultFhirErrorHandlingTest {
     @Test
     fun `extractParam - missing key adds ERROR outcome and skips (Pattern A)`() {
         val result = OperationResult.of(patient())
-            .extractParam("missing", Coverage::class)
+            .extractParam("missing", Coverage::class.java)
         assertTrue(result.hasErrors())
         assertThat(result.getOutcomes(), hasSize(1))
         assertThat(result.getOutcomes()[0].issueFirstRep.severity, equalTo(OperationOutcome.IssueSeverity.ERROR))
@@ -460,7 +460,7 @@ class OperationResultFhirErrorHandlingTest {
     fun `extractParam - found key changes head and leaves no error`() {
         val p = patient()
         val result = OperationResult.of(p)
-            .extractParam("patient", Patient::class)
+            .extractParam("patient", Patient::class.java)
         assertTrue(result.isSuccessful())
         assertSame(p, result.getResult())
     }
@@ -469,7 +469,7 @@ class OperationResultFhirErrorHandlingTest {
     fun `extractParam - missing key with FAIL_FAST skips subsequent steps`() {
         var step2Ran = false
         val result = OperationResult.of(patient())
-            .extractParam("missing", Coverage::class)
+            .extractParam("missing", Coverage::class.java)
             .add("enc") { step2Ran = true; Encounter() }
         assertTrue(result.hasErrors())
         assertFalse(step2Ran)

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFhirPathTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFhirPathTest.kt
@@ -29,7 +29,7 @@ class OperationResultFhirPathTest {
 
         val result = OperationResult.of(activePatient)
             .add { inactivePatient }
-            .addFromMatching<Patient, StringType>("result", Patient::class, "active = true") { matches ->
+            .addFromMatching<Patient, StringType>("result", Patient::class.java, "active = true") { matches ->
                 assertThat(matches, hasSize(1))
                 assertThat(matches[0].idPart, `is`("p1"))
                 StringType("found")
@@ -44,7 +44,7 @@ class OperationResultFhirPathTest {
         val patient = Patient().apply { active = false }
 
         val result = OperationResult.of(patient)
-            .addFromMatching<Patient, StringType>("result", Patient::class, "active = true") { matches ->
+            .addFromMatching<Patient, StringType>("result", Patient::class.java, "active = true") { matches ->
                 assertThat(matches, empty())
                 StringType("none")
             }
@@ -70,7 +70,7 @@ class OperationResultFhirPathTest {
         val patient = Patient().apply { active = true }
 
         val result = OperationResult.of(patient)
-            .addFromMatching("active-patients", Patient::class, "active = true") { StringType("ok") }
+            .addFromMatching("active-patients", Patient::class.java, "active = true") { StringType("ok") }
 
         assertThat(result.getAll("active-patients"), hasSize(1))
     }
@@ -87,7 +87,7 @@ class OperationResultFhirPathTest {
             .add { patientWithoutId }
             .addFromMatching<Patient, StringType>(
                 "has-id",
-                Patient::class,
+                Patient::class.java,
                 "identifier.where(system = 'http://example.org/mpi').exists()"
             ) { matches ->
                 assertThat(matches, hasSize(1))
@@ -103,7 +103,7 @@ class OperationResultFhirPathTest {
         val patient = Patient().apply { active = true }
 
         val result = OperationResult.of(patient)
-            .addFromMatching<Patient, StringType>("out", Patient::class, "(((invalid") { StringType("x") }
+            .addFromMatching<Patient, StringType>("out", Patient::class.java, "(((invalid") { StringType("x") }
 
         assertTrue(result.hasErrors())
         assertThat(result.getOutcomes(), hasSize(1))
@@ -120,7 +120,7 @@ class OperationResultFhirPathTest {
 
         val result = OperationResult.of(patient)
             .add { observation }
-            .addFromMatching<Patient, StringType>("result", Patient::class, "active = true") { matches ->
+            .addFromMatching<Patient, StringType>("result", Patient::class.java, "active = true") { matches ->
                 assertThat(matches, hasSize(1))
                 StringType("patients-only")
             }
@@ -139,7 +139,7 @@ class OperationResultFhirPathTest {
         val result = OperationResult.of(p1)
             .add { p2 }
             .add { p3 }
-            .addAllFromMatching<Patient, Patient>("active", Patient::class, "active = true") { it }
+            .addAllFromMatching<Patient, Patient>("active", Patient::class.java, "active = true") { it }
 
         assertTrue(result.isSuccessful())
         val patients = result.getResult()
@@ -151,7 +151,7 @@ class OperationResultFhirPathTest {
         val patient = Patient().apply { active = true }
 
         val result = OperationResult.of(patient)
-            .addAllFromMatching("active", Patient::class, "active = true") { it }
+            .addAllFromMatching("active", Patient::class.java, "active = true") { it }
 
         assertThat(result.getAll("active"), hasSize(1))
     }
@@ -311,7 +311,7 @@ class OperationResultFhirPathTest {
         }
 
         val result = OperationResult.of(patient)
-            .selectByPath(HumanName::class, "name.first()", "official-name")
+            .selectByPath(HumanName::class.java, "name.first()", "official-name")
 
         assertThat(result.getAll("official-name"), hasSize(1))
     }
@@ -365,7 +365,7 @@ class OperationResultFhirPathTest {
 
         val result = OperationResult.of(activePatient)
             .add { inactivePatient }
-            .addFromMatching<Patient, StringType>("result", Patient::class, expression) { matches ->
+            .addFromMatching<Patient, StringType>("result", Patient::class.java, expression) { matches ->
                 assertThat(matches, hasSize(1))
                 assertThat(matches[0].idPart, `is`("p1"))
                 StringType("found")
@@ -394,7 +394,7 @@ class OperationResultFhirPathTest {
 
         val result = OperationResult.of(p1)
             .add { p2 }
-            .addAllFromMatching("active", Patient::class, expression) { it }
+            .addAllFromMatching("active", Patient::class.java, expression) { it }
 
         assertTrue(result.isSuccessful())
         assertThat(result.getAll("active"), hasSize(2))
@@ -469,7 +469,7 @@ class OperationResultFhirPathTest {
         val expression = FhirPath.relative().navigate("name").first()
 
         val result = OperationResult.of(patient)
-            .selectByPath(HumanName::class, expression)
+            .selectByPath(HumanName::class.java, expression)
 
         assertTrue(result.isSuccessful())
         assertEquals("Smith", result.getResult().family)

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFromTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/OperationResultFromTest.kt
@@ -295,7 +295,7 @@ class OperationResultFromTest {
         }
 
         val result: OperationResult<Patient> =
-            OperationResult.fromParametersTyped(fhirParams, "patient", Patient::class)
+            OperationResult.fromParametersTyped(fhirParams, "patient", Patient::class.java)
 
         // Typed assignment proves compiler sees OperationResult<Patient>
         val retrieved: Patient = result.getResult()
@@ -530,7 +530,7 @@ class OperationResultFromTest {
             addEntry().resource = p
         }
 
-        val result = OperationResult.fromBundleTyped(bundle, "patient", Patient::class)
+        val result = OperationResult.fromBundleTyped(bundle, "patient", Patient::class.java)
 
         assertInstanceOf(Patient::class.java, result.getResult())
         assertEquals("p1", result.getResult().idPart)
@@ -609,7 +609,7 @@ class OperationResultFromTest {
             addParameter().apply { name = "patient"; resource = patient() }
         }
         val result = OperationResult.fromParameters(params)
-            .extractParam("patient", Patient::class)
+            .extractParam("patient", Patient::class.java)
 
         assertNotNull(result.getResult())
         assertInstanceOf(Patient::class.java, result.getResult())

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/OperationResultIdentifierTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/OperationResultIdentifierTest.kt
@@ -21,7 +21,7 @@ class OperationResultIdentifierTest {
         val withSystem = patient("http://example.org/mrn", "12345")
         val otherSystem = patient("http://other.org/id", "12345")
         val result = OperationResult.of(listOf(withSystem, otherSystem), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -35,7 +35,7 @@ class OperationResultIdentifierTest {
         val b = patient("http://example.org/mrn", "002")
         val c = patient("http://example.org/mrn", "003")
         val result = OperationResult.of(listOf(a, b, c), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -45,7 +45,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifierWithSystem with no matches passes empty list to builder`() {
         val result = OperationResult.of(patient("http://other.org/id", "001"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -58,7 +58,7 @@ class OperationResultIdentifierTest {
         val withMrn = patient("http://example.org/mrn", "001")
         val noId = patientNoIdentifier()
         val result = OperationResult.of(listOf(withMrn, noId), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -68,7 +68,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifierWithSystem stores result under fhirType when name is null`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
                 OperationOutcome().apply { addIssue().diagnostics = "found" }
             }
 
@@ -79,7 +79,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifierWithSystem named overload stores result under explicit key`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
-            .addFromFiltered("mrn-summary", Patient::class, FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
+            .addFromFiltered("mrn-summary", Patient::class.java, FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -101,7 +101,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifierWithSystem records ERROR outcome when builder throws`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
                 throw RuntimeException("builder failed")
             }
 
@@ -114,10 +114,10 @@ class OperationResultIdentifierTest {
     fun `addFromHavingIdentifierWithSystem respects FAIL_FAST and skips when already errored`() {
         var builderCalled = false
         val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
                 throw RuntimeException("first failure")
             }
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { _ ->
                 builderCalled = true
                 OperationOutcome()
             }
@@ -132,7 +132,7 @@ class OperationResultIdentifierTest {
         val b = patient("http://example.org/mrn", "002")
         val result = OperationResult.of(a, "group-a")
             .add("group-b") { b }
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -147,7 +147,7 @@ class OperationResultIdentifierTest {
         val b = patient("http://example.org/mrn", "002")
         val other = patient("http://other.org/id", "003")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -155,7 +155,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addAllFromHavingIdentifierWithSystem named overload stores under explicit key`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "001"), "patients")
-            .addAllFromFiltered("mrn-patients", Patient::class, FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { it }
+            .addAllFromFiltered("mrn-patients", Patient::class.java, FhirFilter.hasIdentifierWithSystem("http://example.org/mrn")) { it }
 
         assertTrue(result.containsKey("mrn-patients"))
     }
@@ -176,7 +176,7 @@ class OperationResultIdentifierTest {
         val target = patient("http://example.org/mrn", "12345")
         val other = patient("http://example.org/mrn", "99999")
         val result = OperationResult.of(listOf(target, other), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithValue("12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithValue("12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -186,7 +186,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifierWithValue with no matches passes empty list to builder`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "99999"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithValue("12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithValue("12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -198,7 +198,7 @@ class OperationResultIdentifierTest {
     fun `addFromHavingIdentifierWithValue excludes resources without identifier property`() {
         val withValue = patient("http://example.org/mrn", "12345")
         val result = OperationResult.of(listOf(withValue, patientNoIdentifier()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithValue("12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithValue("12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -208,7 +208,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifierWithValue stores result under fhirType when name is null`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithValue("12345")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithValue("12345")) { _ ->
                 OperationOutcome().apply { addIssue().diagnostics = "found" }
             }
 
@@ -219,7 +219,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifierWithValue named overload stores under explicit key`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
-            .addFromFiltered("value-result", Patient::class, FhirFilter.hasIdentifierWithValue("12345")) { filtered ->
+            .addFromFiltered("value-result", Patient::class.java, FhirFilter.hasIdentifierWithValue("12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -243,7 +243,7 @@ class OperationResultIdentifierTest {
         val b = patient("http://other.org/id", "12345")
         val other = patient("http://example.org/mrn", "99999")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifierWithValue("12345")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifierWithValue("12345")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -256,7 +256,7 @@ class OperationResultIdentifierTest {
         val wrongValue = patient("http://example.org/mrn", "99999")
         val wrongSystem = patient("http://other.org/id", "12345")
         val result = OperationResult.of(listOf(exact, wrongValue, wrongSystem), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -266,7 +266,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifier does not match when system matches but value does not`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "99999"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -276,7 +276,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifier does not match when value matches but system does not`() {
         val result = OperationResult.of(patient("http://other.org/id", "12345"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -290,7 +290,7 @@ class OperationResultIdentifierTest {
             addIdentifier().apply { system = "http://example.org/mrn"; value = "12345" }
         }
         val result = OperationResult.of(multiId, "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -300,7 +300,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifier with no matches passes empty list to builder`() {
         val result = OperationResult.of(patientNoIdentifier(), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -312,7 +312,7 @@ class OperationResultIdentifierTest {
     fun `addFromHavingIdentifier excludes resources without identifier property`() {
         val exact = patient("http://example.org/mrn", "12345")
         val result = OperationResult.of(listOf(exact, patientNoIdentifier()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -322,7 +322,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifier stores result under fhirType when name is null`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { _ ->
                 OperationOutcome().apply { addIssue().diagnostics = "found" }
             }
 
@@ -333,7 +333,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifier named overload stores under explicit key`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
-            .addFromFiltered("matched-patient", Patient::class, FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
+            .addFromFiltered("matched-patient", Patient::class.java, FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -355,7 +355,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addFromHavingIdentifier records ERROR outcome when builder throws`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { _ ->
                 throw RuntimeException("builder failed")
             }
 
@@ -372,7 +372,7 @@ class OperationResultIdentifierTest {
         val b = patient("http://example.org/mrn", "12345")
         val other = patient("http://example.org/mrn", "99999")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -380,7 +380,7 @@ class OperationResultIdentifierTest {
     @Test
     fun `addAllFromHavingIdentifier named overload stores under explicit key`() {
         val result = OperationResult.of(patient("http://example.org/mrn", "12345"), "patients")
-            .addAllFromFiltered("exact-matches", Patient::class, FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { it }
+            .addAllFromFiltered("exact-matches", Patient::class.java, FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { it }
 
         assertTrue(result.containsKey("exact-matches"))
     }
@@ -400,7 +400,7 @@ class OperationResultIdentifierTest {
     fun `identifier filter methods compose with subsequent pipeline steps`() {
         val withMrn = patient("http://example.org/mrn", "12345")
         val result = OperationResult.of(listOf(withMrn, patientNoIdentifier()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasIdentifier("http://example.org/mrn", "12345")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
             .add("flag") { org.hl7.fhir.r4.model.StringType("done") }

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/OperationResultJavaInteropTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/OperationResultJavaInteropTest.kt
@@ -25,7 +25,7 @@ class OperationResultJavaInteropTest {
             .add("appt") { appointment() }
 
         val byClass = result.getByType(Patient::class.java)
-        val byKClass = result.getByType(Patient::class)
+        val byKClass = result.getByType(Patient::class.java)
 
         assertThat(byClass, hasSize(1))
         assertSame(byClass[0], byKClass[0])

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/OperationResultMetaTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/OperationResultMetaTest.kt
@@ -21,7 +21,7 @@ class OperationResultMetaTest {
         val withTag = patientWithTag("http://example.org/tags", "reviewed")
         val otherSystem = patientWithTag("http://other.org/tags", "reviewed")
         val result = OperationResult.of(listOf(withTag, otherSystem), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -34,7 +34,7 @@ class OperationResultMetaTest {
         val a = patientWithTag("http://example.org/tags", "a")
         val b = patientWithTag("http://example.org/tags", "b")
         val result = OperationResult.of(listOf(a, b), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -44,7 +44,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTagWithSystem with no matches passes empty list to builder`() {
         val result = OperationResult.of(patientNoMeta(), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -55,7 +55,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTagWithSystem stores result under fhirType when name is null`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
                 OperationOutcome()
             }
 
@@ -66,7 +66,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTagWithSystem named overload stores result under explicit key`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
-            .addFromFiltered("tagged", Patient::class, FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
+            .addFromFiltered("tagged", Patient::class.java, FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
                 OperationOutcome()
             }
 
@@ -88,7 +88,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTagWithSystem records ERROR outcome when builder throws`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
                 throw RuntimeException("builder failed")
             }
 
@@ -100,10 +100,10 @@ class OperationResultMetaTest {
     fun `addFromHavingMetaTagWithSystem respects FAIL_FAST and skips when already errored`() {
         var builderCalled = false
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
                 throw RuntimeException("first failure")
             }
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { _ ->
                 builderCalled = true
                 OperationOutcome()
             }
@@ -118,7 +118,7 @@ class OperationResultMetaTest {
         val b = patientWithTag("http://example.org/tags", "y")
         val result = OperationResult.of(a, "group-a")
             .add("group-b") { b }
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -133,7 +133,7 @@ class OperationResultMetaTest {
         val b = patientWithTag("http://example.org/tags", "y")
         val other = patientWithTag("http://other.org/tags", "x")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -141,7 +141,7 @@ class OperationResultMetaTest {
     @Test
     fun `addAllFromHavingMetaTagWithSystem named overload stores under explicit key`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "x"), "patients")
-            .addAllFromFiltered("tagged-patients", Patient::class, FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { it }
+            .addAllFromFiltered("tagged-patients", Patient::class.java, FhirFilter.hasMetaTagWithSystem("http://example.org/tags")) { it }
 
         assertTrue(result.containsKey("tagged-patients"))
     }
@@ -162,7 +162,7 @@ class OperationResultMetaTest {
         val target = patientWithTag("http://example.org/tags", "reviewed")
         val other = patientWithTag("http://example.org/tags", "draft")
         val result = OperationResult.of(listOf(target, other), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithCode("reviewed")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithCode("reviewed")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -172,7 +172,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTagWithCode with no matches passes empty list to builder`() {
         val result = OperationResult.of(patientNoMeta(), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithCode("reviewed")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithCode("reviewed")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -183,7 +183,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTagWithCode named overload stores under explicit key`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "reviewed"), "patients")
-            .addFromFiltered("reviewed-result", Patient::class, FhirFilter.hasMetaTagWithCode("reviewed")) { _ -> OperationOutcome() }
+            .addFromFiltered("reviewed-result", Patient::class.java, FhirFilter.hasMetaTagWithCode("reviewed")) { _ -> OperationOutcome() }
 
         assertTrue(result.containsKey("reviewed-result"))
     }
@@ -205,7 +205,7 @@ class OperationResultMetaTest {
         val b = patientWithTag("http://sys2.org", "reviewed")
         val other = patientWithTag("http://sys1.org", "draft")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTagWithCode("reviewed")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTagWithCode("reviewed")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -218,7 +218,7 @@ class OperationResultMetaTest {
         val wrongCode = patientWithTag("http://example.org/tags", "draft")
         val wrongSystem = patientWithTag("http://other.org/tags", "reviewed")
         val result = OperationResult.of(listOf(exact, wrongCode, wrongSystem), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -228,7 +228,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTag does not match when system matches but code does not`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "draft"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -238,7 +238,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTag does not match when code matches but system does not`() {
         val result = OperationResult.of(patientWithTag("http://other.org/tags", "reviewed"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -252,7 +252,7 @@ class OperationResultMetaTest {
             meta.addTag().apply { system = "http://example.org/tags"; code = "reviewed" }
         }
         val result = OperationResult.of(multiTag, "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -262,7 +262,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTag with no matches passes empty list to builder`() {
         val result = OperationResult.of(patientNoMeta(), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -273,7 +273,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTag stores result under fhirType when name is null`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "reviewed"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { _ -> OperationOutcome() }
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { _ -> OperationOutcome() }
 
         assertTrue(result.containsKey("operationoutcome"))
         assertFalse(result.containsKey("patient"))
@@ -282,7 +282,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTag named overload stores under explicit key`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "reviewed"), "patients")
-            .addFromFiltered("matched", Patient::class, FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { _ ->
+            .addFromFiltered("matched", Patient::class.java, FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { _ ->
                 OperationOutcome()
             }
 
@@ -304,7 +304,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaTag records ERROR outcome when builder throws`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "reviewed"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { _ ->
                 throw RuntimeException("builder failed")
             }
 
@@ -318,7 +318,7 @@ class OperationResultMetaTest {
         val b = patientWithTag("http://example.org/tags", "reviewed")
         val other = patientWithTag("http://example.org/tags", "draft")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -326,7 +326,7 @@ class OperationResultMetaTest {
     @Test
     fun `addAllFromHavingMetaTag named overload stores under explicit key`() {
         val result = OperationResult.of(patientWithTag("http://example.org/tags", "reviewed"), "patients")
-            .addAllFromFiltered("exact-matches", Patient::class, FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { it }
+            .addAllFromFiltered("exact-matches", Patient::class.java, FhirFilter.hasMetaTag("http://example.org/tags", "reviewed")) { it }
 
         assertTrue(result.containsKey("exact-matches"))
     }
@@ -338,7 +338,7 @@ class OperationResultMetaTest {
         val restricted = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
         val other = patientWithSecurity("http://other.org/security", "R")
         val result = OperationResult.of(listOf(restricted, other), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurityWithSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurityWithSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -348,7 +348,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaSecurityWithSystem with no matches passes empty list to builder`() {
         val result = OperationResult.of(patientNoMeta(), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurityWithSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurityWithSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -359,7 +359,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaSecurityWithSystem named overload stores under explicit key`() {
         val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
-            .addFromFiltered("restricted", Patient::class, FhirFilter.hasMetaSecurityWithSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode")) { _ ->
+            .addFromFiltered("restricted", Patient::class.java, FhirFilter.hasMetaSecurityWithSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode")) { _ ->
                 OperationOutcome()
             }
 
@@ -383,7 +383,7 @@ class OperationResultMetaTest {
         val b = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N")
         val other = patientWithSecurity("http://other.org/security", "R")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurityWithSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurityWithSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -395,7 +395,7 @@ class OperationResultMetaTest {
         val restricted = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
         val normal = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N")
         val result = OperationResult.of(listOf(restricted, normal), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurityWithCode("R")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurityWithCode("R")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -405,7 +405,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaSecurityWithCode named overload stores under explicit key`() {
         val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
-            .addFromFiltered("restricted-result", Patient::class, FhirFilter.hasMetaSecurityWithCode("R")) { _ -> OperationOutcome() }
+            .addFromFiltered("restricted-result", Patient::class.java, FhirFilter.hasMetaSecurityWithCode("R")) { _ -> OperationOutcome() }
 
         assertTrue(result.containsKey("restricted-result"))
     }
@@ -427,7 +427,7 @@ class OperationResultMetaTest {
         val b = patientWithSecurity("http://sys2.org", "R")
         val other = patientWithSecurity("http://sys1.org", "N")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurityWithCode("R")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurityWithCode("R")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -440,7 +440,7 @@ class OperationResultMetaTest {
         val wrongCode = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N")
         val wrongSystem = patientWithSecurity("http://other.org/security", "R")
         val result = OperationResult.of(listOf(exact, wrongCode, wrongSystem), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -450,7 +450,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaSecurity does not match when system matches but code does not`() {
         val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -464,7 +464,7 @@ class OperationResultMetaTest {
             meta.addSecurity().apply { system = "http://terminology.hl7.org/CodeSystem/v3-ActCode"; code = "R" }
         }
         val result = OperationResult.of(multiSec, "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -474,7 +474,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaSecurity named overload stores under explicit key`() {
         val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
-            .addFromFiltered("restricted", Patient::class, FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { _ ->
+            .addFromFiltered("restricted", Patient::class.java, FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { _ ->
                 OperationOutcome()
             }
 
@@ -496,7 +496,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaSecurity records ERROR outcome when builder throws`() {
         val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { _ ->
                 throw RuntimeException("builder failed")
             }
 
@@ -510,7 +510,7 @@ class OperationResultMetaTest {
         val b = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")
         val other = patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "N")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -518,7 +518,7 @@ class OperationResultMetaTest {
     @Test
     fun `addAllFromHavingMetaSecurity named overload stores under explicit key`() {
         val result = OperationResult.of(patientWithSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R"), "patients")
-            .addAllFromFiltered("restricted-patients", Patient::class, FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { it }
+            .addAllFromFiltered("restricted-patients", Patient::class.java, FhirFilter.hasMetaSecurity("http://terminology.hl7.org/CodeSystem/v3-ActCode", "R")) { it }
 
         assertTrue(result.containsKey("restricted-patients"))
     }
@@ -530,7 +530,7 @@ class OperationResultMetaTest {
         val conforming = patientWithProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")
         val other = patientWithProfile("http://example.org/fhir/StructureDefinition/custom-patient")
         val result = OperationResult.of(listOf(conforming, other), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -542,7 +542,7 @@ class OperationResultMetaTest {
         val a = patientWithProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")
         val b = patientWithProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")
         val result = OperationResult.of(listOf(a, b), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -552,7 +552,7 @@ class OperationResultMetaTest {
     @Test
     fun `addFromHavingMetaProfile with no matches passes empty list to builder`() {
         val result = OperationResult.of(patientNoMeta(), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -565,7 +565,7 @@ class OperationResultMetaTest {
         val result = OperationResult.of(
             patientWithProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"), "patients"
         )
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")) { _ ->
                 OperationOutcome()
             }
 
@@ -578,7 +578,7 @@ class OperationResultMetaTest {
         val result = OperationResult.of(
             patientWithProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"), "patients"
         )
-            .addFromFiltered("us-core-result", Patient::class, FhirFilter.hasMetaProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")) { _ ->
+            .addFromFiltered("us-core-result", Patient::class.java, FhirFilter.hasMetaProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")) { _ ->
                 OperationOutcome()
             }
 
@@ -604,7 +604,7 @@ class OperationResultMetaTest {
             meta.addProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")
         }
         val result = OperationResult.of(multiProfile, "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -616,7 +616,7 @@ class OperationResultMetaTest {
         val result = OperationResult.of(
             patientWithProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"), "patients"
         )
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")) { _ ->
                 throw RuntimeException("builder failed")
             }
 
@@ -629,10 +629,10 @@ class OperationResultMetaTest {
         var builderCalled = false
         val url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
         val result = OperationResult.of(patientWithProfile(url), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile(url)) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile(url)) { _ ->
                 throw RuntimeException("first failure")
             }
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile(url)) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile(url)) { _ ->
                 builderCalled = true
                 OperationOutcome()
             }
@@ -648,7 +648,7 @@ class OperationResultMetaTest {
         val b = patientWithProfile(url)
         val result = OperationResult.of(a, "group-a")
             .add("group-b") { b }
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile(url)) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile(url)) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -664,7 +664,7 @@ class OperationResultMetaTest {
         val b = patientWithProfile(url)
         val other = patientWithProfile("http://example.org/fhir/StructureDefinition/other")
         val result = OperationResult.of(listOf(a, b, other), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile(url)) { it }
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile(url)) { it }
 
         assertThat(result.getResult(), hasSize(2))
     }
@@ -673,7 +673,7 @@ class OperationResultMetaTest {
     fun `addAllFromHavingMetaProfile named overload stores under explicit key`() {
         val url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
         val result = OperationResult.of(patientWithProfile(url), "patients")
-            .addAllFromFiltered("us-core-patients", Patient::class, FhirFilter.hasMetaProfile(url)) { it }
+            .addAllFromFiltered("us-core-patients", Patient::class.java, FhirFilter.hasMetaProfile(url)) { it }
 
         assertTrue(result.containsKey("us-core-patients"))
     }
@@ -693,7 +693,7 @@ class OperationResultMetaTest {
     fun `meta filter methods compose with subsequent pipeline steps`() {
         val url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
         val result = OperationResult.of(listOf(patientWithProfile(url), patientNoMeta()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasMetaProfile(url)) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasMetaProfile(url)) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
             .add("flag") { org.hl7.fhir.r4.model.StringType("done") }

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/OperationResultTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/OperationResultTest.kt
@@ -217,7 +217,7 @@ class OperationResultTest {
         val p1 = patient()
         val p2 = patient()
         val result = OperationResult.of(listOf(p1, p2), "people")
-            .addFrom("people", Patient::class) { patients ->
+            .addFrom("people", Patient::class.java) { patients ->
                 OperationOutcome().apply {
                     issue = patients.map { OperationOutcome.OperationOutcomeIssueComponent() }
                 }
@@ -231,7 +231,7 @@ class OperationResultTest {
     @Test
     fun `addFrom returns empty list when key does not exist`() {
         val result = OperationResult.of(patient())
-            .addFrom("missing", Patient::class) { patients ->
+            .addFrom("missing", Patient::class.java) { patients ->
                 Appointment().apply { addParticipant().actor = Reference().apply { display = "count=${patients.size}" } }
             }
 
@@ -272,7 +272,7 @@ class OperationResultTest {
     @Test
     fun `addAllFrom builder returning a Set stores all elements`() {
         val result = OperationResult.of(listOf(patient(), patient()), "patients")
-            .addAllFrom("patients", Patient::class) { patients ->
+            .addAllFrom("patients", Patient::class.java) { patients ->
                 patients.map { OperationOutcome() }.toSet()
             }
 
@@ -285,7 +285,7 @@ class OperationResultTest {
     @Test
     fun `addAllFrom filters by type and maps to list added under same name`() {
         val result = OperationResult.of(listOf(patient(), appointment()), "items")
-            .addAllFrom("items", Patient::class) { patients ->
+            .addAllFrom("items", Patient::class.java) { patients ->
                 patients.map { OperationOutcome() }
             }
 
@@ -301,7 +301,7 @@ class OperationResultTest {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val notEnrolled = patient()
         val result = OperationResult.of(listOf(enrolled, notEnrolled), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -318,7 +318,7 @@ class OperationResultTest {
         }
         val onlyFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val result = OperationResult.of(listOf(both, onlyFirst), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/url1", "http://example.org/url2")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/url1", "http://example.org/url2")) { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -337,7 +337,7 @@ class OperationResultTest {
         }
         val hasNeither = patient()
         val result = OperationResult.of(listOf(hasFirst, hasSecond, hasBoth, hasNeither), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAnyExtension("http://example.org/url1", "http://example.org/url2")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAnyExtension("http://example.org/url1", "http://example.org/url2")) { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -351,7 +351,7 @@ class OperationResultTest {
         val hasIt = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val hasNot = patient()
         val result = OperationResult.of(listOf(hasIt, hasNot), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAnyExtension("http://example.org/url1")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAnyExtension("http://example.org/url1")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -361,7 +361,7 @@ class OperationResultTest {
     @Test
     fun `addFromFiltered - hasAllExtensions with no URLs returns all resources of the given type`() {
         val result = OperationResult.of(listOf(patient(), patient(), appointment()), "items")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions()) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions()) { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -373,7 +373,7 @@ class OperationResultTest {
     @Test
     fun `addFromFiltered - hasAllExtensions predicate produces empty list when no resources match`() {
         val result = OperationResult.of(listOf(patient(), patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/nonexistent")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/nonexistent")) { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -385,7 +385,7 @@ class OperationResultTest {
     @Test
     fun `addFromFiltered - hasAnyExtension predicate produces empty list when no resources match`() {
         val result = OperationResult.of(listOf(patient(), patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAnyExtension("http://example.org/nonexistent")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAnyExtension("http://example.org/nonexistent")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -398,7 +398,7 @@ class OperationResultTest {
         val enrolled2 = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(enrolled1, "group-a")
             .add("group-b") { enrolled2 }
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
@@ -411,7 +411,7 @@ class OperationResultTest {
     fun `addAllFromFiltered - hasAllExtensions returns list result`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
                 filtered.map { OperationOutcome() }
             }
 
@@ -424,7 +424,7 @@ class OperationResultTest {
         val hasFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val hasSecond = patient().apply { addExtension("http://example.org/url2", StringType("b")) }
         val result = OperationResult.of(listOf(hasFirst, hasSecond, patient()), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasAnyExtension("http://example.org/url1", "http://example.org/url2")) { filtered ->
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAnyExtension("http://example.org/url1", "http://example.org/url2")) { filtered ->
                 filtered.map { OperationOutcome() }
             }
 
@@ -459,7 +459,7 @@ class OperationResultTest {
     @Test
     fun `addFromFiltered - records error outcome when builder throws`() {
         val result = OperationResult.of(patient(), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions()) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions()) { _ ->
                 throw RuntimeException("builder failed")
             }
 
@@ -471,7 +471,7 @@ class OperationResultTest {
     fun `addFromFiltered - hasAllExtensions unnamed overload stores result under output fhirType not input type`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { _ ->
                 OperationOutcome().apply { addIssue().diagnostics = "found" }
             }
 
@@ -484,7 +484,7 @@ class OperationResultTest {
     fun `addFromFiltered - hasAnyExtension unnamed overload stores result under output fhirType not input type`() {
         val hasExt = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val result = OperationResult.of(listOf(hasExt, patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAnyExtension("http://example.org/url1")) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAnyExtension("http://example.org/url1")) { _ ->
                 OperationOutcome().apply { addIssue().diagnostics = "found" }
             }
 
@@ -496,14 +496,14 @@ class OperationResultTest {
     fun `addFromFiltered - named overload stores result under explicit name`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
-            .addFromFiltered("enrolled-summary", Patient::class, FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
+            .addFromFiltered("enrolled-summary", Patient::class.java, FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
                 OperationOutcome().apply {
                     addIssue().diagnostics = "count=${filtered.size}"
                 }
             }
 
         assertTrue(result.containsKey("enrolled-summary"))
-        val summary = result.takeFirstTyped("enrolled-summary", OperationOutcome::class)
+        val summary = result.takeFirstTyped("enrolled-summary", OperationOutcome::class.java)
         assertEquals("count=1", summary!!.issueFirstRep.diagnostics)
     }
 
@@ -522,7 +522,7 @@ class OperationResultTest {
     fun `addAllFromFiltered - hasAllExtensions unnamed overload stores results under output fhirType not input type`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
                 filtered.map { OperationOutcome() }
             }
 
@@ -535,7 +535,7 @@ class OperationResultTest {
         val hasFirst = patient().apply { addExtension("http://example.org/url1", StringType("a")) }
         val hasSecond = patient().apply { addExtension("http://example.org/url2", StringType("b")) }
         val result = OperationResult.of(listOf(hasFirst, hasSecond, patient()), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasAnyExtension("http://example.org/url1", "http://example.org/url2")) { filtered ->
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAnyExtension("http://example.org/url1", "http://example.org/url2")) { filtered ->
                 filtered.map { OperationOutcome() }
             }
 
@@ -551,7 +551,7 @@ class OperationResultTest {
         val withBoolean = patient().apply { addExtension("http://example.org/flag", BooleanType(true)) }
         val noExtension = patient()
         val result = OperationResult.of(listOf(withString, withBoolean, noExtension), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class)) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class.java)) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -562,7 +562,7 @@ class OperationResultTest {
     fun `addFromFiltered - hasExtensionWithValueType produces empty list when no resources match`() {
         val withBoolean = patient().apply { addExtension("http://example.org/flag", BooleanType(false)) }
         val result = OperationResult.of(listOf(withBoolean, patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class)) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class.java)) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -573,12 +573,12 @@ class OperationResultTest {
     fun `addFromFiltered - hasExtensionWithValueType named variant stores result under explicit name`() {
         val withString = patient().apply { addExtension("http://example.org/flag", StringType("active")) }
         val result = OperationResult.of(listOf(withString, patient()), "patients")
-            .addFromFiltered("flag-summary", Patient::class, FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class)) { filtered ->
+            .addFromFiltered("flag-summary", Patient::class.java, FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class.java)) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
         assertTrue(result.containsKey("flag-summary"))
-        val summary = result.takeFirstTyped("flag-summary", OperationOutcome::class)
+        val summary = result.takeFirstTyped("flag-summary", OperationOutcome::class.java)
         assertEquals("count=1", summary!!.issueFirstRep.diagnostics)
     }
 
@@ -588,7 +588,7 @@ class OperationResultTest {
         val withString2 = patient().apply { addExtension("http://example.org/flag", StringType("b")) }
         val withBoolean = patient().apply { addExtension("http://example.org/flag", BooleanType(true)) }
         val result = OperationResult.of(listOf(withString1, withString2, withBoolean), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class)) { filtered ->
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionWithValueType("http://example.org/flag", StringType::class.java)) { filtered ->
                 filtered.map { OperationOutcome() }
             }
 
@@ -612,7 +612,7 @@ class OperationResultTest {
         val notEnrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("false")) }
         val noExt = patient()
         val result = OperationResult.of(listOf(enrolled, notEnrolled, noExt), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -623,7 +623,7 @@ class OperationResultTest {
     fun `addFromFiltered - hasExtensionValueMatching produces empty list when predicate never satisfied`() {
         val patient1 = patient().apply { addExtension("http://example.org/enrolled", StringType("false")) }
         val result = OperationResult.of(listOf(patient1, patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -634,12 +634,12 @@ class OperationResultTest {
     fun `addFromFiltered - hasExtensionValueMatching named variant stores result under explicit name`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
-            .addFromFiltered("enrolled-patients", Patient::class, FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { filtered ->
+            .addFromFiltered("enrolled-patients", Patient::class.java, FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
         assertTrue(result.containsKey("enrolled-patients"))
-        val summary = result.takeFirstTyped("enrolled-patients", OperationOutcome::class)
+        val summary = result.takeFirstTyped("enrolled-patients", OperationOutcome::class.java)
         assertEquals("count=1", summary!!.issueFirstRep.diagnostics)
     }
 
@@ -649,7 +649,7 @@ class OperationResultTest {
         val low = patient().apply { addExtension("http://example.org/priority", IntegerType(1)) }
         val none = patient()
         val result = OperationResult.of(listOf(high, low, none), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<IntegerType>("http://example.org/priority") { it.value > 5 }) { filtered ->
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionValueMatching<IntegerType>("http://example.org/priority") { it.value > 5 }) { filtered ->
                 filtered.map { OperationOutcome() }
             }
 
@@ -676,7 +676,7 @@ class OperationResultTest {
         }
         val userOnly = patient().apply { addExtension("http://example.org/role", StringType("user")) }
         val result = OperationResult.of(listOf(multiExt, userOnly, patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/role") { it.value == "admin" }) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/role") { it.value == "admin" }) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -687,7 +687,7 @@ class OperationResultTest {
     fun `addFromFiltered - hasExtensionValueMatching unnamed overload stores result under output fhirType not input type`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { _ ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionValueMatching<StringType>("http://example.org/enrolled") { it.value == "true" }) { _ ->
                 OperationOutcome().apply { addIssue().diagnostics = "found" }
             }
 
@@ -699,7 +699,7 @@ class OperationResultTest {
     fun `addAllFromFiltered - hasExtensionValueMatching unnamed overload stores results under output fhirType not input type`() {
         val high = patient().apply { addExtension("http://example.org/priority", IntegerType(10)) }
         val result = OperationResult.of(listOf(high, patient()), "patients")
-            .addAllFromFiltered(type = Patient::class, predicate = FhirFilter.hasExtensionValueMatching<IntegerType>("http://example.org/priority") { it.value > 5 }) { filtered ->
+            .addAllFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasExtensionValueMatching<IntegerType>("http://example.org/priority") { it.value > 5 }) { filtered ->
                 filtered.map { OperationOutcome() }
             }
 
@@ -1434,7 +1434,7 @@ class OperationResultTest {
         val original = patient()
         val replacement = patient().apply { addName().family = "Smith" }
         val result = OperationResult.of(original, "patient")
-            .mapStored("patient", Patient::class) { replacement }
+            .mapStored("patient", Patient::class.java) { replacement }
 
         assertThat(result.getAll("patient").first(), sameInstance(replacement))
     }
@@ -1444,7 +1444,7 @@ class OperationResultTest {
         val appt = appointment()
         val result = OperationResult.of(patient(), "mixed")
             .add("mixed") { appt }
-            .mapStored("mixed", Patient::class) { patient().apply { addName().family = "Transformed" } }
+            .mapStored("mixed", Patient::class.java) { patient().apply { addName().family = "Transformed" } }
 
         // appointment is non-matching — should still be present
         assertTrue(result.getAll("mixed").any { it is Appointment && it === appt })
@@ -1454,7 +1454,7 @@ class OperationResultTest {
     fun `mapStored named key absent is a no-op`() {
         val p = patient()
         val result = OperationResult.of(p, "patient")
-            .mapStored("other", Patient::class) { patient() }
+            .mapStored("other", Patient::class.java) { patient() }
 
         assertThat(result.getAll("patient").first(), sameInstance(p))
         assertFalse(result.containsKey("other"))
@@ -1464,7 +1464,7 @@ class OperationResultTest {
     fun `mapStored named head is unchanged`() {
         val original = patient()
         val result = OperationResult.of(original, "patient")
-            .mapStored("patient", Patient::class) { patient() }
+            .mapStored("patient", Patient::class.java) { patient() }
 
         assertThat(result.getResult(), sameInstance(original))
     }
@@ -1474,7 +1474,7 @@ class OperationResultTest {
         val appt = appointment()
         val result = OperationResult.of(patient(), "patient")
             .add("appt") { appt }
-            .mapStored("patient", Patient::class) { patient() }
+            .mapStored("patient", Patient::class.java) { patient() }
 
         assertThat(result.getAll("appt").first(), sameInstance(appt))
     }
@@ -1483,7 +1483,7 @@ class OperationResultTest {
     fun `mapStored named transform throws records WARNING outcome and preserves original`() {
         val original = patient()
         val result = OperationResult.of(original, "patient")
-            .mapStored("patient", Patient::class) { throw RuntimeException("boom") }
+            .mapStored("patient", Patient::class.java) { throw RuntimeException("boom") }
 
         assertFalse(result.hasErrors())
         assertTrue(result.hasWarnings())
@@ -1500,7 +1500,7 @@ class OperationResultTest {
         var called = false
         val result = OperationResult.of(original, "patient")
             .add { throw RuntimeException("first") }
-            .mapStored("patient", Patient::class) { called = true; patient() }
+            .mapStored("patient", Patient::class.java) { called = true; patient() }
 
         assertFalse(called)
         assertThat(result.getAll("patient").first(), sameInstance(original))
@@ -1519,7 +1519,7 @@ class OperationResultTest {
     fun `mapStored named Class overload produces same result as KClass overload`() {
         val replacement = patient().apply { addName().family = "Java" }
         val viaKClass = OperationResult.of(patient(), "patient")
-            .mapStored("patient", Patient::class) { replacement }
+            .mapStored("patient", Patient::class.java) { replacement }
         val viaClass = OperationResult.of(patient(), "patient")
             .mapStored("patient", Patient::class.java) { replacement }
 
@@ -1538,7 +1538,7 @@ class OperationResultTest {
         val replacement = patient().apply { addName().family = "Transformed" }
         val result = OperationResult.of(p1, "key1")
             .add("key2") { p2 }
-            .mapStored(Patient::class) { replacement }
+            .mapStored(Patient::class.java) { replacement }
 
         assertTrue(result.getAll("key1").all { it === replacement })
         assertTrue(result.getAll("key2").all { it === replacement })
@@ -1549,7 +1549,7 @@ class OperationResultTest {
         val appt = appointment()
         val result = OperationResult.of(patient(), "patient")
             .add("appt") { appt }
-            .mapStored(Patient::class) { patient().apply { addName().family = "X" } }
+            .mapStored(Patient::class.java) { patient().apply { addName().family = "X" } }
 
         assertThat(result.getAll("appt").first(), sameInstance(appt))
     }
@@ -1558,7 +1558,7 @@ class OperationResultTest {
     fun `mapStored unkeyed no matching values is a no-op`() {
         val appt = appointment()
         val result = OperationResult.of(appt, "appt")
-            .mapStored(Patient::class) { patient() }
+            .mapStored(Patient::class.java) { patient() }
 
         assertThat(result.getAll("appt").first(), sameInstance(appt))
     }
@@ -1567,7 +1567,7 @@ class OperationResultTest {
     fun `mapStored unkeyed head is unchanged`() {
         val original = patient()
         val result = OperationResult.of(original, "patient")
-            .mapStored(Patient::class) { patient() }
+            .mapStored(Patient::class.java) { patient() }
 
         assertThat(result.getResult(), sameInstance(original))
     }
@@ -1576,7 +1576,7 @@ class OperationResultTest {
     fun `mapStored unkeyed transform throws records WARNING outcome and preserves original`() {
         val original = patient()
         val result = OperationResult.of(original, "patient")
-            .mapStored(Patient::class) { throw RuntimeException("boom") }
+            .mapStored(Patient::class.java) { throw RuntimeException("boom") }
 
         assertFalse(result.hasErrors())
         assertTrue(result.hasWarnings())
@@ -1593,7 +1593,7 @@ class OperationResultTest {
         var called = false
         val result = OperationResult.of(original, "patient")
             .add { throw RuntimeException("first") }
-            .mapStored(Patient::class) { called = true; patient() }
+            .mapStored(Patient::class.java) { called = true; patient() }
 
         assertFalse(called)
         assertThat(result.getAll("patient").first(), sameInstance(original))
@@ -1684,7 +1684,7 @@ class OperationResultTest {
         val result = OperationResult.of(patient(), "entry")
             .add("entry") { appt }
 
-        val found: Appointment? = result.takeFirstTyped("entry", Appointment::class)
+        val found: Appointment? = result.takeFirstTyped("entry", Appointment::class.java)
         assertThat(found, sameInstance(appt))
     }
 
@@ -1692,7 +1692,7 @@ class OperationResultTest {
     fun `takeFirstTyped returns null when no value matches the given type`() {
         val result = OperationResult.of(patient(), "patient")
 
-        assertEquals(null, result.takeFirstTyped("patient", Appointment::class))
+        assertEquals(null, result.takeFirstTyped("patient", Appointment::class.java))
     }
 
     @Test
@@ -2620,7 +2620,7 @@ class OperationResultTest {
     fun `addFromFiltered stores result under output fhirType when name is null`() {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(listOf(enrolled, patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -2631,7 +2631,7 @@ class OperationResultTest {
     @Test
     fun `addFromFiltered with explicit name stores under that name`() {
         val result = OperationResult.of(listOf(patient()), "patients")
-            .addFromFiltered("my-key", Patient::class, { true }) { patients ->
+            .addFromFiltered("my-key", Patient::class.java, { true }) { patients ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${patients.size}" }
             }
 
@@ -2652,7 +2652,7 @@ class OperationResultTest {
     @Test
     fun `addFromFiltered with no matching resources passes empty list to builder`() {
         val result = OperationResult.of(listOf(patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = { false }) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = { false }) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 
@@ -2663,7 +2663,7 @@ class OperationResultTest {
     @Test
     fun `addFromFiltered builder exception records ERROR outcome (Pattern A)`() {
         val result = OperationResult.of(listOf(patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = { true }) { _ -> throw RuntimeException("boom") }
+            .addFromFiltered(type = Patient::class.java, predicate = { true }) { _ -> throw RuntimeException("boom") }
 
         assertTrue(result.hasErrors())
         assertEquals(
@@ -2675,7 +2675,7 @@ class OperationResultTest {
     @Test
     fun `addFromFiltered stores result under output type not input type`() {
         val result = OperationResult.of(listOf(patient()), "patients")
-            .addFromFiltered(type = Patient::class, predicate = { true }) { _ -> OperationOutcome() }
+            .addFromFiltered(type = Patient::class.java, predicate = { true }) { _ -> OperationOutcome() }
 
         assertTrue(result.containsKey("operationoutcome"))
         assertFalse(result.containsKey("patient"))
@@ -2686,7 +2686,7 @@ class OperationResultTest {
         val p1 = patient()
         val p2 = patient()
         val result = OperationResult.of(listOf(p1, p2, appointment()), "items")
-            .addAllFromFiltered(type = Patient::class, predicate = { true }) { filtered -> filtered }
+            .addAllFromFiltered(type = Patient::class.java, predicate = { true }) { filtered -> filtered }
 
         assertThat(result.getResultList(), hasSize(2))
         assertTrue(result.containsKey("patient"))
@@ -2695,7 +2695,7 @@ class OperationResultTest {
     @Test
     fun `addAllFromFiltered with explicit name groups all items under that name`() {
         val result = OperationResult.of(listOf(patient(), appointment()), "items")
-            .addAllFromFiltered("mixed", Base::class, { true }) { items -> items }
+            .addAllFromFiltered("mixed", Base::class.java, { true }) { items -> items }
 
         assertEquals(2, result.count("mixed"))
     }
@@ -2705,7 +2705,7 @@ class OperationResultTest {
         val enrolled = patient().apply { addExtension("http://example.org/enrolled", StringType("true")) }
         val result = OperationResult.of(enrolled, "p1")
             .add { patient() }
-            .addFromFiltered(type = Patient::class, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
+            .addFromFiltered(type = Patient::class.java, predicate = FhirFilter.hasAllExtensions("http://example.org/enrolled")) { filtered ->
                 OperationOutcome().apply { addIssue().diagnostics = "count=${filtered.size}" }
             }
 


### PR DESCRIPTION
All public API methods that previously required KClass<T> now accept Class<T> as the
primary type parameter, making them directly callable from Java without wrapping.
Kotlin callers retain natural KClass<T> overloads that delegate to the Class<T> variants.

Changes per module:

R4 (OperationResult, AsyncOperationResult, FhirFilter, helpers):
- addFrom / addAllFrom — Class<I> primary + KClass<I> companion
- addFromFiltered / addAllFromFiltered — Class<I> primary + KClass<I> companion (@JvmOverloads)
- addFromMatching / addAllFromMatching (String + FhirPath) — same pattern
- mapStored (keyed + unkeyed) — Class<I> primary + KClass<I> companion
- takeFirstTyped / extractParam / extractParamList — Class<R> primary + KClass<R> companion
- selectByPath (String + FhirPath) — Class<R> primary + KClass<R> companion (@JvmOverloads)
- getByType — Class<R> primary + KClass<R> companion
- fromParametersTyped / fromBundleTyped (companion) — Class<T> primary + KClass<T> @JvmStatic companion
- FhirFilter.hasExtensionWithValueType — Class<V> primary + KClass<V> companion
- AsyncOperationResult: addAfter / addListAfter / addAfterAll / addListAfterAll,
  *WithTimeout, *WithRetry typed variants — Class<T> primary + KClass<T> companions
- Internal helpers (FhirExtensionHelper, FhirIdentifierHelper, FhirMetaHelper) updated
  to use Class<T> natively (filterIsInstance accepts Class directly)

DSTU3:
- FhirFilter.hasExtensionWithValueType — KClass<V> companion added alongside Class<V> primary
- Internal helpers updated to use Class<T> natively
- ReferenceLinkRule: Class<T> companion factory @JvmStatic of() mirrors R4 pattern