### PR TITLE
Add QuestionnaireResponse to PDF converter module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1738,6 +1738,7 @@ suspend fun buildOutput(): Parameters {
 | `fhirmason-hapi-r4` | `fhirmason-hapi-r4` | R4 pipeline builders (`OperationResult`, `AsyncOperationResult`) |
 | `fhirmason-hapi-dstu3` | `fhirmason-hapi-dstu3` | DSTU3 pipeline builders (`OperationResult`, `AsyncOperationResult`) |
 | `fhirmason-hapi-spring-r4` | `fhirmason-hapi-spring-r4` | Spring Boot auto-configuration and base provider class |
+| `fhirmason-hapi-pdf-r4` | `fhirmason-hapi-pdf-r4` | Renders R4 `QuestionnaireResponse` resources to PDF (`QuestionnaireResponseRenderer`) |
 
 ---
 
@@ -1874,6 +1875,18 @@ fhirmason-hapi-spring-r4/
     └── test/java/dev/ratkay/spring/
         ├── FhirMasonAutoConfigurationTest.kt
         └── FhirMasonOperationProviderTest.kt
+
+fhirmason-hapi-pdf-r4/
+└── src/
+    ├── main/java/dev/ratkay/questionnaire/pdf/
+    │   ├── QuestionnaireResponseRenderer.kt   # Public entry point — QuestionnaireResponse → PDF
+    │   ├── PdfRenderOptions.kt                # Title, metadata, logo, unanswered handling, font sizes
+    │   ├── RenderModel.kt                     # PDF-agnostic intermediate model (internal)
+    │   ├── RenderModelBuilder.kt              # Questionnaire + Response → RenderModel (internal)
+    │   └── OpenPdfWriter.kt                   # RenderModel → PDF via OpenPDF (internal)
+    └── test/java/dev/ratkay/questionnaire/pdf/
+        ├── RenderModelBuilderTest.kt
+        └── QuestionnaireResponseRendererTest.kt
 ```
 
 ---
@@ -1965,6 +1978,56 @@ class FhirMasonConfig {
         FhirMasonFactory(properties)  // or a custom subclass
 }
 ```
+
+---
+
+## QuestionnaireResponse → PDF
+
+The optional `fhirmason-hapi-pdf-r4` module renders a completed R4 `QuestionnaireResponse` into a
+human-readable PDF — useful for printable, archivable or patient-facing copies of a filled form. It
+is a standalone utility (it does not participate in an `OperationResult` pipeline) backed by
+[OpenPDF](https://github.com/LibrePDF/OpenPDF) (LGPL/MPL).
+
+```xml
+<dependency>
+    <groupId>dev.ratkay</groupId>
+    <artifactId>fhirmason-hapi-pdf-r4</artifactId>
+</dependency>
+```
+
+Rendering requires **both** the `Questionnaire` (for item ordering, labels, grouping and
+answer-option display text) and the `QuestionnaireResponse` (the captured answers). Items are
+matched by `linkId`: groups become headings, questions become label/answer rows, and nested groups
+are indented.
+
+```kotlin
+val pdf: ByteArray = QuestionnaireResponseRenderer.render(questionnaire, response)
+Files.write(Path.of("response.pdf"), pdf)
+
+// Or stream directly to an HTTP response / file:
+QuestionnaireResponseRenderer.render(questionnaire, response, outputStream)
+```
+
+Customise output with `PdfRenderOptions`:
+
+```kotlin
+val options = PdfRenderOptions(
+    title = "Patient Intake Form",   // overrides Questionnaire.title
+    showUnanswered = true,           // render unanswered questions with a placeholder
+    includeMetadata = true,          // show a status / authored-date line under the title
+    logoPng = logoBytes,             // optional PNG/JPEG header logo
+    unansweredPlaceholder = "—"
+)
+val pdf = QuestionnaireResponseRenderer.render(questionnaire, response, options)
+```
+
+Supported answer value types: `boolean` (rendered as *Yes*/*No*), `decimal`, `integer`, `date`,
+`dateTime`, `time`, `string`, `uri`, `Coding` (display → answer-option display → code), `Quantity`
+(value + unit), `Attachment` (title/content-type) and `Reference` (display → reference). Repeating
+questions and repeating groups render every captured answer/instance.
+
+> **FHIR version:** this module currently targets R4 only. A DSTU3 counterpart
+> (`fhirmason-hapi-pdf-dstu3`) is planned as a follow-up.
 
 ---
 

--- a/fhirmason-hapi-pdf-r4/pom.xml
+++ b/fhirmason-hapi-pdf-r4/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.ratkay</groupId>
+        <artifactId>fhirmason</artifactId>
+        <version>0.0.1</version>
+    </parent>
+
+    <artifactId>fhirmason-hapi-pdf-r4</artifactId>
+    <packaging>jar</packaging>
+
+    <name>FHIRMason HAPI PDF R4</name>
+    <description>Renders FHIR R4 QuestionnaireResponse resources to PDF documents using OpenPDF.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ca.uhn.hapi.fhir</groupId>
+            <artifactId>hapi-fhir-structures-r4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.librepdf</groupId>
+            <artifactId>openpdf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <!-- Test -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/java</testSourceDirectory>
+        <plugins>
+            <!-- Kotlin compiles first so Java test files can reference compiled Kotlin classes -->
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <jvmTarget>${maven.compiler.target}</jvmTarget>
+                </configuration>
+            </plugin>
+            <!-- Java compiles after Kotlin; default executions are disabled to preserve order -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/fhirmason-hapi-pdf-r4/src/main/java/dev/ratkay/questionnaire/pdf/OpenPdfWriter.kt
+++ b/fhirmason-hapi-pdf-r4/src/main/java/dev/ratkay/questionnaire/pdf/OpenPdfWriter.kt
@@ -1,0 +1,94 @@
+package dev.ratkay.questionnaire.pdf
+
+import com.lowagie.text.Chunk
+import com.lowagie.text.Document
+import com.lowagie.text.Element
+import com.lowagie.text.Font
+import com.lowagie.text.FontFactory
+import com.lowagie.text.Image
+import com.lowagie.text.Paragraph
+import com.lowagie.text.pdf.PdfWriter
+import java.io.OutputStream
+
+/**
+ * Writes a [RenderModel] to a PDF document using OpenPDF.
+ *
+ * This layer is intentionally thin: all questionnaire traversal and answer formatting happens in
+ * [RenderModelBuilder], leaving this object responsible only for fonts, spacing, indentation and
+ * stream handling.
+ */
+internal object OpenPdfWriter {
+
+    /** Points of left indentation applied per nesting level. */
+    private const val INDENT_PER_LEVEL = 18f
+
+    /**
+     * Renders [model] to [out]. The stream is flushed but not closed — ownership of the stream
+     * stays with the caller.
+     */
+    fun write(model: RenderModel, options: PdfRenderOptions, out: OutputStream) {
+        val document = Document()
+        try {
+            PdfWriter.getInstance(document, out)
+            document.open()
+
+            options.logoPng?.let { bytes ->
+                val image = Image.getInstance(bytes)
+                image.scaleToFit(120f, 80f)
+                document.add(image)
+            }
+
+            document.add(titleParagraph(model.title, options))
+            model.metadataLine?.let { document.add(metadataParagraph(it, options)) }
+            document.add(Paragraph(" "))
+
+            for (node in model.nodes) {
+                when (node) {
+                    is RenderNode.Section -> document.add(sectionParagraph(node, options))
+                    is RenderNode.Field -> document.add(fieldParagraph(node, options))
+                }
+            }
+        } finally {
+            // Closing the Document finalises the PDF structure onto the (still-open) stream.
+            if (document.isOpen) document.close()
+            out.flush()
+        }
+    }
+
+    private fun titleParagraph(title: String, options: PdfRenderOptions): Paragraph {
+        val font = FontFactory.getFont(FontFactory.HELVETICA_BOLD, options.titleFontSize)
+        return Paragraph(title, font).apply { spacingAfter = 4f }
+    }
+
+    private fun metadataParagraph(text: String, options: PdfRenderOptions): Paragraph {
+        val font = FontFactory.getFont(FontFactory.HELVETICA_OBLIQUE, options.bodyFontSize)
+        return Paragraph(text, font)
+    }
+
+    private fun sectionParagraph(node: RenderNode.Section, options: PdfRenderOptions): Paragraph {
+        val size = (options.sectionFontSize - node.depth).coerceAtLeast(options.bodyFontSize)
+        val font = FontFactory.getFont(FontFactory.HELVETICA_BOLD, size)
+        return Paragraph(node.title, font).apply {
+            indentationLeft = node.depth * INDENT_PER_LEVEL
+            spacingBefore = 8f
+            spacingAfter = 2f
+        }
+    }
+
+    private fun fieldParagraph(node: RenderNode.Field, options: PdfRenderOptions): Paragraph {
+        val labelFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, options.bodyFontSize)
+        val valueFont = FontFactory.getFont(FontFactory.HELVETICA, options.bodyFontSize)
+        val valueText = if (node.values.isEmpty()) {
+            options.unansweredPlaceholder
+        } else {
+            node.values.joinToString("; ")
+        }
+        return Paragraph().apply {
+            alignment = Element.ALIGN_LEFT
+            indentationLeft = node.depth * INDENT_PER_LEVEL
+            spacingAfter = 2f
+            add(Chunk("${node.label}: ", labelFont))
+            add(Chunk(valueText, valueFont))
+        }
+    }
+}

--- a/fhirmason-hapi-pdf-r4/src/main/java/dev/ratkay/questionnaire/pdf/PdfRenderOptions.kt
+++ b/fhirmason-hapi-pdf-r4/src/main/java/dev/ratkay/questionnaire/pdf/PdfRenderOptions.kt
@@ -1,0 +1,33 @@
+package dev.ratkay.questionnaire.pdf
+
+/**
+ * Tuning options for [QuestionnaireResponseRenderer].
+ *
+ * All values have sensible defaults, so Java and Kotlin callers can omit any subset. The
+ * constructor is annotated with [JvmOverloads] so Java callers can use the trailing-default
+ * overloads instead of always passing every argument.
+ *
+ * @property title overrides the document title. When `null`, the renderer falls back to the
+ *   `Questionnaire.title` (then `Questionnaire.name`, then a generic label).
+ * @property showUnanswered when `true`, questions with no answer are still rendered (with
+ *   [unansweredPlaceholder]); when `false`, unanswered questions are omitted entirely.
+ * @property includeMetadata when `true`, a metadata line (response status and authored date) is
+ *   rendered beneath the title.
+ * @property logoPng optional PNG/JPEG image bytes rendered at the top of the document; `null`
+ *   omits the logo. Invalid image bytes cause [QuestionnaireResponseRenderer.render] to throw.
+ * @property titleFontSize point size of the document title.
+ * @property sectionFontSize point size of the top-level group headings (nested headings shrink
+ *   by one point per level, never below [bodyFontSize]).
+ * @property bodyFontSize point size of question labels and answer values.
+ * @property unansweredPlaceholder text shown in place of a missing answer when [showUnanswered] is `true`.
+ */
+class PdfRenderOptions @JvmOverloads constructor(
+    val title: String? = null,
+    val showUnanswered: Boolean = true,
+    val includeMetadata: Boolean = true,
+    val logoPng: ByteArray? = null,
+    val titleFontSize: Float = 18f,
+    val sectionFontSize: Float = 13f,
+    val bodyFontSize: Float = 11f,
+    val unansweredPlaceholder: String = "—"
+)

--- a/fhirmason-hapi-pdf-r4/src/main/java/dev/ratkay/questionnaire/pdf/QuestionnaireResponseRenderer.kt
+++ b/fhirmason-hapi-pdf-r4/src/main/java/dev/ratkay/questionnaire/pdf/QuestionnaireResponseRenderer.kt
@@ -1,0 +1,71 @@
+package dev.ratkay.questionnaire.pdf
+
+import org.hl7.fhir.r4.model.Questionnaire
+import org.hl7.fhir.r4.model.QuestionnaireResponse
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+
+/**
+ * Renders a FHIR R4 [QuestionnaireResponse] to a human-readable PDF document.
+ *
+ * Rendering requires both the completed [QuestionnaireResponse] (the captured answers) and its
+ * [Questionnaire] definition (which supplies item ordering, labels, grouping and answer-option
+ * display text). Items are matched by `linkId`; groups become headings, questions become
+ * label/answer rows, and nested groups are indented.
+ *
+ * The renderer is a stateless, standalone utility — it does not participate in an
+ * `OperationResult` pipeline. Use [PdfRenderOptions] to control the title, metadata line,
+ * unanswered-question handling, an optional logo and font sizing.
+ *
+ * ### Example
+ * ```kotlin
+ * val pdf: ByteArray = QuestionnaireResponseRenderer.render(questionnaire, response)
+ * Files.write(Path.of("response.pdf"), pdf)
+ * ```
+ */
+object QuestionnaireResponseRenderer {
+
+    /**
+     * Renders the response to a PDF and returns the document as a byte array.
+     *
+     * @param questionnaire the questionnaire definition providing structure and labels.
+     * @param response the completed response whose answers are rendered.
+     * @param options rendering options; defaults are applied when omitted.
+     * @return the generated PDF as a byte array.
+     * @throws IllegalArgumentException if the questionnaire has no items to render.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun render(
+        questionnaire: Questionnaire,
+        response: QuestionnaireResponse,
+        options: PdfRenderOptions = PdfRenderOptions()
+    ): ByteArray {
+        val buffer = ByteArrayOutputStream()
+        render(questionnaire, response, buffer, options)
+        return buffer.toByteArray()
+    }
+
+    /**
+     * Renders the response to a PDF written to [out]. The caller retains ownership of [out] and is
+     * responsible for closing it; this method flushes but does not close the stream.
+     *
+     * @param questionnaire the questionnaire definition providing structure and labels.
+     * @param response the completed response whose answers are rendered.
+     * @param out the destination stream for the PDF bytes.
+     * @param options rendering options; defaults are applied when omitted.
+     * @throws IllegalArgumentException if the questionnaire has no items to render.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun render(
+        questionnaire: Questionnaire,
+        response: QuestionnaireResponse,
+        out: OutputStream,
+        options: PdfRenderOptions = PdfRenderOptions()
+    ) {
+        require(questionnaire.hasItem()) { "Questionnaire has no items to render" }
+        val model = RenderModelBuilder.build(questionnaire, response, options)
+        OpenPdfWriter.write(model, options, out)
+    }
+}

--- a/fhirmason-hapi-pdf-r4/src/main/java/dev/ratkay/questionnaire/pdf/RenderModel.kt
+++ b/fhirmason-hapi-pdf-r4/src/main/java/dev/ratkay/questionnaire/pdf/RenderModel.kt
@@ -1,0 +1,43 @@
+package dev.ratkay.questionnaire.pdf
+
+/**
+ * A version-agnostic, PDF-library-agnostic intermediate representation of a rendered
+ * questionnaire response.
+ *
+ * The model is produced by [RenderModelBuilder] from a `Questionnaire` + `QuestionnaireResponse`
+ * pair and consumed by [OpenPdfWriter]. Keeping this layer free of any FHIR or PDF dependency
+ * makes the (non-trivial) traversal/matching logic deterministic and unit-testable in isolation.
+ *
+ * @property title the document title shown at the top of the PDF.
+ * @property metadataLine optional single line of metadata (status / authored date); `null` when omitted.
+ * @property nodes the ordered, flattened list of content nodes to render top-to-bottom.
+ */
+internal data class RenderModel(
+    val title: String,
+    val metadataLine: String?,
+    val nodes: List<RenderNode>
+)
+
+/**
+ * A single renderable element in a [RenderModel]. Carries its own nesting [depth] so the writer
+ * can indent without reconstructing the tree.
+ */
+internal sealed class RenderNode {
+    /** Nesting depth: `0` for top-level items, incremented for each enclosing group. */
+    abstract val depth: Int
+
+    /**
+     * A group heading or a standalone display item.
+     *
+     * @property title the heading text.
+     */
+    data class Section(val title: String, override val depth: Int) : RenderNode()
+
+    /**
+     * A question and its answer(s).
+     *
+     * @property label the question text (falls back to the linkId when no text is present).
+     * @property values the rendered answer values; empty when the question was left unanswered.
+     */
+    data class Field(val label: String, val values: List<String>, override val depth: Int) : RenderNode()
+}

--- a/fhirmason-hapi-pdf-r4/src/main/java/dev/ratkay/questionnaire/pdf/RenderModelBuilder.kt
+++ b/fhirmason-hapi-pdf-r4/src/main/java/dev/ratkay/questionnaire/pdf/RenderModelBuilder.kt
@@ -1,0 +1,168 @@
+package dev.ratkay.questionnaire.pdf
+
+import org.hl7.fhir.r4.model.Attachment
+import org.hl7.fhir.r4.model.BooleanType
+import org.hl7.fhir.r4.model.Coding
+import org.hl7.fhir.r4.model.PrimitiveType
+import org.hl7.fhir.r4.model.Quantity
+import org.hl7.fhir.r4.model.Questionnaire
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType
+import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent
+import org.hl7.fhir.r4.model.Reference
+import org.hl7.fhir.r4.model.Type
+
+/**
+ * Builds a [RenderModel] from a `Questionnaire` (structure, labels, ordering, answer-option
+ * display text) and a `QuestionnaireResponse` (the captured answers).
+ *
+ * The traversal is driven by the `Questionnaire.item` tree — the source of truth for ordering and
+ * labels — and matches `QuestionnaireResponse` items/answers by `linkId`. The builder is pure and
+ * has no PDF dependency, so its behaviour can be asserted directly in unit tests.
+ */
+internal object RenderModelBuilder {
+
+    /** Builds the intermediate model. See class docs for the traversal contract. */
+    fun build(
+        questionnaire: Questionnaire,
+        response: QuestionnaireResponse,
+        options: PdfRenderOptions
+    ): RenderModel {
+        val title = options.title
+            ?: questionnaire.title?.takeIf { it.isNotBlank() }
+            ?: questionnaire.name?.takeIf { it.isNotBlank() }
+            ?: "Questionnaire Response"
+
+        val metadataLine = if (options.includeMetadata) buildMetadataLine(response) else null
+
+        val nodes = mutableListOf<RenderNode>()
+        val responseByLinkId = groupByLinkId(response.item)
+        for (item in questionnaire.item) {
+            renderItem(item, responseByLinkId, depth = 0, options = options, out = nodes)
+        }
+        return RenderModel(title, metadataLine, nodes)
+    }
+
+    /** Composes the "Status / Authored" metadata line, omitting absent parts. */
+    private fun buildMetadataLine(response: QuestionnaireResponse): String? {
+        val parts = mutableListOf<String>()
+        response.status?.let { parts.add("Status: ${it.toCode()}") }
+        if (response.hasAuthored()) parts.add("Authored: ${response.authoredElement.valueAsString}")
+        return parts.joinToString("  |  ").takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * Renders a single questionnaire item (and its descendants) into [out].
+     *
+     * Groups/displays emit a [RenderNode.Section]; every other type emits a [RenderNode.Field]
+     * carrying the rendered answers found under matching response items.
+     */
+    private fun renderItem(
+        item: QuestionnaireItemComponent,
+        responseByLinkId: Map<String, List<QuestionnaireResponseItemComponent>>,
+        depth: Int,
+        options: PdfRenderOptions,
+        out: MutableList<RenderNode>
+    ) {
+        val matches = responseByLinkId[item.linkId].orEmpty()
+        val label = item.text?.takeIf { it.isNotBlank() } ?: item.linkId ?: ""
+
+        when (item.type) {
+            QuestionnaireItemType.GROUP -> {
+                val hasContent = matches.isNotEmpty() || options.showUnanswered
+                if (!hasContent) return
+                out.add(RenderNode.Section(label, depth))
+                if (matches.isEmpty()) {
+                    // Unanswered group: still descend so required structure is visible.
+                    val empty = emptyMap<String, List<QuestionnaireResponseItemComponent>>()
+                    item.item.forEach { renderItem(it, empty, depth + 1, options, out) }
+                } else {
+                    // Render each captured group instance (groups may repeat).
+                    matches.forEach { instance ->
+                        val childResponses = groupByLinkId(instance.item)
+                        item.item.forEach { renderItem(it, childResponses, depth + 1, options, out) }
+                    }
+                }
+            }
+
+            QuestionnaireItemType.DISPLAY -> {
+                // Display items carry instructional text only; render as a heading-style note.
+                out.add(RenderNode.Section(label, depth))
+            }
+
+            else -> {
+                val values = matches
+                    .flatMap { it.answer }
+                    .filter { it.hasValue() }
+                    .map { renderAnswerValue(it.value, item) }
+                if (values.isEmpty() && !options.showUnanswered) return
+                out.add(RenderNode.Field(label, values, depth))
+
+                // Nested items under a question (e.g. follow-up questions) are rendered as children.
+                if (item.hasItem()) {
+                    val childResponses = matches
+                        .flatMap { it.item + it.answer.flatMap { ans -> ans.item } }
+                        .let(::groupByLinkId)
+                    item.item.forEach { renderItem(it, childResponses, depth + 1, options, out) }
+                }
+            }
+        }
+    }
+
+    /** Indexes response items by their `linkId`, preserving document order within each key. */
+    private fun groupByLinkId(
+        items: List<QuestionnaireResponseItemComponent>
+    ): Map<String, List<QuestionnaireResponseItemComponent>> {
+        val map = LinkedHashMap<String, MutableList<QuestionnaireResponseItemComponent>>()
+        for (item in items) {
+            val key = item.linkId ?: continue
+            map.getOrPut(key) { mutableListOf() }.add(item)
+        }
+        return map
+    }
+
+    /**
+     * Renders a single answer value to display text.
+     *
+     * For `Coding` answers whose `display` is absent, the matching `answerOption` on [item] is
+     * consulted so coded choices still render a human label rather than a bare code.
+     */
+    private fun renderAnswerValue(value: Type?, item: QuestionnaireItemComponent): String {
+        return when (value) {
+            null -> ""
+            is BooleanType -> if (value.value == true) "Yes" else "No"
+            is Coding -> codingDisplay(value, item)
+            is Quantity -> quantityDisplay(value)
+            is Attachment -> value.title?.takeIf { it.isNotBlank() }
+                ?: value.contentType?.takeIf { it.isNotBlank() }
+                ?: value.url?.takeIf { it.isNotBlank() }
+                ?: "[attachment]"
+            is Reference -> value.display?.takeIf { it.isNotBlank() }
+                ?: value.reference?.takeIf { it.isNotBlank() }
+                ?: "[reference]"
+            is PrimitiveType<*> -> value.valueAsString ?: ""
+            else -> value.fhirType()
+        }
+    }
+
+    /** Resolves a coded value's label: explicit display, else answer-option display, else code. */
+    private fun codingDisplay(coding: Coding, item: QuestionnaireItemComponent): String {
+        coding.display?.takeIf { it.isNotBlank() }?.let { return it }
+        val optionDisplay = item.answerOption
+            .map { it.value }
+            .filterIsInstance<Coding>()
+            .firstOrNull { it.code == coding.code && (coding.system == null || it.system == coding.system) }
+            ?.display
+            ?.takeIf { it.isNotBlank() }
+        return optionDisplay ?: coding.code?.takeIf { it.isNotBlank() } ?: "[coding]"
+    }
+
+    /** Formats a quantity as "value unit" (or "value code" when no unit is set). */
+    private fun quantityDisplay(quantity: Quantity): String {
+        val number = quantity.value?.toPlainString() ?: ""
+        val unit = quantity.unit?.takeIf { it.isNotBlank() }
+            ?: quantity.code?.takeIf { it.isNotBlank() }
+        return listOfNotNull(number.takeIf { it.isNotBlank() }, unit).joinToString(" ").ifBlank { "[quantity]" }
+    }
+}

--- a/fhirmason-hapi-pdf-r4/src/test/java/dev/ratkay/questionnaire/pdf/QuestionnaireResponseRendererTest.kt
+++ b/fhirmason-hapi-pdf-r4/src/test/java/dev/ratkay/questionnaire/pdf/QuestionnaireResponseRendererTest.kt
@@ -1,0 +1,131 @@
+package dev.ratkay.questionnaire.pdf
+
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.text.PDFTextStripper
+import org.hl7.fhir.r4.model.BooleanType
+import org.hl7.fhir.r4.model.IntegerType
+import org.hl7.fhir.r4.model.Questionnaire
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType
+import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseStatus
+import org.hl7.fhir.r4.model.StringType
+import org.hl7.fhir.r4.model.Type
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+class QuestionnaireResponseRendererTest {
+
+    private fun qItem(linkId: String, text: String, type: QuestionnaireItemType): QuestionnaireItemComponent =
+        QuestionnaireItemComponent().setLinkId(linkId).setText(text).setType(type)
+
+    private fun rItem(linkId: String, value: Type): QuestionnaireResponseItemComponent =
+        QuestionnaireResponseItemComponent().setLinkId(linkId)
+            .addAnswer(QuestionnaireResponseItemAnswerComponent().setValue(value)) as QuestionnaireResponseItemComponent
+
+    private fun sampleQuestionnaire(): Questionnaire = Questionnaire().apply {
+        title = "Intake Form"
+        addItem(
+            qItem("demographics", "Demographics", QuestionnaireItemType.GROUP).apply {
+                addItem(qItem("name", "Full name", QuestionnaireItemType.STRING))
+                addItem(qItem("age", "Age", QuestionnaireItemType.INTEGER))
+            }
+        )
+        addItem(qItem("smoker", "Do you smoke?", QuestionnaireItemType.BOOLEAN))
+    }
+
+    private fun sampleResponse(): QuestionnaireResponse = QuestionnaireResponse().apply {
+        status = QuestionnaireResponseStatus.COMPLETED
+        setAuthored(java.util.Date(0))
+        addItem(
+            QuestionnaireResponseItemComponent().setLinkId("demographics").apply {
+                addItem(rItem("name", StringType("Alice Smith")))
+                addItem(rItem("age", IntegerType(34)))
+            }
+        )
+        addItem(rItem("smoker", BooleanType(false)))
+    }
+
+    private fun extractText(pdf: ByteArray): String =
+        PDDocument.load(pdf).use { PDFTextStripper().getText(it) }
+
+    @Test
+    fun `render produces a valid non-empty PDF`() {
+        val pdf = QuestionnaireResponseRenderer.render(sampleQuestionnaire(), sampleResponse())
+        assertTrue(pdf.size > 100, "PDF should be non-trivial in size")
+        val header = String(pdf.copyOfRange(0, 5), Charsets.US_ASCII)
+        assertTrue(header.startsWith("%PDF-"), "PDF should start with the %PDF- header, was: $header")
+    }
+
+    @Test
+    fun `rendered text contains title labels and answers in order`() {
+        val text = extractText(QuestionnaireResponseRenderer.render(sampleQuestionnaire(), sampleResponse()))
+
+        assertTrue(text.contains("Intake Form"), "missing title in: $text")
+        assertTrue(text.contains("Demographics"), "missing group heading in: $text")
+        assertTrue(text.contains("Full name"), "missing label in: $text")
+        assertTrue(text.contains("Alice Smith"), "missing answer in: $text")
+        assertTrue(text.contains("Age"), "missing label in: $text")
+        assertTrue(text.contains("34"), "missing answer in: $text")
+        assertTrue(text.contains("Do you smoke?"), "missing label in: $text")
+        assertTrue(text.contains("No"), "missing boolean answer in: $text")
+
+        // Document order: title before group, group before its children, smoker last.
+        assertTrue(text.indexOf("Intake Form") < text.indexOf("Demographics"))
+        assertTrue(text.indexOf("Demographics") < text.indexOf("Full name"))
+        assertTrue(text.indexOf("Full name") < text.indexOf("Do you smoke?"))
+    }
+
+    @Test
+    fun `rendered text contains metadata line`() {
+        val text = extractText(QuestionnaireResponseRenderer.render(sampleQuestionnaire(), sampleResponse()))
+        assertTrue(text.contains("Status: completed"), "missing status in: $text")
+    }
+
+    @Test
+    fun `unanswered placeholder appears when showUnanswered enabled`() {
+        val q = Questionnaire().apply {
+            title = "T"
+            addItem(qItem("notes", "Additional notes", QuestionnaireItemType.STRING))
+        }
+        val options = PdfRenderOptions(showUnanswered = true, unansweredPlaceholder = "N/A")
+        val text = extractText(QuestionnaireResponseRenderer.render(q, QuestionnaireResponse(), options))
+        assertTrue(text.contains("Additional notes"), "missing label in: $text")
+        assertTrue(text.contains("N/A"), "missing placeholder in: $text")
+    }
+
+    @Test
+    fun `render to output stream writes the same bytes`() {
+        val buffer = ByteArrayOutputStream()
+        QuestionnaireResponseRenderer.render(sampleQuestionnaire(), sampleResponse(), buffer)
+        val header = String(buffer.toByteArray().copyOfRange(0, 5), Charsets.US_ASCII)
+        assertTrue(header.startsWith("%PDF-"))
+    }
+
+    @Test
+    fun `render with logo succeeds`() {
+        val logo = ByteArrayOutputStream().use { out ->
+            ImageIO.write(BufferedImage(8, 8, BufferedImage.TYPE_INT_RGB), "png", out)
+            out.toByteArray()
+        }
+        val pdf = QuestionnaireResponseRenderer.render(
+            sampleQuestionnaire(),
+            sampleResponse(),
+            PdfRenderOptions(logoPng = logo)
+        )
+        assertTrue(pdf.size > 100)
+    }
+
+    @Test
+    fun `render throws when questionnaire has no items`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            QuestionnaireResponseRenderer.render(Questionnaire(), QuestionnaireResponse())
+        }
+    }
+}

--- a/fhirmason-hapi-pdf-r4/src/test/java/dev/ratkay/questionnaire/pdf/RenderModelBuilderTest.kt
+++ b/fhirmason-hapi-pdf-r4/src/test/java/dev/ratkay/questionnaire/pdf/RenderModelBuilderTest.kt
@@ -1,0 +1,281 @@
+package dev.ratkay.questionnaire.pdf
+
+import org.hl7.fhir.r4.model.Attachment
+import org.hl7.fhir.r4.model.BooleanType
+import org.hl7.fhir.r4.model.Coding
+import org.hl7.fhir.r4.model.DateType
+import org.hl7.fhir.r4.model.DecimalType
+import org.hl7.fhir.r4.model.IntegerType
+import org.hl7.fhir.r4.model.Quantity
+import org.hl7.fhir.r4.model.Questionnaire
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemAnswerOptionComponent
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType
+import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseItemComponent
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseStatus
+import org.hl7.fhir.r4.model.Reference
+import org.hl7.fhir.r4.model.StringType
+import org.hl7.fhir.r4.model.Type
+import org.hl7.fhir.r4.model.UriType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class RenderModelBuilderTest {
+
+    private val options = PdfRenderOptions()
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun qItem(linkId: String, text: String?, type: QuestionnaireItemType): QuestionnaireItemComponent =
+        QuestionnaireItemComponent().setLinkId(linkId).setText(text).setType(type)
+
+    private fun answer(value: Type): QuestionnaireResponseItemAnswerComponent =
+        QuestionnaireResponseItemAnswerComponent().setValue(value)
+
+    private fun rItem(linkId: String, vararg values: Type): QuestionnaireResponseItemComponent {
+        val item = QuestionnaireResponseItemComponent().setLinkId(linkId)
+        values.forEach { item.addAnswer(answer(it)) }
+        return item
+    }
+
+    private fun fields(model: RenderModel): List<RenderNode.Field> =
+        model.nodes.filterIsInstance<RenderNode.Field>()
+
+    private fun sections(model: RenderModel): List<RenderNode.Section> =
+        model.nodes.filterIsInstance<RenderNode.Section>()
+
+    // ── title ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `title falls back to questionnaire title then name then generic`() {
+        val q = Questionnaire().apply { addItem(qItem("1", "Q", QuestionnaireItemType.STRING)) }
+        val qr = QuestionnaireResponse()
+
+        q.title = "My Form"
+        assertEquals("My Form", RenderModelBuilder.build(q, qr, options).title)
+
+        q.title = null
+        q.name = "form-name"
+        assertEquals("form-name", RenderModelBuilder.build(q, qr, options).title)
+
+        q.name = null
+        assertEquals("Questionnaire Response", RenderModelBuilder.build(q, qr, options).title)
+    }
+
+    @Test
+    fun `explicit option title overrides questionnaire title`() {
+        val q = Questionnaire().apply {
+            title = "Ignored"
+            addItem(qItem("1", "Q", QuestionnaireItemType.STRING))
+        }
+        val model = RenderModelBuilder.build(q, QuestionnaireResponse(), PdfRenderOptions(title = "Override"))
+        assertEquals("Override", model.title)
+    }
+
+    // ── metadata ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `metadata line contains status and authored date`() {
+        val q = Questionnaire().apply { addItem(qItem("1", "Q", QuestionnaireItemType.STRING)) }
+        val qr = QuestionnaireResponse().apply {
+            status = QuestionnaireResponseStatus.COMPLETED
+            setAuthored(java.util.Date(0))
+        }
+        val line = RenderModelBuilder.build(q, qr, options).metadataLine
+        assertTrue(line!!.contains("Status: completed"), "was: $line")
+        assertTrue(line.contains("Authored:"), "was: $line")
+    }
+
+    @Test
+    fun `metadata line omitted when includeMetadata is false`() {
+        val q = Questionnaire().apply { addItem(qItem("1", "Q", QuestionnaireItemType.STRING)) }
+        val qr = QuestionnaireResponse().apply { status = QuestionnaireResponseStatus.COMPLETED }
+        val model = RenderModelBuilder.build(q, qr, PdfRenderOptions(includeMetadata = false))
+        assertEquals(null, model.metadataLine)
+    }
+
+    // ── answer value types ──────────────────────────────────────────────────────
+
+    @Test
+    fun `boolean answers render as Yes and No`() {
+        val q = Questionnaire().apply {
+            addItem(qItem("yes", "Smoker", QuestionnaireItemType.BOOLEAN))
+            addItem(qItem("no", "Diabetic", QuestionnaireItemType.BOOLEAN))
+        }
+        val qr = QuestionnaireResponse().apply {
+            addItem(rItem("yes", BooleanType(true)))
+            addItem(rItem("no", BooleanType(false)))
+        }
+        val f = fields(RenderModelBuilder.build(q, qr, options))
+        assertEquals(listOf("Yes"), f[0].values)
+        assertEquals(listOf("No"), f[1].values)
+    }
+
+    @Test
+    fun `primitive answers render via valueAsString`() {
+        val q = Questionnaire().apply {
+            addItem(qItem("s", "Name", QuestionnaireItemType.STRING))
+            addItem(qItem("d", "Score", QuestionnaireItemType.DECIMAL))
+            addItem(qItem("i", "Count", QuestionnaireItemType.INTEGER))
+            addItem(qItem("dt", "DOB", QuestionnaireItemType.DATE))
+            addItem(qItem("u", "Site", QuestionnaireItemType.URL))
+        }
+        val qr = QuestionnaireResponse().apply {
+            addItem(rItem("s", StringType("Alice")))
+            addItem(rItem("d", DecimalType(BigDecimal("3.50"))))
+            addItem(rItem("i", IntegerType(42)))
+            addItem(rItem("dt", DateType("2024-03-15")))
+            addItem(rItem("u", UriType("http://example.org")))
+        }
+        val f = fields(RenderModelBuilder.build(q, qr, options))
+        assertEquals(listOf("Alice"), f[0].values)
+        assertEquals(listOf("3.50"), f[1].values)
+        assertEquals(listOf("42"), f[2].values)
+        assertEquals(listOf("2024-03-15"), f[3].values)
+        assertEquals(listOf("http://example.org"), f[4].values)
+    }
+
+    @Test
+    fun `coding answer prefers explicit display`() {
+        val q = Questionnaire().apply { addItem(qItem("c", "Sex", QuestionnaireItemType.CHOICE)) }
+        val qr = QuestionnaireResponse().apply {
+            addItem(rItem("c", Coding("http://sys", "F", "Female")))
+        }
+        assertEquals(listOf("Female"), fields(RenderModelBuilder.build(q, qr, options))[0].values)
+    }
+
+    @Test
+    fun `coding answer without display resolves from answerOption`() {
+        val q = Questionnaire().apply {
+            addItem(
+                qItem("c", "Sex", QuestionnaireItemType.CHOICE).apply {
+                    addAnswerOption(
+                        QuestionnaireItemAnswerOptionComponent().setValue(Coding("http://sys", "F", "Female"))
+                    )
+                }
+            )
+        }
+        val qr = QuestionnaireResponse().apply {
+            addItem(rItem("c", Coding("http://sys", "F", null)))
+        }
+        assertEquals(listOf("Female"), fields(RenderModelBuilder.build(q, qr, options))[0].values)
+    }
+
+    @Test
+    fun `coding answer falls back to code when no display available`() {
+        val q = Questionnaire().apply { addItem(qItem("c", "Sex", QuestionnaireItemType.CHOICE)) }
+        val qr = QuestionnaireResponse().apply { addItem(rItem("c", Coding("http://sys", "F", null))) }
+        assertEquals(listOf("F"), fields(RenderModelBuilder.build(q, qr, options))[0].values)
+    }
+
+    @Test
+    fun `quantity answer renders value and unit`() {
+        val q = Questionnaire().apply { addItem(qItem("w", "Weight", QuestionnaireItemType.QUANTITY)) }
+        val qr = QuestionnaireResponse().apply {
+            addItem(rItem("w", Quantity().setValue(BigDecimal("72.5")).setUnit("kg")))
+        }
+        assertEquals(listOf("72.5 kg"), fields(RenderModelBuilder.build(q, qr, options))[0].values)
+    }
+
+    @Test
+    fun `attachment answer renders title`() {
+        val q = Questionnaire().apply { addItem(qItem("a", "Scan", QuestionnaireItemType.ATTACHMENT)) }
+        val qr = QuestionnaireResponse().apply {
+            addItem(rItem("a", Attachment().setTitle("xray.png")))
+        }
+        assertEquals(listOf("xray.png"), fields(RenderModelBuilder.build(q, qr, options))[0].values)
+    }
+
+    @Test
+    fun `reference answer prefers display then reference`() {
+        val q = Questionnaire().apply {
+            addItem(qItem("r1", "Doctor", QuestionnaireItemType.REFERENCE))
+            addItem(qItem("r2", "Patient", QuestionnaireItemType.REFERENCE))
+        }
+        val qr = QuestionnaireResponse().apply {
+            addItem(rItem("r1", Reference().setDisplay("Dr. House")))
+            addItem(rItem("r2", Reference("Patient/123")))
+        }
+        val f = fields(RenderModelBuilder.build(q, qr, options))
+        assertEquals(listOf("Dr. House"), f[0].values)
+        assertEquals(listOf("Patient/123"), f[1].values)
+    }
+
+    @Test
+    fun `repeating question collects multiple answers`() {
+        val q = Questionnaire().apply {
+            addItem(qItem("lang", "Languages", QuestionnaireItemType.STRING).setRepeats(true))
+        }
+        val qr = QuestionnaireResponse().apply {
+            addItem(rItem("lang", StringType("English"), StringType("Hungarian")))
+        }
+        assertEquals(listOf("English", "Hungarian"), fields(RenderModelBuilder.build(q, qr, options))[0].values)
+    }
+
+    // ── groups & nesting ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `group becomes a section with nested fields at increasing depth`() {
+        val q = Questionnaire().apply {
+            addItem(
+                qItem("g", "Demographics", QuestionnaireItemType.GROUP).apply {
+                    addItem(qItem("g.name", "Name", QuestionnaireItemType.STRING))
+                    addItem(qItem("g.age", "Age", QuestionnaireItemType.INTEGER))
+                }
+            )
+        }
+        val qr = QuestionnaireResponse().apply {
+            addItem(
+                QuestionnaireResponseItemComponent().setLinkId("g").apply {
+                    addItem(rItem("g.name", StringType("Alice")))
+                    addItem(rItem("g.age", IntegerType(30)))
+                }
+            )
+        }
+        val model = RenderModelBuilder.build(q, qr, options)
+        val section = sections(model).single()
+        assertEquals("Demographics", section.title)
+        assertEquals(0, section.depth)
+        val f = fields(model)
+        assertEquals(listOf("Alice"), f[0].values)
+        assertEquals(1, f[0].depth)
+        assertEquals(listOf("30"), f[1].values)
+        assertEquals(1, f[1].depth)
+    }
+
+    @Test
+    fun `display item becomes a section`() {
+        val q = Questionnaire().apply {
+            addItem(qItem("info", "Please answer truthfully.", QuestionnaireItemType.DISPLAY))
+        }
+        val model = RenderModelBuilder.build(q, QuestionnaireResponse(), options)
+        assertEquals("Please answer truthfully.", sections(model).single().title)
+    }
+
+    // ── unanswered handling ───────────────────────────────────────────────────────
+
+    @Test
+    fun `unanswered question rendered with empty values when showUnanswered true`() {
+        val q = Questionnaire().apply { addItem(qItem("x", "Notes", QuestionnaireItemType.STRING)) }
+        val model = RenderModelBuilder.build(q, QuestionnaireResponse(), PdfRenderOptions(showUnanswered = true))
+        assertTrue(fields(model).single().values.isEmpty())
+    }
+
+    @Test
+    fun `unanswered question omitted when showUnanswered false`() {
+        val q = Questionnaire().apply { addItem(qItem("x", "Notes", QuestionnaireItemType.STRING)) }
+        val model = RenderModelBuilder.build(q, QuestionnaireResponse(), PdfRenderOptions(showUnanswered = false))
+        assertTrue(fields(model).isEmpty())
+    }
+
+    @Test
+    fun `label falls back to linkId when text is absent`() {
+        val q = Questionnaire().apply { addItem(qItem("link-42", null, QuestionnaireItemType.STRING)) }
+        val qr = QuestionnaireResponse().apply { addItem(rItem("link-42", StringType("v"))) }
+        assertEquals("link-42", fields(RenderModelBuilder.build(q, qr, options)).single().label)
+    }
+}

