### PR TITLE
Apply production-readiness fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,49 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Run tests
-        run: mvn --no-transfer-progress --batch-mode test
+      - name: Run tests and coverage check
+        run: mvn --no-transfer-progress --batch-mode verify
+
+      - name: Coverage summary
+        if: always()
+        run: |
+          echo "## Code Coverage" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Module | Instructions | Branches |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|---|" >> $GITHUB_STEP_SUMMARY
+          for xml in $(find . -path "*/target/site/jacoco/jacoco.xml" | sort); do
+            module=$(echo "$xml" | sed 's|\./||' | sed 's|/target.*||')
+            instr=$(python3 -c "
+          import xml.etree.ElementTree as ET, sys
+          root = ET.parse('$xml').getroot()
+          for c in root.findall('counter'):
+              if c.get('type') == 'INSTRUCTION':
+                  missed, covered = int(c.get('missed')), int(c.get('covered'))
+                  total = missed + covered
+                  pct = round(100 * covered / total, 1) if total else 0
+                  print(f'{covered}/{total} ({pct}%)')
+                  sys.exit()
+          print('n/a')
+          ")
+            branch=$(python3 -c "
+          import xml.etree.ElementTree as ET, sys
+          root = ET.parse('$xml').getroot()
+          for c in root.findall('counter'):
+              if c.get('type') == 'BRANCH':
+                  missed, covered = int(c.get('missed')), int(c.get('covered'))
+                  total = missed + covered
+                  pct = round(100 * covered / total, 1) if total else 0
+                  print(f'{covered}/{total} ({pct}%)')
+                  sys.exit()
+          print('n/a')
+          ")
+            echo "| \`$module\` | $instr | $branch |" >> $GITHUB_STEP_SUMMARY
+          done
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: jacoco-reports
+          path: '**/target/site/jacoco/'
+          retention-days: 14

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ src/test/java/dev/ratkay/operation/
 
 ## Tech Stack
 
-- Kotlin 2.1.21, JVM target Java 11
+- Kotlin 2.1.21, JVM target Java 21
 - HAPI FHIR 7.6.1 (R4)
 - Kotlin Coroutines 1.10.2
 - JUnit Jupiter 5.14.3, Hamcrest 3.0, ApprovalCrest

--- a/README.md
+++ b/README.md
@@ -1720,11 +1720,11 @@ suspend fun buildOutput(): Parameters {
 
 | | |
 |---|---|
-| Language | Kotlin 2.1.21 (JVM 11) |
+| Language | Kotlin 2.1.21 (JVM 21) |
 | FHIR | HAPI FHIR 7.6.1 (R4 and DSTU3) |
 | Async | Kotlin Coroutines 1.10.2 |
-| Logging | SLF4J 1.7.36 API (no binding — consumer-supplied) |
-| Spring Boot | 2.7.18 (optional — `fhirmason-hapi-spring-r4` module) |
+| Logging | SLF4J 2.0.x API (no binding — consumer-supplied) |
+| Spring Boot | 3.4.5+ (optional — `fhirmason-hapi-spring-r4` module) |
 | Build | Maven (multi-module) |
 | Testing | JUnit Jupiter 5.14.3, Hamcrest 3.0, ApprovalCrest, Logback 1.2.12, AssertJ 3.23.1 |
 
@@ -1788,12 +1788,15 @@ fhirmason-hapi-r4/
         ├── OperationResultFhirErrorHandlingTest.kt
         ├── OperationResultRetryTest.kt
         ├── OperationResultFhirPathTest.kt
+        ├── OperationResultImmutabilityTest.kt
+        ├── OperationResultJavaInteropTest.kt
         ├── FhirPathEvaluationTest.kt
         ├── OperationResultIdentifierTest.kt
         ├── OperationResultMetaTest.kt
         ├── OperationResultComplexTest.kt
         ├── FhirFilterTest.kt
         ├── AsyncOperationResultTest.kt
+        ├── AsyncOperationResultJavaTest.java
         ├── AsyncOperationResultMetricsTest.kt
         ├── AsyncOperationResultDescribeTest.kt
         ├── AsyncOperationResultRetryTest.kt
@@ -1834,12 +1837,15 @@ fhirmason-hapi-dstu3/
         ├── OperationResultFhirErrorHandlingTest.kt
         ├── OperationResultRetryTest.kt
         ├── OperationResultFhirPathTest.kt
+        ├── OperationResultImmutabilityTest.kt
+        ├── OperationResultJavaInteropTest.kt
         ├── FhirPathEvaluationTest.kt
         ├── OperationResultIdentifierTest.kt
         ├── OperationResultMetaTest.kt
         ├── OperationResultComplexTest.kt
         ├── FhirFilterTest.kt
         ├── AsyncOperationResultTest.kt
+        ├── AsyncOperationResultJavaTest.java
         ├── AsyncOperationResultMetricsTest.kt
         ├── AsyncOperationResultDescribeTest.kt
         ├── AsyncOperationResultRetryTest.kt
@@ -1866,12 +1872,15 @@ fhirmason-hapi-spring-r4/
     │   ├── spring.factories                # Boot 2.x auto-config registration
     │   └── spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
     └── test/java/dev/ratkay/spring/
-        └── FhirMasonAutoConfigurationTest.kt
+        ├── FhirMasonAutoConfigurationTest.kt
+        └── FhirMasonOperationProviderTest.kt
 ```
 
 ---
 
 ## Spring Boot Integration
+
+**Minimum supported version: Spring Boot 3.x.** Spring Boot 2.7.x can be tested against using the `-Pspring2` Maven profile, but is not officially supported.
 
 ### Dependency
 
@@ -1956,6 +1965,17 @@ class FhirMasonConfig {
         FhirMasonFactory(properties)  // or a custom subclass
 }
 ```
+
+---
+
+## Memory & Scale
+
+Both builders accumulate resources in-memory for the lifetime of the pipeline:
+
+- **`OperationResult`** holds all accumulated resources plus any `OperationOutcome` objects until the reference is released. It is designed for per-request pipelines that process tens to hundreds of resources. For volumes in the thousands, batch or paginate at the call site before feeding resources into a pipeline.
+- **`AsyncOperationResult`** retains the results of every completed task in memory until `execute()` or `executeBlocking()` returns. Release the result promptly so the GC can reclaim it.
+
+Neither builder streams or pages results. If you are processing large data sets (e.g., bulk export files), split the data into chunks externally and run a pipeline per chunk.
 
 ---
 

--- a/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/AsyncOperationResult.kt
+++ b/fhirmason-hapi-dstu3/src/main/java/dev/ratkay/operation/dstu3/AsyncOperationResult.kt
@@ -79,16 +79,23 @@ class AsyncOperationResult {
 
     private val nodes: LinkedHashMap<String, TaskNode> = LinkedHashMap()
 
+    /** Holds the per-task [Deferred] registry so [execute] can harvest partial results when a
+     *  DAG-level timeout fires before all tasks complete. */
+    private inner class ExecutionState {
+        val resolved: ConcurrentHashMap<String, Deferred<List<Base>?>> = ConcurrentHashMap()
+    }
+
     /** Enables per-task metrics collection. [getMetrics] returns empty when not called. */
     fun timed(): AsyncOperationResult = also { timingEnabled = true }
 
     /**
      * Sets a maximum wall-clock time for the entire DAG execution.
      *
-     * If [execute] does not complete within [durationMs] milliseconds, it returns an
-     * [OperationResult] containing a single `TIMEOUT`-coded [OperationOutcome] and no task
-     * results. [getTotalDuration] will return `0` on timeout because the duration assignment
-     * inside the DAG execution is interrupted before it can run.
+     * If [execute] does not complete within [durationMs] milliseconds, execution is cancelled and
+     * an [OperationResult] is returned that contains any tasks which completed before the deadline
+     * plus a `TIMEOUT`-coded [OperationOutcome]. Tasks still in-flight at cancellation time are
+     * silently dropped. [getTotalDuration] will return `0` on timeout because the duration
+     * assignment inside the DAG execution is interrupted before it can run.
      *
      * [executeBlocking] inherits this timeout automatically.
      *
@@ -834,25 +841,41 @@ class AsyncOperationResult {
         return sb.toString().trimEnd()
     }
 
+    /**
+     * Executes all registered tasks as a coroutine DAG and returns the accumulated
+     * [OperationResult]. Independent tasks run in parallel; dependent tasks wait for their
+     * dependencies via [kotlinx.coroutines.Deferred.await].
+     *
+     * If a DAG-level timeout was configured via [timeout], the execution is wrapped in
+     * [kotlinx.coroutines.withTimeout]. On timeout, any tasks that completed before the deadline
+     * are included in the returned [OperationResult] alongside a `TIMEOUT`-coded [OperationOutcome].
+     * Tasks that were still in-flight are silently dropped.
+     */
     suspend fun execute(): OperationResult<Base> {
         val ctx = executor?.asCoroutineDispatcher() ?: Dispatchers.IO
-        val execute: suspend () -> OperationResult<Base> = {
+        return withContext(ctx) {
             val t = dagTimeoutMs
             if (t != null) {
+                val state = ExecutionState()
                 try {
-                    withTimeout(t) { runInternal() }
+                    withTimeout(t) { runInternal(state) }
                 } catch (e: TimeoutCancellationException) {
-                    OperationResult.fromMap(emptyMap(), listOf(dagTimeoutOutcome(t)), emptyMap())
+                    val partialAccumulator = mutableMapOf<String, List<Base>>()
+                    state.resolved.forEach { (key, deferred) ->
+                        if (deferred.isCompleted && !deferred.isCancelled) {
+                            deferred.getCompleted()?.let { partialAccumulator[key] = it }
+                        }
+                    }
+                    OperationResult.fromMap(partialAccumulator, listOf(dagTimeoutOutcome(t)), emptyMap())
                 }
             } else {
-                runInternal()
+                runInternal(ExecutionState())
             }
         }
-        return withContext(ctx) { execute() }
     }
 
-    private suspend fun runInternal(): OperationResult<Base> = coroutineScope {
-        val resolved = mutableMapOf<String, Deferred<List<Base>?>>()
+    private suspend fun runInternal(state: ExecutionState): OperationResult<Base> = coroutineScope {
+        val resolved = state.resolved
         val failedTasks = ConcurrentHashMap<String, OperationOutcome>()
 
         fun launchNode(node: TaskNode): Deferred<List<Base>?> =

--- a/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultDagTimeoutTest.kt
+++ b/fhirmason-hapi-dstu3/src/test/java/dev/ratkay/operation/dstu3/AsyncOperationResultDagTimeoutTest.kt
@@ -31,7 +31,7 @@ class AsyncOperationResultDagTimeoutTest {
     // ── Exceeds deadline ──────────────────────────────────────────────────────
 
     @Test
-    fun `DAG exceeding timeout returns error and no task results`() = runBlocking {
+    fun `DAG exceeding timeout when no tasks complete returns TIMEOUT error and empty result`() = runBlocking {
         val result = AsyncOperationResult()
             .timeout(20)
             .add("patient") { delay(200); patient() }
@@ -40,6 +40,21 @@ class AsyncOperationResultDagTimeoutTest {
         assertFalse(result.containsKey("patient"))
         assertTrue(result.hasErrors())
         assertTrue(result.getKeys().isEmpty())
+    }
+
+    @Test
+    fun `DAG exceeding timeout returns partial results for tasks that completed before deadline`() = runBlocking {
+        val result = AsyncOperationResult()
+            .timeout(300)
+            .add("fast") { patient("fast") }
+            .add("slow") { delay(500); patient("slow") }
+            .execute()
+
+        assertTrue(result.containsKey("fast"))
+        assertFalse(result.containsKey("slow"))
+        assertTrue(result.hasErrors())
+        assertEquals(1, result.getOutcomes().size)
+        assertThat(result.getOutcomes().first().issueFirstRep.diagnostics, containsString("exceeded timeout"))
     }
 
     @Test

--- a/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/AsyncOperationResult.kt
+++ b/fhirmason-hapi-r4/src/main/java/dev/ratkay/operation/r4/AsyncOperationResult.kt
@@ -79,16 +79,23 @@ class AsyncOperationResult {
 
     private val nodes: LinkedHashMap<String, TaskNode> = LinkedHashMap()
 
+    /** Holds the per-task [Deferred] registry so [execute] can harvest partial results when a
+     *  DAG-level timeout fires before all tasks complete. */
+    private inner class ExecutionState {
+        val resolved: ConcurrentHashMap<String, Deferred<List<Base>?>> = ConcurrentHashMap()
+    }
+
     /** Enables per-task metrics collection. [getMetrics] returns empty when not called. */
     fun timed(): AsyncOperationResult = also { timingEnabled = true }
 
     /**
      * Sets a maximum wall-clock time for the entire DAG execution.
      *
-     * If [execute] does not complete within [durationMs] milliseconds, it returns an
-     * [OperationResult] containing a single `TIMEOUT`-coded [OperationOutcome] and no task
-     * results. [getTotalDuration] will return `0` on timeout because the duration assignment
-     * inside the DAG execution is interrupted before it can run.
+     * If [execute] does not complete within [durationMs] milliseconds, execution is cancelled and
+     * an [OperationResult] is returned that contains any tasks which completed before the deadline
+     * plus a `TIMEOUT`-coded [OperationOutcome]. Tasks still in-flight at cancellation time are
+     * silently dropped. [getTotalDuration] will return `0` on timeout because the duration
+     * assignment inside the DAG execution is interrupted before it can run.
      *
      * [executeBlocking] inherits this timeout automatically.
      *
@@ -1078,28 +1085,35 @@ class AsyncOperationResult {
      * dependencies via [kotlinx.coroutines.Deferred.await].
      *
      * If a DAG-level timeout was configured via [timeout], the execution is wrapped in
-     * [kotlinx.coroutines.withTimeout]. On timeout, an [OperationResult] containing a single
-     * `TIMEOUT`-coded [OperationOutcome] is returned with no task results.
+     * [kotlinx.coroutines.withTimeout]. On timeout, any tasks that completed before the deadline
+     * are included in the returned [OperationResult] alongside a `TIMEOUT`-coded [OperationOutcome].
+     * Tasks that were still in-flight are silently dropped.
      */
     suspend fun execute(): OperationResult<Base> {
         val ctx = executor?.asCoroutineDispatcher() ?: Dispatchers.IO
-        val execute: suspend () -> OperationResult<Base> = {
+        return withContext(ctx) {
             val t = dagTimeoutMs
             if (t != null) {
+                val state = ExecutionState()
                 try {
-                    withTimeout(t) { runInternal() }
+                    withTimeout(t) { runInternal(state) }
                 } catch (e: TimeoutCancellationException) {
-                    OperationResult.fromMap(emptyMap(), listOf(dagTimeoutOutcome(t)), emptyMap())
+                    val partialAccumulator = mutableMapOf<String, List<Base>>()
+                    state.resolved.forEach { (key, deferred) ->
+                        if (deferred.isCompleted && !deferred.isCancelled) {
+                            deferred.getCompleted()?.let { partialAccumulator[key] = it }
+                        }
+                    }
+                    OperationResult.fromMap(partialAccumulator, listOf(dagTimeoutOutcome(t)), emptyMap())
                 }
             } else {
-                runInternal()
+                runInternal(ExecutionState())
             }
         }
-        return withContext(ctx) { execute() }
     }
 
-    private suspend fun runInternal(): OperationResult<Base> = coroutineScope {
-        val resolved = mutableMapOf<String, Deferred<List<Base>?>>()
+    private suspend fun runInternal(state: ExecutionState): OperationResult<Base> = coroutineScope {
+        val resolved = state.resolved
         val failedTasks = ConcurrentHashMap<String, OperationOutcome>()
 
         fun launchNode(node: TaskNode): Deferred<List<Base>?> =

--- a/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultDagTimeoutTest.kt
+++ b/fhirmason-hapi-r4/src/test/java/dev/ratkay/operation/r4/AsyncOperationResultDagTimeoutTest.kt
@@ -31,7 +31,7 @@ class AsyncOperationResultDagTimeoutTest {
     // ── Exceeds deadline ──────────────────────────────────────────────────────
 
     @Test
-    fun `DAG exceeding timeout returns error and no task results`() = runBlocking {
+    fun `DAG exceeding timeout when no tasks complete returns TIMEOUT error and empty result`() = runBlocking {
         val result = AsyncOperationResult()
             .timeout(20)
             .add("patient") { delay(200); patient() }
@@ -40,6 +40,21 @@ class AsyncOperationResultDagTimeoutTest {
         assertFalse(result.containsKey("patient"))
         assertTrue(result.hasErrors())
         assertTrue(result.getKeys().isEmpty())
+    }
+
+    @Test
+    fun `DAG exceeding timeout returns partial results for tasks that completed before deadline`() = runBlocking {
+        val result = AsyncOperationResult()
+            .timeout(300)
+            .add("fast") { patient("fast") }
+            .add("slow") { delay(500); patient("slow") }
+            .execute()
+
+        assertTrue(result.containsKey("fast"))
+        assertFalse(result.containsKey("slow"))
+        assertTrue(result.hasErrors())
+        assertEquals(1, result.getOutcomes().size)
+        assertThat(result.getOutcomes().first().issueFirstRep.diagnostics, containsString("exceeded timeout"))
     }
 
     @Test

--- a/fhirmason-hapi-spring-r4/pom.xml
+++ b/fhirmason-hapi-spring-r4/pom.xml
@@ -17,7 +17,7 @@
     <description>Spring Boot auto-configuration and integration for the FHIRMason HAPI FHIR R4 builder API.</description>
 
     <properties>
-        <!-- Override with -Pspring3 to compile and test against Spring Boot 3.x -->
+        <!-- Override with -Pspring2 to compile and test against Spring Boot 2.7.x (legacy) -->
         <spring.boot.test.version>${spring.boot.version}</spring.boot.test.version>
     </properties>
 
@@ -105,9 +105,9 @@
 
     <profiles>
         <profile>
-            <id>spring3</id>
+            <id>spring2</id>
             <properties>
-                <spring.boot.test.version>3.4.5</spring.boot.test.version>
+                <spring.boot.test.version>2.7.18</spring.boot.test.version>
             </properties>
         </profile>
     </profiles>

--- a/fhirmason-hapi-spring-r4/src/test/java/dev/ratkay/spring/FhirMasonOperationProviderTest.kt
+++ b/fhirmason-hapi-spring-r4/src/test/java/dev/ratkay/spring/FhirMasonOperationProviderTest.kt
@@ -1,0 +1,92 @@
+package dev.ratkay.spring
+
+import org.hl7.fhir.r4.model.Bundle
+import org.hl7.fhir.r4.model.Parameters
+import org.hl7.fhir.r4.model.Patient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+
+class FhirMasonOperationProviderTest {
+
+    private val factory = FhirMasonFactory(FhirMasonProperties())
+
+    private inner class TestProvider : FhirMasonOperationProvider(factory) {
+        override fun getResourceType() = Patient::class.java
+        fun doPipeline(p: Patient) = pipeline(p)
+        fun doAsyncPipeline() = asyncPipeline()
+        fun doParameters(block: () -> dev.ratkay.operation.r4.OperationResult<*>) = parameters(block)
+        fun doBundle(type: Bundle.BundleType = Bundle.BundleType.COLLECTION, block: () -> dev.ratkay.operation.r4.OperationResult<*>) = bundle(type, block)
+    }
+
+    private val provider = TestProvider()
+    private fun patient(id: String = "p1") = Patient().apply { setId(id) }
+
+    // ── pipeline ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `pipeline delegates to factory and seeds with resource`() {
+        val p = patient()
+        val result = provider.doPipeline(p)
+        assertEquals(p, result.getResult())
+    }
+
+    @Test
+    fun `pipeline returns a new OperationResult for each call`() {
+        val result1 = provider.doPipeline(patient("a"))
+        val result2 = provider.doPipeline(patient("b"))
+        assertNotNull(result1)
+        assertNotNull(result2)
+        assertEquals("a", result1.getResult()?.idElement?.idPart)
+        assertEquals("b", result2.getResult()?.idElement?.idPart)
+    }
+
+    // ── asyncPipeline ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `asyncPipeline returns a new AsyncOperationResult`() {
+        val dag = provider.doAsyncPipeline()
+        assertNotNull(dag)
+    }
+
+    // ── parameters DSL helper ─────────────────────────────────────────────────
+
+    @Test
+    fun `parameters DSL helper converts pipeline result to FHIR Parameters`() {
+        val p = patient()
+        val params = provider.doParameters { provider.doPipeline(p) }
+        assertInstanceOf(Parameters::class.java, params)
+    }
+
+    @Test
+    fun `parameters DSL helper includes accumulated resources`() {
+        val p = patient()
+        val params = provider.doParameters {
+            provider.doPipeline(p).add("extra") { patient("extra") }
+        }
+        val hasExtra = params.parameter.any { it.name == "extra" }
+        assertEquals(true, hasExtra)
+    }
+
+    // ── bundle DSL helper ─────────────────────────────────────────────────────
+
+    @Test
+    fun `bundle DSL helper converts pipeline result to FHIR Bundle`() {
+        val p = patient()
+        val b = provider.doBundle { provider.doPipeline(p) }
+        assertInstanceOf(Bundle::class.java, b)
+    }
+
+    @Test
+    fun `bundle DSL helper defaults to COLLECTION type`() {
+        val b = provider.doBundle { provider.doPipeline(patient()) }
+        assertEquals(Bundle.BundleType.COLLECTION, b.type)
+    }
+
+    @Test
+    fun `bundle DSL helper respects specified bundle type`() {
+        val b = provider.doBundle(Bundle.BundleType.TRANSACTION) { provider.doPipeline(patient()) }
+        assertEquals(Bundle.BundleType.TRANSACTION, b.type)
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <coroutines.version>1.10.2</coroutines.version>
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.18</logback.version>
-        <spring.boot.version>2.7.18</spring.boot.version>
+        <spring.boot.version>3.4.5</spring.boot.version>
         <dokka.version>1.9.20</dokka.version>
     </properties>
 
@@ -198,8 +198,50 @@
                     <artifactId>central-publishing-maven-plugin</artifactId>
                     <version>0.7.0</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.12</version>
+                </plugin>
             </plugins>
         </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jacoco-prepare-agent</id>
+                        <goals><goal>prepare-agent</goal></goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>verify</phase>
+                        <goals><goal>report</goal></goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <phase>verify</phase>
+                        <goals><goal>check</goal></goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.65</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>


### PR DESCRIPTION
- Fix Java version doc (CLAUDE.md: 11 → 21) to match pom.xml
- Add Jacoco 0.8.12 to parent POM (report + 65% instruction coverage check on verify phase)
- Upgrade Spring Boot default from 2.7.18 (EOL) to 3.4.5; rename spring3 profile to spring2 for legacy compat testing
- AsyncOperationResult: return partial results on DAG timeout — tasks that complete before the deadline are included in the result alongside the TIMEOUT OperationOutcome; update timeout() and execute() KDoc; add partial-result tests to R4 and DSTU3
- Add FhirMasonOperationProviderTest (8 tests covering pipeline, asyncPipeline, parameters, and bundle DSL helpers)
- README: correct JVM/SLF4J/Spring Boot versions in Tech Stack, add missing test files to Project Structure, add Memory & Scale section, document Spring Boot 3.x requirement