--- a/fhirmason-hapi-pdf-r4/src/test/resources/logback-test.xml
+++ b/fhirmason-hapi-pdf-r4/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- PDFBox/FontBox emit verbose DEBUG noise during rendering; keep the test log readable. -->
+    <logger name="org.apache.pdfbox" level="WARN"/>
+    <logger name="org.apache.fontbox" level="WARN"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <module>fhirmason-hapi-r4</module>
         <module>fhirmason-hapi-dstu3</module>
         <module>fhirmason-hapi-spring-r4</module>
+        <module>fhirmason-hapi-pdf-r4</module>
     </modules>
 
     <properties>
@@ -56,6 +57,8 @@
         <logback.version>1.5.18</logback.version>
         <spring.boot.version>3.4.5</spring.boot.version>
         <dokka.version>1.9.20</dokka.version>
+        <openpdf.version>2.0.3</openpdf.version>
+        <pdfbox.version>2.0.31</pdfbox.version>
     </properties>
 
     <dependencyManagement>
@@ -146,6 +149,18 @@
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>hapi-fhir-caching-guava</artifactId>
                 <version>${hapi.fhir.version}</version>
+            </dependency>
+            <!-- PDF rendering (OpenPDF — LGPL/MPL) -->
+            <dependency>
+                <groupId>com.github.librepdf</groupId>
+                <artifactId>openpdf</artifactId>
+                <version>${openpdf.version}</version>
+            </dependency>
+            <!-- PDF text extraction for tests -->
+            <dependency>
+                <groupId>org.apache.pdfbox</groupId>
+                <artifactId>pdfbox</artifactId>
+                <version>${pdfbox.version}</version>
             </dependency>
             <!-- Internal modules -->
             <dependency>


### PR DESCRIPTION
Introduces fhirmason-hapi-pdf-r4, a standalone module that renders a
completed R4 QuestionnaireResponse to a PDF document using OpenPDF
(LGPL/MPL).

Rendering is driven by the Questionnaire definition (structure, labels,
ordering, answer-option display text) matched against the
QuestionnaireResponse answers by linkId: groups become headings,
questions become label/answer rows, nested groups are indented.

Design splits traversal from rendering for testability:
- RenderModelBuilder: pure Questionnaire+Response -> RenderModel
- OpenPdfWriter: thin RenderModel -> PDF bytes
- QuestionnaireResponseRenderer: public standalone entry point
- PdfRenderOptions: title, metadata line, logo, unanswered handling, fonts

Supports boolean (Yes/No), decimal, integer, date, dateTime, time,
string, uri, Coding (display -> answer-option display -> code), Quantity,
Attachment, and Reference answers, plus repeating items/groups.

DSTU3 port deferred to a follow-up (fhirmason-hapi-pdf-dstu3).